### PR TITLE
Update to check for IIIF resource type of sound.

### DIFF
--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -39,7 +39,7 @@ const Viewer: React.FC<ViewerProps> = ({ manifest }) => {
     const painting = getPaintingResource(vault, activeCanvas);
     if (painting) {
       setIsMedia(
-        ["Audio", "Video"].indexOf(painting.type as ExternalResourceTypes) > -1
+        ["Sound", "Video"].indexOf(painting.type as ExternalResourceTypes) > -1
           ? true
           : false,
       );


### PR DESCRIPTION
This is a quick fix to update the `isMedia` logic to be determined by **Sound** instead of _Audio_.