### PR TITLE
Support non-HLS media, hardcode ID. 

### DIFF
--- a/public/fixtures/iiif/manifests/assortedCanvases.json
+++ b/public/fixtures/iiif/manifests/assortedCanvases.json
@@ -189,6 +189,92 @@
           ]
         }
       ]
+    },
+    {
+      "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2",
+      "type": "Canvas",
+      "width": 720,
+      "height": 480,
+      "duration": 277,
+      "label": {
+        "en": ["Video canvas (.mp4), with supplementing webVTT"]
+      },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/posters/3774f727-6090-444e-8f4e-16d1c0154955/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "@type": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/bca5b88d-7433-4710-96db-e38f1a24e9ae"
+            }
+          ],
+          "width": 8540,
+          "height": 8714
+        }
+      ],
+      "items": [
+        {
+          "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2",
+              "body": {
+                "id": "http://techslides.com/demos/sample-videos/small.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 720,
+                "width": 480,
+                "duration": 277
+              }
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2/annotation_page/2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2/page/annotation_page/1/annotation/2",
+              "type": "Annotation",
+              "motivation": "supplementing",
+              "body": {
+                "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_en.vtt",
+                "type": "Text",
+                "format": "text/vtt",
+                "label": {
+                  "en": ["en"]
+                },
+                "language": "en"
+              },
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2"
+            },
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2/page/annotation_page/1/annotation/3",
+              "type": "Annotation",
+              "motivation": "supplementing",
+              "body": {
+                "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_es.vtt",
+                "type": "Text",
+                "format": "text/vtt",
+                "label": {
+                  "es": ["es"]
+                },
+                "language": "en"
+              },
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/2"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -31,7 +31,17 @@ const Player: React.FC<PlayerProps> = ({
    * STAGING and PRODUCTION environments only
    */
   React.useEffect(() => {
+    /**
+     * Check that IIIF content resource ID exists and
+     * we have a reffed <video> for attaching HLS
+     */
     if (!painting.id || !playerRef.current) return;
+
+    /**
+     * Eject HLS attachment if file extension from
+     * the IIIF content resource ID is not .m3u8
+     */
+    if (painting.id.split(".").pop() !== "m3u8") return;
 
     // Bind hls.js package to our <video /> element and then load the media source
     const hls = new Hls();
@@ -91,13 +101,14 @@ const Player: React.FC<PlayerProps> = ({
   return (
     <PlayerWrapper>
       <video
+        id="react-media-player"
         ref={playerRef}
         controls
         height={painting.height}
         width={painting.width}
         onPlay={handlePlay}
       >
-        <source src={painting.id} type={painting.type} />
+        <source src={painting.id} type={painting.format} />
         {resources.length > 0 &&
           resources.map((resource) => {
             return (


### PR DESCRIPTION
## What does this do?
This adds a quick check on the IIIF content resource ID's file extension. If it is `m3u8`, we'll eject out of the the HLS attachment functionality and simply rely on the `<source src="https://url.to/filename.mp4">` to populate the `<video>` element. I also have hardcoded an ID for the `<video>` element.

## How do we test this?
- `npm run dev`
- A manifest should load with three canvases. The first two are HLS supported videos. The third is a run of the mill .mp4. All should load.

## Notes
- Add logic for ejecting HLS for non-m3u8 extenstions.
- Temporary hardcoding of an ID for `<video>`.
