### PR TITLE
Add activeCanvas callback for consuming apps.

### DIFF
--- a/public/fixtures/iiif/manifests/canvasless.json
+++ b/public/fixtures/iiif/manifests/canvasless.json
@@ -1,0 +1,16 @@
+{
+  "id": "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/iiif3/6b/25/d6/c8/-0/80/2-/41/a9/-8/83/c-/58/9a/44/55/17/46-manifest.json",
+  "label": {
+    "en": ["424233"]
+  },
+  "requiredStatement": {
+    "label": {
+      "en": ["Attribution"]
+    },
+    "value": {
+      "en": ["Courtesy of Northwestern University Libraries"]
+    }
+  },
+  "type": "Manifest",
+  "@context": "http://iiif.io/api/presentation/3/context.json"
+}

--- a/public/fixtures/iiif/manifests/nonStreaming.json
+++ b/public/fixtures/iiif/manifests/nonStreaming.json
@@ -1,0 +1,86 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Assorted canvases for testing nulib/react-media-player"]
+  },
+  "summary": {
+    "en": [
+      "Integer non fringilla massa, ac tristique ipsum. Quisque imperdiet malesuada magna, id congue augue semper vitae. Etiam nec eleifend elit, vel pharetra velit. Donec facilisis augue eget nisi convallis, vel fermentum dolor tincidunt. "
+    ]
+  },
+  "rights": "http://rightsstatements.org/vocab/NoC-NC/1.0/",
+  "requiredStatement": {
+    "label": { "en": ["Attribution"] },
+    "value": {
+      "en": ["Who knows?"]
+    }
+  },
+  "items": [
+    {
+      "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0",
+      "type": "Canvas",
+      "width": 720,
+      "height": 480,
+      "duration": 500,
+      "label": {
+        "en": ["Video canvas, streaming (.m3u8), with supplementing webVTT"]
+      },
+      "items": [
+        {
+          "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0/annotation_page/4",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0",
+              "body": {
+                "id": "http://techslides.com/demos/sample-videos/small.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 720,
+                "width": 480,
+                "duration": 500
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/1",
+      "type": "Canvas",
+      "width": 400,
+      "height": 300,
+      "duration": 102,
+      "label": {
+        "en": ["Video canvas, non-streaming, with supplementing webVTT"]
+      },
+      "items": [
+        {
+          "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/1/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/1",
+              "body": {
+                "id": "https://upload.wikimedia.org/wikipedia/commons/6/6b/1946-02-21_New_Airliner.ogv",
+                "type": "Video",
+                "format": "video/ogg",
+                "height": 400,
+                "width": 300,
+                "duration": 102
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -102,6 +102,7 @@ const Player: React.FC<PlayerProps> = ({
     <PlayerWrapper>
       <video
         id="react-media-player"
+        key={painting.id}
         ref={playerRef}
         controls
         height={painting.height}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -28,9 +28,12 @@ const ViewerDispatchContext =
   React.createContext<ViewerContextStore>(defaultState);
 
 function viewerReducer(state: ViewerContextStore, action: ViewerAction) {
-  console.log(action);
   switch (action.type) {
     case "updateActiveCanvas": {
+      /**
+       * Set canvasId to empty string if it comes back undefined.
+       */
+      if (!action.canvasId) action.canvasId = "";
       return {
         ...state,
         activeCanvas: action.canvasId,

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -5,7 +5,11 @@ import App from "./index";
 const sampleManifest: string =
   "http://127.0.0.1:8080/fixtures/iiif/manifests/assortedCanvases.json";
 
+const handleCanvasIdCallback = (canvasId) => {
+  console.log(`canvasId`, canvasId);
+};
+
 ReactDOM.render(
-  <App manifestId={sampleManifest} />,
+  <App manifestId={sampleManifest} canvasIdCallback={handleCanvasIdCallback} />,
   document.getElementById("root"),
 );


### PR DESCRIPTION
## What does this do?
This adds in a relatively simple callback that sends the activeCanvas from the context store up to a consuming application.  The callback is optional and the app should be able to rendered in a consuming application with or without a `canvasIdCallback={}` prop.

Also, while tackling this I through in the fix for https://github.com/nulib/repodev_planning_and_docs/issues/2345.

## How do we test this?
1. `npm run dev`
2. A `console.log();` in `dev.tsx` will deliver the current **canvasId**

