### PR TITLE
Update RMP entry logic to address manifests missing labels.

### DIFF
--- a/public/fixtures/iiif/manifests/canvasless.json
+++ b/public/fixtures/iiif/manifests/canvasless.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/iiif3/6b/25/d6/c8/-0/80/2-/41/a9/-8/83/c-/58/9a/44/55/17/46-manifest.json",
+  "id": "http://127.0.0.1:8080/fixtures/manifest/labelless.json",
   "label": {
     "en": ["424233"]
   },

--- a/public/fixtures/iiif/manifests/labelless.json
+++ b/public/fixtures/iiif/manifests/labelless.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/iiif3/6b/25/d6/c8/-0/80/2-/41/a9/-8/83/c-/58/9a/44/55/17/46-manifest.json",
+  "id": "http://127.0.0.1:8080/fixtures/manifest/labelless.json",
   "requiredStatement": {
     "label": {
       "en": ["Attribution"]
@@ -8,6 +8,40 @@
       "en": ["Courtesy of Northwestern University Libraries"]
     }
   },
+  "items": [
+    {
+      "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0",
+      "type": "Canvas",
+      "width": 720,
+      "height": 480,
+      "duration": 500,
+      "label": {
+        "en": ["Video canvas, streaming (.m3u8), with supplementing webVTT"]
+      },
+      "items": [
+        {
+          "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0/annotation_page/4",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/manifest/assortedCanvases/canvas/0",
+              "body": {
+                "id": "http://techslides.com/demos/sample-videos/small.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 720,
+                "width": 480,
+                "duration": 500
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "type": "Manifest",
   "@context": "http://iiif.io/api/presentation/3/context.json"
 }

--- a/src/hooks/use-hyperion-framework/getLabel.ts
+++ b/src/hooks/use-hyperion-framework/getLabel.ts
@@ -6,6 +6,11 @@ export const getLabel = (
   language: string = "en",
 ) => {
   /*
+   * If no label exists, return a hardcoded string.
+   */
+  if (!label) return "Untitled";
+
+  /*
    * If InternationalString code does not exist on label, then
    * return what may be there, ex: label.none[0] OR label.fr[0]
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,12 +76,15 @@ const RenderViewer: React.FC<Props> = ({ manifestId, canvasIdCallback }) => {
   /**
    * If an error occurs during manifest fetch process used by
    * @hyperion-framework/vault, vault will not return a manifest
-   * that is fully normalized, and be missing the label property.
+   * that is fully normalized, and be missing the items property.
    * This being undefined signals that something went wrong and we
    * will render a user-friendly error as a functional component.
    */
-  if (!manifest || !manifest["label"])
-    return <>The IIIF manifest {manifestId} failed to load.</>;
+
+  if (!manifest || !manifest["items"]) {
+    console.log(`The IIIF manifest ${manifestId} failed to load.`);
+    return <></>;
+  }
 
   /**
    * If the manifest returned by @hyperion-framework/vault does not
@@ -89,8 +92,10 @@ const RenderViewer: React.FC<Props> = ({ manifestId, canvasIdCallback }) => {
    * may be required if the viewer is rendered to preview manifests in
    * repository administration views.
    */
-  if (manifest["items"].length === 0)
-    return <>The IIIF manifest {manifestId} does not contain any canvases.</>;
+  if (manifest["items"].length === 0) {
+    console.log(`The IIIF manifest ${manifestId} does not contain canvases.`);
+    return <></>;
+  }
 
   /**
    * If manifest is normalized by @hyperion-framework/vault, we know


### PR DESCRIPTION
### What does this do?

This updates our app entry conditionals to allow a manifest without a label to render the media player. Due to how our workflow occurs in Meadow, works may exist without a corresponding title, and thus the manifest may exist without a label. Although these manifests are not valid, they also will never be in the wild.

- Switch of conditional to check that hyperion has loaded manifest to look at the `items` property
- If a label does not exist, we will assigned a string `Untitled` as the label.
- Adds some new uses cases to fixtures