### PR TITLE
Render label if exists and available code if `en` not existing.

### DIFF
--- a/src/components/Media/MediaItem.tsx
+++ b/src/components/Media/MediaItem.tsx
@@ -38,7 +38,7 @@ const MediaItem: React.FC<MediaItemProps> = ({
           </MediaItemDuration>
         </div>
         <figcaption>
-          {getLabel(canvas.label as InternationalString, "en")}
+          {canvas.label && getLabel(canvas.label as InternationalString, "en")}
         </figcaption>
       </figure>
     </MediaItemWrapper>

--- a/src/hooks/use-hyperion-framework/getLabel.ts
+++ b/src/hooks/use-hyperion-framework/getLabel.ts
@@ -5,5 +5,17 @@ export const getLabel = (
   label: InternationalString,
   language: string = "en",
 ) => {
+  /*
+   * If InternationalString code does not exist on label, then
+   * return what may be there, ex: label.none[0] OR label.fr[0]
+   */
+  if (!label[language]) {
+    const codes: Array<string> = Object.getOwnPropertyNames(label);
+    if (codes.length > 0) return label[codes[0]];
+  }
+
+  /*
+   * Return label value for InternationalString code `en`
+   */
   return label[language];
 };


### PR DESCRIPTION
As I was researching our usage of IIIF Presentation Manifests, I tested the player against the lunchroom manners recipe. I found immediately that it crashed, expecting a label to exist on canvas. In addition, I tested what would happen if a label with a code other than `en` existed and decided we could quickly fix both.

This is a manifest that you can use for testing:
https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/internationalizedLabels.json 

- First canvas has the `en` label
- Second canvas has the `none` label
- Third canvas has no label