### PR TITLE
Render Media Component

### DIFF
--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -41,9 +41,9 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
         if (canvasEntity !== undefined)
           return (
             <MediaItem
-              key={key}
-              canvasEntity={canvasEntity}
               active={true}
+              canvasEntity={canvasEntity}
+              key={key}
               handleChange={handleChange}
             />
           );

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -37,8 +37,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
           paintingType,
         );
 
-        let isActive = false;
-        if (activeCanvas === item.id) isActive = true;
+        let isActive = activeCanvas === item.id ? true : false;
 
         if (canvasEntity !== undefined)
           return (

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -28,7 +28,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
 
   const displayItems = items.map((item: object, key: number) => {
     // this probably needs to be written in a .filter()
-    const canvasEntity: object = getCanvasByCriteria(
+    const canvasEntity = getCanvasByCriteria(
       vault,
       item,
       motivation,

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import {
-  CanvasNormalized,
-  AnnotationPageNormalized,
-  AnnotationNormalized,
-  ContentResource,
-} from "@hyperion-framework/types";
+import { getCanvasByAnnotation } from "services/iiif";
 
 interface MediaProps {
   items: object[];
@@ -22,8 +17,6 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const annotationMotivation = "painting";
   const contentResourceType = ["Sound", "Video"];
 
-  console.log(activeCanvas);
-
   const handleChange = (canvasId: string) => {
     if (activeCanvas !== canvasId)
       dispatch({
@@ -35,40 +28,20 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   return (
     <MediaWrapper>
       {items.map((item: object, key: number) => {
-        // 1. get canvas
-        const canvas: CanvasNormalized = vault.fromRef(item);
-        // 2. get annotationPage
-        const annotationPage: AnnotationPageNormalized = vault.fromRef(
-          canvas.items[0],
+        const canvas: object = getCanvasByAnnotation(
+          vault,
+          item,
+          annotationMotivation,
+          contentResourceType,
         );
-        // 3.get annotations
-        const annotations: Array<AnnotationNormalized> = vault.allFromRef(
-          annotationPage.items,
+        return (
+          <MediaItem
+            key={key}
+            canvas={canvas}
+            active={true}
+            handleChange={handleChange}
+          />
         );
-
-        // 4.determine if W3C annotation is motivation painting
-        for (const annotation of annotations) {
-          if (annotation.motivation.includes(annotationMotivation)) {
-            // 5.get contentResource (the annotation body)
-            const contentResource: ContentResource = vault.fromRef(
-              annotation.body[0],
-            );
-            // 6. render media item if annotation target matches original
-            //    canvas ID and contentResource type is Sound or Video
-            if (
-              annotation.target === item.id &&
-              contentResourceType.includes(contentResource.type)
-            )
-              return (
-                <MediaItem
-                  key={key}
-                  canvas={canvas}
-                  active={true}
-                  handleChange={handleChange}
-                />
-              );
-          }
-        }
       })}
     </MediaWrapper>
   );

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import { getNormalizedByCritera } from "services/iiif";
+import { getCanvasEntities } from "services/iiif";
 
 interface MediaProps {
   items: object[];
@@ -28,14 +28,15 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   return (
     <MediaWrapper>
       {items.map((item: object, key: number) => {
-        const normalized: object = getNormalizedByCritera(
+        // this probably needs to be written in a .filter()
+        const canvases: object = getCanvasEntities(
           vault,
           item,
           motivation,
           paintingType,
         );
 
-        if (normalized !== undefined)
+        if (canvases !== undefined)
           return (
             <MediaItem
               key={key}

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -15,6 +15,8 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const state: any = useViewerState();
   const { activeCanvas, vault } = state;
 
+  console.log(activeCanvas);
+
   const motivation = "painting";
   const paintingType = ["Image", "Sound", "Video"];
 

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import { getCanvasEntities } from "services/iiif";
+import { Canvas } from "@hyperion-framework/types";
+
+import { getCanvasByCriteria } from "services/iiif";
 
 interface MediaProps {
   items: object[];
@@ -15,7 +17,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const { activeCanvas, vault } = state;
 
   const motivation = "painting";
-  const paintingType = ["Image", "Video"];
+  const paintingType = ["Image", "Sound", "Video"];
 
   const handleChange = (canvasId: string) => {
     if (activeCanvas !== canvasId)
@@ -29,18 +31,18 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
     <MediaWrapper>
       {items.map((item: object, key: number) => {
         // this probably needs to be written in a .filter()
-        const canvases: object = getCanvasEntities(
+        const canvasEntity: object = getCanvasByCriteria(
           vault,
           item,
           motivation,
           paintingType,
         );
 
-        if (canvases !== undefined)
+        if (canvasEntity !== undefined)
           return (
             <MediaItem
               key={key}
-              normalized={normalized}
+              canvasEntity={canvasEntity}
               active={true}
               handleChange={handleChange}
             />

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -14,8 +14,8 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const state: any = useViewerState();
   const { activeCanvas, vault } = state;
 
-  const annotationMotivation = "supplementing";
-  const contentResourceType = ["Sound", "Video"];
+  const motivation = "painting";
+  const paintingType = ["Image", "Video"];
 
   const handleChange = (canvasId: string) => {
     if (activeCanvas !== canvasId)
@@ -31,18 +31,19 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
         const normalized: object = getNormalizedByCritera(
           vault,
           item,
-          annotationMotivation,
-          contentResourceType,
+          motivation,
+          paintingType,
         );
 
-        // return (
-        //   <MediaItem
-        //     key={key}
-        //     normalized={normalized}
-        //     active={true}
-        //     handleChange={handleChange}
-        //   />
-        // );
+        if (normalized !== undefined)
+          return (
+            <MediaItem
+              key={key}
+              normalized={normalized}
+              active={true}
+              handleChange={handleChange}
+            />
+          );
       })}
     </MediaWrapper>
   );

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import { getCanvasByAnnotation } from "services/iiif";
+import { getNormalizedByCritera } from "services/iiif";
 
 interface MediaProps {
   items: object[];
@@ -14,7 +14,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const state: any = useViewerState();
   const { activeCanvas, vault } = state;
 
-  const annotationMotivation = "painting";
+  const annotationMotivation = "supplementing";
   const contentResourceType = ["Sound", "Video"];
 
   const handleChange = (canvasId: string) => {
@@ -28,20 +28,21 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   return (
     <MediaWrapper>
       {items.map((item: object, key: number) => {
-        const canvas: object = getCanvasByAnnotation(
+        const normalized: object = getNormalizedByCritera(
           vault,
           item,
           annotationMotivation,
           contentResourceType,
         );
-        return (
-          <MediaItem
-            key={key}
-            canvas={canvas}
-            active={true}
-            handleChange={handleChange}
-          />
-        );
+
+        // return (
+        //   <MediaItem
+        //     key={key}
+        //     normalized={normalized}
+        //     active={true}
+        //     handleChange={handleChange}
+        //   />
+        // );
       })}
     </MediaWrapper>
   );

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-import { Canvas } from "@hyperion-framework/types";
 
-import { getCanvasByCriteria } from "services/iiif";
+import { getCanvasByCriteria, getThumbnail } from "services/iiif";
 
 interface MediaProps {
   items: object[];
@@ -43,6 +42,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
             <MediaItem
               active={true}
               canvasEntity={canvasEntity}
+              thumbnail={getThumbnail(vault, canvasEntity, 200, null)}
               key={key}
               handleChange={handleChange}
             />

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -26,32 +26,30 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
       });
   };
 
-  return (
-    <MediaWrapper>
-      {items.map((item: object, key: number) => {
-        // this probably needs to be written in a .filter()
-        const canvasEntity: object = getCanvasByCriteria(
-          vault,
-          item,
-          motivation,
-          paintingType,
-        );
+  const displayItems = items.map((item: object, key: number) => {
+    // this probably needs to be written in a .filter()
+    const canvasEntity: object = getCanvasByCriteria(
+      vault,
+      item,
+      motivation,
+      paintingType,
+    );
 
-        let isActive = activeCanvas === item.id ? true : false;
+    const isActive = activeCanvas === item.id ? true : false;
 
-        if (canvasEntity !== undefined)
-          return (
-            <MediaItem
-              active={isActive}
-              canvasEntity={canvasEntity}
-              thumbnail={getThumbnail(vault, canvasEntity, 200, null)}
-              key={key}
-              handleChange={handleChange}
-            />
-          );
-      })}
-    </MediaWrapper>
-  );
+    if (canvasEntity !== undefined)
+      return (
+        <MediaItem
+          active={isActive}
+          canvasEntity={canvasEntity}
+          thumbnail={getThumbnail(vault, canvasEntity, 200, null)}
+          key={key}
+          handleChange={handleChange}
+        />
+      );
+  });
+
+  return <MediaWrapper>{displayItems}</MediaWrapper>;
 };
 
 const MediaWrapper = styled("nav", {

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -2,20 +2,14 @@ import React, { useState, useEffect } from "react";
 import { styled } from "@stitches/react";
 import MediaItem from "components/Media/MediaItem";
 import { useViewerState, useViewerDispatch } from "context/viewer-context";
-
 import { getCanvasByCriteria, getThumbnail } from "services/iiif";
-import {
-  Annotation,
-  AnnotationPageNormalized,
-  CanvasNormalized,
-} from "@hyperion-framework/types";
 
 interface MediaProps {
   items: object[];
   activeItem: number;
 }
 
-const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
+const Media: React.FC<MediaProps> = ({ items }) => {
   const dispatch: any = useViewerDispatch();
   const state: any = useViewerState();
   const { activeCanvas, vault } = state;

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -15,8 +15,6 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
   const state: any = useViewerState();
   const { activeCanvas, vault } = state;
 
-  console.log(activeCanvas);
-
   const motivation = "painting";
   const paintingType = ["Image", "Sound", "Video"];
 
@@ -39,10 +37,13 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
           paintingType,
         );
 
+        let isActive = false;
+        if (activeCanvas === item.id) isActive = true;
+
         if (canvasEntity !== undefined)
           return (
             <MediaItem
-              active={true}
+              active={isActive}
               canvasEntity={canvasEntity}
               thumbnail={getThumbnail(vault, canvasEntity, 200, null)}
               key={key}

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -43,7 +43,7 @@ const Media: React.FC<MediaProps> = ({ items, activeItem }) => {
           active={isActive}
           canvasEntity={canvasEntity}
           thumbnail={getThumbnail(vault, canvasEntity, 200, null)}
-          key={key}
+          key={item.id}
           handleChange={handleChange}
         />
       );

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,21 +1,26 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { styled } from "@stitches/react";
 import { getLabel } from "services/iiif";
 
 interface Props {
   canvasEntity: object;
   active: boolean;
+  thumbnail: object;
   handleChange: (arg0: string) => void;
 }
 
-const MediaItem: React.FC<Props> = ({ canvasEntity, handleChange }) => {
+const MediaItem: React.FC<Props> = ({
+  canvasEntity,
+  thumbnail,
+  handleChange,
+}) => {
   return (
     <MediaItemWrapper
       onClick={() => handleChange(canvasEntity.canvas.id)}
       data-testid="media-item-wrapper"
     >
       <figure>
-        <img src="" />
+        <img src={thumbnail.src} />
         <figcaption>{getLabel(canvasEntity.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,23 +1,22 @@
 import React from "react";
 import { styled } from "@stitches/react";
 import { getLabel } from "services/iiif";
-import { CanvasNormalized } from "@hyperion-framework/types";
 
 interface Props {
-  normalized: object;
+  canvasEntity: object;
   active: boolean;
   handleChange: (arg0: string) => void;
 }
 
-const MediaItem: React.FC<Props> = ({ normalized, handleChange }) => {
+const MediaItem: React.FC<Props> = ({ canvasEntity, handleChange }) => {
   return (
     <MediaItemWrapper
-      onClick={() => handleChange(normalized.canvas.id)}
+      onClick={() => handleChange(canvasEntity.canvas.id)}
       data-testid="media-item-wrapper"
     >
       <figure>
-        {/* <img src={normalized.canvas.thumbnail[0].id} /> */}
-        <figcaption>{getLabel(normalized.canvas.label, "en")}</figcaption>
+        <img src="" />
+        <figcaption>{getLabel(canvasEntity.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>
   );

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { styled } from "@stitches/react";
-import { getLabel } from "../../services/iiif";
+import { getLabel } from "services/iiif";
 import { CanvasNormalized } from "@hyperion-framework/types";
 
 interface Props {
-  canvas: CanvasNormalized;
+  canvas: object;
   active: boolean;
   handleChange: (arg0: string) => void;
 }
@@ -12,12 +12,12 @@ interface Props {
 const MediaItem: React.FC<Props> = ({ canvas, handleChange }) => {
   return (
     <MediaItemWrapper
-      onClick={() => handleChange(canvas.id)}
+      onClick={() => handleChange(canvas.canvas.id)}
       data-testid="media-item-wrapper"
     >
       <figure>
-        <img src={canvas.thumbnail[0].id} />
-        <figcaption>{getLabel(canvas.label, "en")}</figcaption>
+        <img src={canvas.canvas.thumbnail[0].id} />
+        <figcaption>{getLabel(canvas.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>
   );

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -23,13 +23,19 @@ const MediaItem: React.FC<Props> = ({
       <figure>
         <div>
           <img src={thumbnail.src} />
-          <span>{convertTime(canvasEntity.canvas.duration)}</span>
+          <MediaItemDuration>
+            {convertTime(canvasEntity.canvas.duration)}
+          </MediaItemDuration>
         </div>
         <figcaption>{getLabel(canvasEntity.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>
   );
 };
+
+const MediaItemDuration = styled("span", {
+  display: "flex",
+});
 
 const MediaItemWrapper = styled("a", {
   display: "flex",
@@ -44,6 +50,25 @@ const MediaItemWrapper = styled("a", {
   figure: {
     margin: "0",
     width: "199px",
+
+    "> div": {
+      position: "relative",
+      display: "flex",
+      boxShadow: "2px 2px 5px #00000011",
+      backgroundColor: "#f1f1f1",
+
+      [`& ${MediaItemDuration}`]: {
+        position: "absolute",
+        right: "0.25rem",
+        bottom: "0.25rem",
+        padding: "0.125rem 0.25rem",
+        backgroundColor: "black",
+        color: "white",
+        fontWeight: "700",
+        fontSize: "0.722rem",
+        borderRadius: "1px",
+      },
+    },
 
     img: {
       width: "199px",

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -4,20 +4,20 @@ import { getLabel } from "services/iiif";
 import { CanvasNormalized } from "@hyperion-framework/types";
 
 interface Props {
-  canvas: object;
+  normalized: object;
   active: boolean;
   handleChange: (arg0: string) => void;
 }
 
-const MediaItem: React.FC<Props> = ({ canvas, handleChange }) => {
+const MediaItem: React.FC<Props> = ({ normalized, handleChange }) => {
   return (
     <MediaItemWrapper
-      onClick={() => handleChange(canvas.canvas.id)}
+      onClick={() => handleChange(normalized.canvas.id)}
       data-testid="media-item-wrapper"
     >
       <figure>
-        <img src={canvas.canvas.thumbnail[0].id} />
-        <figcaption>{getLabel(canvas.canvas.label, "en")}</figcaption>
+        <img src={normalized.canvas.thumbnail[0].id} />
+        <figcaption>{getLabel(normalized.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>
   );

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { styled } from "@stitches/react";
 import { getLabel } from "services/iiif";
+import { convertTime } from "services/utils";
 
 interface Props {
   canvasEntity: object;
@@ -20,7 +21,10 @@ const MediaItem: React.FC<Props> = ({
       data-testid="media-item-wrapper"
     >
       <figure>
-        <img src={thumbnail.src} />
+        <div>
+          <img src={thumbnail.src} />
+          <span>{convertTime(canvasEntity.canvas.duration)}</span>
+        </div>
         <figcaption>{getLabel(canvasEntity.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -47,10 +47,6 @@ const MediaItemWrapper = styled("a", {
   margin: "0 1.618rem 0 0",
   cursor: "pointer",
 
-  "&[data-active='true']": {
-    opacity: "0.5",
-  },
-
   figure: {
     margin: "0",
     width: "199px",
@@ -58,8 +54,18 @@ const MediaItemWrapper = styled("a", {
     "> div": {
       position: "relative",
       display: "flex",
-      boxShadow: "2px 2px 5px #00000011",
       backgroundColor: "#f1f1f1",
+      overflow: "hidden",
+      transition: "all 200ms ease-in-out",
+
+      img: {
+        width: "199px",
+        height: "123px",
+        objectFit: "cover",
+        filter: "blur(0)",
+        transform: "scale3d(1, 1, 1)",
+        transition: "all 200ms ease-in-out",
+      },
 
       [`& ${MediaItemDuration}`]: {
         position: "absolute",
@@ -69,20 +75,54 @@ const MediaItemWrapper = styled("a", {
         backgroundColor: "black",
         color: "white",
         fontWeight: "700",
-        fontSize: "0.722rem",
+        fontSize: "0.7272rem",
         borderRadius: "1px",
+        transition: "all 200ms ease-in-out",
+        opacity: "1",
       },
-    },
-
-    img: {
-      width: "199px",
-      height: "123px",
-      objectFit: "cover",
     },
 
     figcaption: {
       marginTop: "0.382rem",
       fontWeight: "400",
+    },
+  },
+
+  "&[data-active='true']": {
+    figure: {
+      "> div": {
+        backgroundColor: "black",
+
+        "&::before": {
+          position: "absolute",
+          zIndex: "1",
+          color: "white",
+          textTransform: "uppercase",
+          fontSize: "0.8333rem",
+          fontWeight: "700",
+          content: "Now Playing",
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          flexDirection: "column",
+          justifyContent: "center",
+          textAlign: "center",
+        },
+
+        img: {
+          opacity: "0.382",
+          filter: "blur(2px)",
+          transform: "scale3d(1.1, 1.1, 1.1)",
+        },
+
+        [`& ${MediaItemDuration}`]: {
+          opacity: "0",
+        },
+      },
+    },
+
+    figcaption: {
+      fontWeight: "700",
     },
   },
 });

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -16,7 +16,7 @@ const MediaItem: React.FC<Props> = ({ normalized, handleChange }) => {
       data-testid="media-item-wrapper"
     >
       <figure>
-        <img src={normalized.canvas.thumbnail[0].id} />
+        {/* <img src={normalized.canvas.thumbnail[0].id} /> */}
         <figcaption>{getLabel(normalized.canvas.label, "en")}</figcaption>
       </figure>
     </MediaItemWrapper>

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { createRef, useEffect } from "react";
 import { styled } from "@stitches/react";
 import { getLabel } from "services/iiif";
 import { convertTime } from "services/utils";
@@ -12,13 +12,17 @@ interface Props {
 
 const MediaItem: React.FC<Props> = ({
   canvasEntity,
+  active,
   thumbnail,
   handleChange,
 }) => {
+  const refAnchor = createRef<HTMLAnchorElement>();
   return (
     <MediaItemWrapper
       onClick={() => handleChange(canvasEntity.canvas.id)}
       data-testid="media-item-wrapper"
+      data-active={active}
+      ref={refAnchor}
     >
       <figure>
         <div>
@@ -43,8 +47,8 @@ const MediaItemWrapper = styled("a", {
   margin: "0 1.618rem 0 0",
   cursor: "pointer",
 
-  "&.active": {
-    backgroundColor: "black",
+  "&[data-active='true']": {
+    opacity: "0.5",
   },
 
   figure: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const sampleManifest: string =
-  "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/new_airliner.json";
+  "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases.json";
 
 const App: React.FC<Props> = ({ manifestId }) => {
   return (

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -3,7 +3,6 @@ import {
   AnnotationPageNormalized,
   Canvas,
   CanvasNormalized,
-  ContentResource,
   InternationalString,
 } from "@hyperion-framework/types";
 
@@ -15,19 +14,19 @@ export const getLabel = (
   return label[language];
 };
 
-interface CanvasEntities {
+interface CanvasEntity {
   canvas: CanvasNormalized | undefined;
   annotationPage: AnnotationPageNormalized | undefined;
   annotations: Array<Annotation> | undefined;
 }
 
-export const getCanvasEntities = (
+export const getCanvasByCriteria = (
   vault: object,
   item: Canvas,
   motivation: string,
   paintingType: Array<string>,
 ) => {
-  const normalized: CanvasEntities = {
+  const entity: CanvasEntity = {
     canvas: undefined,
     annotationPage: undefined,
     annotations: undefined,
@@ -50,12 +49,12 @@ export const getCanvasEntities = (
     }
   };
 
-  normalized.canvas = vault.fromRef(item);
-  normalized.annotationPage = vault.fromRef(normalized.canvas.items[0]);
+  entity.canvas = vault.fromRef(item);
+  entity.annotationPage = vault.fromRef(entity.canvas.items[0]);
 
-  normalized.annotations = vault
-    .allFromRef(normalized.annotationPage.items)
+  entity.annotations = vault
+    .allFromRef(entity.annotationPage.items)
     .filter(filterAnnotations);
 
-  if (normalized.annotations.length > 0) return normalized;
+  if (entity.annotations.length > 0) return entity;
 };

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -59,7 +59,7 @@ export const getCanvasByCriteria = (
     .allFromRef(entity.annotationPage.items)
     .filter(filterAnnotations);
 
-  if (entity.annotations.length > 0) return entity;
+  return entity;
 };
 
 export const getThumbnail = (vault, entity, width, height) => {

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -15,19 +15,19 @@ export const getLabel = (
   return label[language];
 };
 
-interface NormalizedData {
+interface CanvasEntities {
   canvas: CanvasNormalized | undefined;
   annotationPage: AnnotationPageNormalized | undefined;
   annotations: Array<Annotation> | undefined;
 }
 
-export const getNormalizedByCritera = (
+export const getCanvasEntities = (
   vault: object,
   item: Canvas,
   motivation: string,
   paintingType: Array<string>,
 ) => {
-  const normalized: NormalizedData = {
+  const normalized: CanvasEntities = {
     canvas: undefined,
     annotationPage: undefined,
     annotations: undefined,
@@ -57,9 +57,5 @@ export const getNormalizedByCritera = (
     .allFromRef(normalized.annotationPage.items)
     .filter(filterAnnotations);
 
-  return reconstructedCanvas(normalized);
-};
-
-export const reconstructedCanvas = (normalizedData: NormalizedData) => {
-  if (normalizedData.annotations.length > 0) return normalizedData;
+  if (normalized.annotations.length > 0) return normalized;
 };

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -43,6 +43,8 @@ export const getCanvasByCriteria = (
         )
           return annotation;
         break;
+      case "supplementing":
+        return;
       default: {
         throw new Error(`Invalid annotation motivation.`);
       }

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -1,4 +1,10 @@
-import { InternationalString } from "@hyperion-framework/types";
+import {
+  AnnotationNormalized,
+  AnnotationPageNormalized,
+  CanvasNormalized,
+  ContentResource,
+  InternationalString,
+} from "@hyperion-framework/types";
 
 // Get string from a IIIF pres 3 label by language code
 export const getLabel = (
@@ -8,9 +14,37 @@ export const getLabel = (
   return label[language];
 };
 
-export const getCanvasByCriteria = (
-  motivation: string,
+export const getCanvasByAnnotation = (
+  vault: object,
+  item: object,
+  annotationMotivation: string,
   contentResourceType: Array<string>,
 ) => {
-  return;
+  const canvas: CanvasNormalized = vault.fromRef(item);
+
+  const annotationPage: AnnotationPageNormalized = vault.fromRef(
+    canvas.items[0],
+  );
+
+  const annotations: Array<AnnotationNormalized> = vault.allFromRef(
+    annotationPage.items,
+  );
+
+  for (const annotation of annotations) {
+    if (annotation.motivation.includes(annotationMotivation)) {
+      const contentResource: ContentResource = vault.fromRef(
+        annotation.body[0],
+      );
+
+      if (
+        annotation.target === item.id &&
+        contentResourceType.includes(contentResource.type)
+      )
+        return {
+          canvas: canvas,
+          annotations: [annotation],
+          contentResource: contentResource,
+        };
+    }
+  }
 };

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -3,6 +3,7 @@ import {
   AnnotationPageNormalized,
   Canvas,
   CanvasNormalized,
+  ContentResource,
   InternationalString,
 } from "@hyperion-framework/types";
 
@@ -59,4 +60,64 @@ export const getCanvasByCriteria = (
     .filter(filterAnnotations);
 
   if (entity.annotations.length > 0) return entity;
+};
+
+export const getThumbnail = (vault, entity, width, height) => {
+  /*
+   * 1. Initiate empty candidates array.
+   */
+  let candidates: Array<object> | null = [];
+
+  /*
+   * 2. Check if canvas has an explicitly assigned IIIF thumbnail.
+   */
+  if (entity.canvas.thumbnail.length > 0) {
+    const canvasThumbnail: ContentResource = vault.fromRef(
+      entity.canvas.thumbnail[0],
+    );
+    candidates.push(canvasThumbnail);
+  }
+
+  /*
+   * 2. Check if painting annotation has an explicitly assigned IIIF thumbnail.
+   */
+  if (entity.annotations[0].thumbnail) {
+    if (entity.annotations[0].thumbnail.length > 0) {
+      const annotationThumbnail: ContentResource = vault.fromRef(
+        entity.annotations[0].thumbnail[0],
+      );
+      candidates.push(annotationThumbnail);
+    }
+  }
+
+  /*
+   * 3. Check if painting annotation is of type Image.
+   */
+  if (entity.annotations[0].body[0].type === "Image") {
+    candidates.push(entity.annotations[0].body[0]);
+  }
+
+  /*
+   * 4. Validate candidates and make selection.
+   *
+   *    (WIP)
+   *
+   */
+
+  const selectedCandidate: object = {
+    src: candidates[0].id,
+    format: candidates[0].format,
+  };
+
+  /*
+   * 5. Return (for time being crudely) constructed image object.
+   */
+  const thumbnailContent: object = {
+    src: selectedCandidate.src,
+    width: width,
+    height: height,
+    format: selectedCandidate.format,
+  };
+
+  return thumbnailContent;
 };

--- a/src/services/utils.test.ts
+++ b/src/services/utils.test.ts
@@ -1,4 +1,4 @@
-import { cleanTime } from "./utils";
+import { cleanTime, convertTime } from "./utils";
 
 test("Test output a 'cleaned time' when given international standard time notation.", () => {
   const hours1 = cleanTime("11:15:55.784");
@@ -12,5 +12,20 @@ test("Test output a 'cleaned time' when given international standard time notati
   const seconds1 = cleanTime("00:00:55.784");
   expect(seconds1).toBe("0:55");
   const seconds2 = cleanTime("00:00:05.784");
+  expect(seconds2).toBe("0:05");
+});
+
+test("Test output a 'converted time' when given seconds as integer.", () => {
+  const hours1 = convertTime(40555);
+  expect(hours1).toBe("11:15:55");
+  const hours2 = convertTime(4555);
+  expect(hours2).toBe("1:15:55");
+  const minutes1 = convertTime(955);
+  expect(minutes1).toBe("15:55");
+  const minutes2 = convertTime(355);
+  expect(minutes2).toBe("5:55");
+  const seconds1 = convertTime(55);
+  expect(seconds1).toBe("0:55");
+  const seconds2 = convertTime(5);
   expect(seconds2).toBe("0:05");
 });

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -13,5 +13,12 @@ export const cleanTime = (standardNotation: String) => {
   return time;
 };
 
+export const convertTime = (duration: number) => {
+  const standardNotation: string = new Date(duration * 1000)
+    .toISOString()
+    .substr(11, 8);
+  return cleanTime(standardNotation);
+};
+
 const zeroPad = (num: number, places: number) =>
   String(num).padStart(places, "0");


### PR DESCRIPTION
This pull request lays the ground work for rendering out canvases as individual `<MediaItem/>` in the `<Media/>` component. 

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/7376450/135483032-2fc651be-b2d6-4257-a751-a0fdc1f24bd6.png">

It introduces a function `getCanvasByCriteria()` that we may want to treat as a _hook_. This filters out canvases that do not match a specified W3C annotation motivation ("painting", "supplementing"), or content resource type ("Image", "Sound", "Video").

Additionally, some work was completed to indicate to the end user visually which active media item is set.
