### PR TITLE
Refine styling of RMP.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,9 +11,49 @@
 
       body {
         margin: 0;
-        font-family: "Akkurat Pro Regular", "-apple-system", "system-ui",
-          "sans-serif";
-        color: rgb(52, 47, 46);
+        font: 62.5%/1.7em "Akkurat Pro Regular", Arial, sans-serif;
+        color: #342f2e;
+        background: #fff;
+      }
+
+      @font-face {
+        font-family: "Akkurat Pro Regular";
+        src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProRegular.woff")
+          format("woff");
+        font-weight: normal;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: "Akkurat Pro Italic";
+        src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProItalic.woff")
+          format("woff");
+        font-weight: normal;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: "Akkurat Pro Bold";
+        src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProBold.woff")
+          format("woff");
+        font-weight: normal;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: "Akkurat Pro Bold Italic";
+        src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProBoldItalic.woff")
+          format("woff");
+        font-weight: normal;
+        font-style: normal;
+      }
+
+      @font-face {
+        font-family: "Campton Bold";
+        src: url("https://common.northwestern.edu/v8/css/fonts/CamptonBold.woff")
+          format("woff");
+        font-weight: normal;
+        font-style: normal;
       }
     </style>
   </head>

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -69,9 +69,6 @@ const MediaWrapper = styled("nav", {
   flexGrow: "1",
   padding: "1.618rem 0.618rem 1.618rem 0 ",
   overflowX: "scroll",
-  backgroundColor: "white",
-  borderRight: "2px solid #D8D8D8",
-  borderImage: "linear-gradient(to bottom, #D8D8D8, #FFFFFF00) 0 100%",
 });
 
 export default Media;

--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -7,6 +7,7 @@ import {
   IIIFExternalWebResource,
   InternationalString,
 } from "@hyperion-framework/types";
+import { theme } from "theme";
 
 export interface MediaItemProps {
   canvas: CanvasNormalized;
@@ -61,36 +62,45 @@ const MediaItemWrapper = styled("a", {
     "> div": {
       position: "relative",
       display: "flex",
-      backgroundColor: "#f1f1f1",
+      backgroundColor: theme.color.secondaryAlt,
+      width: "199px",
+      height: "123px",
       overflow: "hidden",
-      transition: "all 200ms ease-in-out",
+      transition: theme.transition.all,
 
       img: {
-        width: "199px",
-        height: "123px",
+        width: "100%",
+        height: "100%",
         objectFit: "cover",
         filter: "blur(0)",
         transform: "scale3d(1, 1, 1)",
-        transition: "all 200ms ease-in-out",
+        transition: theme.transition.all,
       },
 
       [`& ${MediaItemDuration}`]: {
         position: "absolute",
-        right: "0.25rem",
-        bottom: "0.25rem",
-        padding: "0.125rem 0.25rem",
-        backgroundColor: "black",
-        color: "white",
-        fontWeight: "700",
-        fontSize: "0.7272rem",
+        right: "0",
+        bottom: "0",
+        padding: "0.25rem 0.5rem 0.2rem",
+        backgroundColor: theme.color.primaryAlt,
+        color: theme.color.secondary,
+        fontSize: "0.8333rem",
         borderRadius: "1px",
-        transition: "all 200ms ease-in-out",
         opacity: "1",
+
+        "&::after": {
+          color: "white",
+          width: "0",
+          content: "Active Item",
+          fontSize: "0",
+        },
       },
     },
 
     figcaption: {
-      marginTop: "0.382rem",
+      marginTop: "0.5rem",
+      color: theme.color.primaryMuted,
+      fontSize: "1rem",
       fontWeight: "400",
     },
   },
@@ -98,16 +108,15 @@ const MediaItemWrapper = styled("a", {
   "&[data-active='true']": {
     figure: {
       "> div": {
-        backgroundColor: "black",
+        backgroundColor: theme.color.primary,
 
         "&::before": {
           position: "absolute",
           zIndex: "1",
-          color: "white",
+          color: theme.color.secondary,
           textTransform: "uppercase",
-          fontSize: "0.8333rem",
           fontWeight: "700",
-          content: "Now Playing",
+          content: "",
           display: "flex",
           width: "100%",
           height: "100%",
@@ -117,19 +126,29 @@ const MediaItemWrapper = styled("a", {
         },
 
         img: {
-          opacity: "0.382",
-          filter: "blur(2px)",
+          opacity: "0.5",
           transform: "scale3d(1.1, 1.1, 1.1)",
+          filter: "blur(1px)",
         },
 
         [`& ${MediaItemDuration}`]: {
-          opacity: "0",
+          color: "transparent",
+          fontSize: "0",
+          backgroundColor: theme.color.accent,
+
+          "&::after": {
+            color: "white",
+            width: "auto",
+            content: "Active Item",
+            fontSize: "0.8333rem",
+          },
         },
       },
     },
 
     figcaption: {
       fontWeight: "700",
+      color: theme.color.primary,
     },
   },
 });

--- a/src/components/Navigator/Navigator.tsx
+++ b/src/components/Navigator/Navigator.tsx
@@ -3,6 +3,7 @@ import { styled } from "@stitches/react";
 import { LabeledResource } from "hooks/use-hyperion-framework/getContentResourcesByCriteria";
 import NavigatorResource from "./NavigatorResource";
 import NavigatorTab from "./NavigatorTab";
+import { theme } from "theme";
 
 interface NavigatorProps {
   activeCanvas: string;
@@ -58,13 +59,14 @@ const NavigatorWrapper = styled("div", {
   flexShrink: "0",
   position: "relative",
   zIndex: "1",
+  boxShadow: "-5px -5px 5px #00000011",
 });
 
 const NavigatorHeader = styled("header", {
   display: "flex",
   flexGrow: "0",
-  padding: "0 1.618rem 1.618rem",
-  backgroundColor: "transparent !important",
+  margin: "0 1.618rem 0",
+  borderBottom: `4px solid ${theme.color.secondaryAlt}`,
 });
 
 const NavigatorBody = styled("div", {
@@ -72,13 +74,24 @@ const NavigatorBody = styled("div", {
   flexGrow: "1",
   flexShrink: "0",
   position: "relative",
+
+  "&:after": {
+    position: "absolute",
+    bottom: 0,
+    content: "",
+    width: "100%",
+    height: "1rem",
+    backgroundImage: `linear-gradient(0deg, #FFFFFF 0%, #FFFFFF00 100%)`,
+    zIndex: 1,
+  },
 });
 
 const NavigatorScroll = styled("div", {
   position: "absolute",
   overflowY: "scroll",
-  height: "100%",
+  height: "calc(100% - 2rem)",
   width: "100%",
+  padding: "1rem 0 1rem",
 });
 
 export default Navigator;

--- a/src/components/Navigator/NavigatorCue.tsx
+++ b/src/components/Navigator/NavigatorCue.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { styled } from "@stitches/react";
+import { styled, keyframes } from "@stitches/react";
 import { cleanTime } from "services/utils";
+import { theme } from "theme";
 
 interface Props {
   label: string;
@@ -17,15 +18,105 @@ const NavigatorCue: React.FC<Props> = ({ label, startTime }) => {
   );
 };
 
+const spin = keyframes({
+  from: { transform: "rotate(360deg)" },
+  to: { transform: "rotate(0deg)" },
+});
+
 const NavigatorCueAnchor = styled("a", {
   display: "flex",
   flexGrow: "1",
   justifyContent: "space-between",
-  padding: "0.5rem  1.618rem ",
+  margin: "0",
+  padding: "0.55rem 1.618rem 0.45rem",
+  fontSize: "1rem",
   cursor: "pointer",
+  color: theme.color.primaryMuted,
+  position: "relative",
+
+  "&::before": {
+    content: "",
+    width: "12px",
+    height: "12px",
+    borderRadius: "12px",
+    position: "absolute",
+    backgroundColor: theme.color.primaryMuted,
+    opacity: "0",
+    left: "8px",
+    marginTop: "2px",
+  },
+
+  "&::after": {
+    content: "",
+    width: "4px",
+    height: "6px",
+    position: "absolute",
+    backgroundColor: theme.color.secondary,
+    opacity: "0",
+    clipPath: "polygon(100% 50%, 0 100%, 0 0)",
+    left: "13px",
+    marginTop: "5px",
+  },
+
+  strong: {
+    marginLeft: "1rem",
+  },
 
   "&:hover": {
-    backgroundColor: "#D8D6D6",
+    color: theme.color.accent,
+
+    "&::before": {
+      backgroundColor: theme.color.accent,
+      opacity: "1",
+    },
+
+    "&::after": {
+      content: "",
+      width: "4px",
+      height: "6px",
+      position: "absolute",
+      backgroundColor: theme.color.secondary,
+      clipPath: "polygon(100% 50%, 0 100%, 0 0)",
+      left: "13px",
+      marginTop: "5px",
+      opacity: "1",
+    },
+  },
+
+  "&:first-child": {
+    color: theme.color.primary,
+    backgroundColor: theme.color.secondaryMuted,
+
+    "&::before": {
+      content: "",
+      width: "6px",
+      height: "6px",
+      position: "absolute",
+      backgroundColor: "transparent",
+      border: `3px solid ${theme.color.accentMuted}`,
+      borderRadius: "12px",
+      left: "8px",
+      marginTop: "2px",
+      opacity: "1",
+      animation: "1s linear infinite",
+      animationName: spin,
+    },
+
+    "&::after": {
+      content: "",
+      width: "6px",
+      height: "6px",
+      position: "absolute",
+      backgroundColor: "transparent",
+      border: `3px solid ${theme.color.accent}`,
+      clipPath: "polygon(100% 0, 100% 100%, 0 0)",
+      borderRadius: "12px",
+      left: "8px",
+      marginTop: "2px",
+      opacity: "1",
+      animation: "1.5s linear infinite",
+      animationName: spin,
+    },
   },
 
   "&:last-child": {

--- a/src/components/Navigator/NavigatorTab.tsx
+++ b/src/components/Navigator/NavigatorTab.tsx
@@ -3,6 +3,7 @@ import { styled } from "@stitches/react";
 import { InternationalString } from "@hyperion-framework/types";
 import { LabeledResource } from "hooks/use-hyperion-framework/getContentResourcesByCriteria";
 import { getLabel } from "hooks/use-hyperion-framework";
+import { theme } from "theme";
 
 interface NavigatorTabProps {
   active: boolean;
@@ -34,21 +35,43 @@ const NavigatorTab: React.FC<NavigatorTabProps> = ({
 
 const NavigatorTabButton = styled("button", {
   display: "flex",
-  padding: "calc(0.618rem - 2px) calc(1rem - 2px)",
+  position: "relative",
+  padding: "0.6rem 1rem 0.5rem",
   background: "none",
   backgroundColor: "transparent",
-  border: "1px solid #d8d8d8",
-  color: "rgb(52, 47, 46)",
+  color: theme.color.primaryMuted,
+  border: "none",
   fontFamily: "inherit",
   fontSize: "1rem",
-  textTransform: "uppercase",
   marginRight: "1rem",
+  lineHeight: "1rem",
   whiteSpace: "nowrap",
   cursor: "pointer",
+  fontWeight: 700,
+  transition: theme.transition.all,
+
+  "&::after": {
+    width: "0",
+    height: "4px",
+    content: "",
+    backgroundColor: theme.color.primaryMuted,
+    position: "absolute",
+    bottom: "-4px",
+    left: "0",
+    transition: theme.transition.all,
+  },
+
+  "&:hover": {
+    color: theme.color.primary,
+  },
 
   "&[data-active=true]": {
-    backgroundColor: "#d8d8d8",
-    fontWeight: 700,
+    color: theme.color.accent,
+
+    "&::after": {
+      width: "100%",
+      backgroundColor: theme.color.accent,
+    },
   },
 });
 

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Hls from "hls.js";
 import { styled } from "@stitches/react";
 import { IIIFExternalWebResource } from "@hyperion-framework/types";
+import { theme } from "theme";
 
 // Set referrer header as a NU domain: ie. meadow.rdc-staging.library.northwestern.edu
 
@@ -80,7 +81,7 @@ const PlayerWrapper = styled("div", {
     objectFit: "cover",
     width: "100%",
     height: "100%",
-    backgroundColor: "#e0e0e0",
+    backgroundColor: theme.color.secondaryMuted,
   },
 });
 

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -16,6 +16,7 @@ import Navigator from "components/Navigator/Navigator";
 import Player from "components/Player/Player";
 import { useViewerState } from "context/viewer-context";
 import ImageViewer from "components/ImageViewer/ImageViewer";
+import { theme } from "theme";
 
 interface ViewerProps {
   manifest: ManifestNormalized;
@@ -53,7 +54,7 @@ const Viewer: React.FC<ViewerProps> = ({ manifest }) => {
   );
 
   return (
-    <ViewerWrapper>
+    <ViewerWrapper className={theme}>
       <Header>
         <span>{getLabel(manifest.label as InternationalString, "en")}</span>
       </Header>
@@ -87,8 +88,10 @@ const ViewerWrapper = styled("section", {
   display: "flex",
   flexDirection: "column",
   padding: "1.618rem",
-  fontFamily: "inherit",
-  backgroundColor: "white",
+  fontFamily: theme.font.sans,
+  backgroundColor: theme.color.secondary,
+  fontSmooth: "auto",
+  webkitFontSmoothing: "antialiased",
 });
 
 const ViewerInner = styled("div", {
@@ -119,7 +122,8 @@ const Header = styled("header", {
   span: {
     fontSize: "1.25rem",
     fontWeight: "700",
-    padding: "1rem 0",
+    padding: "1rem 0 1.25rem",
+    fontFamily: theme.font.display,
   },
 });
 

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,36 @@
+import { createTheme } from "@stitches/react";
+
+export const theme = createTheme("light", {
+  color: {
+    /*
+     * Black and dark grays in a light theme.
+     * Must contrast to 4.5 or greater with `secondary`.
+     */
+    primary: "#342F2E",
+    primaryMuted: "#716C6B",
+    primaryAlt: "#000000",
+
+    /*
+     * Key brand color(s).
+     * Must contrast to 4.5 or greater with `secondary`.
+     */
+    accent: "#4E2A84",
+    accentMuted: "#B6ACD1",
+    accentAlt: "#401F68",
+
+    /*
+     * White and light grays in a light theme.
+     * Must contrast to 4.5 or greater with `primary` and  `accent`.
+     */
+    secondary: "#FFFFFF",
+    secondaryMuted: "#F0F0F0",
+    secondaryAlt: "#CCCCCC",
+  },
+  font: {
+    sans: "'Akkurat Pro Regular', Arial, sans-serif",
+    display: "Campton, 'Akkurat Pro Regular', Arial, sans-serif",
+  },
+  transition: {
+    all: "all 200ms ease-in-out",
+  },
+});


### PR DESCRIPTION
## What does this do?

This pull request refines the styling of the RMP app:
- adds variable based colors, fonts, and transitions using stitches theming, naming colors with the thought that these might someday be used for multiple _modes_.
- defines font sizes for various selectors resolving small font sizes issues for the media item labels and the navigator cue text.
- adds a pure CSS spinning indicator for active cue item (this is just styled for now and set to the first child) actual work for active cue item will occur in [2188](https://github.com/nulib/repodev_planning_and_docs/issues/2188)
- adds a pure CSS play indicator on hover of a navigator cue
- includes the Northwestern font imports in the `public/index.html` for a better dev experience

##  Notes
If you have thoughts on a better location for `theme.tsx`, I'm all ears. Long term this could ultimately house a light and a dark mode though.

![image](https://user-images.githubusercontent.com/7376450/136855228-f02a8be2-add9-4ced-85fb-1876ee4ddad4.png)

