### PR TITLE
Tidy up active cue logic, fix indicator, adjust label.

### DIFF
--- a/src/components/Navigator/NavigatorCue.styled.tsx
+++ b/src/components/Navigator/NavigatorCue.styled.tsx
@@ -28,6 +28,7 @@ export const NavigatorCueAnchor = styled("a", {
     opacity: "0",
     left: "8px",
     marginTop: "5px",
+    boxSizing: "content-box",
   },
 
   "&::after": {
@@ -40,6 +41,7 @@ export const NavigatorCueAnchor = styled("a", {
     clipPath: "polygon(100% 50%, 0 100%, 0 0)",
     left: "13px",
     marginTop: "8px",
+    boxSizing: "content-box",
   },
 
   strong: {
@@ -82,6 +84,7 @@ export const NavigatorCueAnchor = styled("a", {
       opacity: "1",
       animation: "1s linear infinite",
       animationName: spin,
+      boxSizing: "content-box",
     },
 
     "&::after": {
@@ -98,6 +101,7 @@ export const NavigatorCueAnchor = styled("a", {
       opacity: "1",
       animation: "1.5s linear infinite",
       animationName: spin,
+      boxSizing: "content-box",
     },
   },
 

--- a/src/components/Navigator/NavigatorResource.tsx
+++ b/src/components/Navigator/NavigatorResource.tsx
@@ -37,16 +37,18 @@ const NavigatorResource: React.FC<NavigatorResource> = ({
   return (
     <>
       {cues.map(({ id, text, startTime, endTime }) => {
-        const time = convertTimeToSeconds(startTime);
+        const startTimeSeconds = convertTimeToSeconds(startTime);
+        const endTimeSeconds = convertTimeToSeconds(endTime);
+
         let active =
-          time <= currentTime && currentTime < convertTimeToSeconds(endTime);
+          startTimeSeconds <= currentTime && currentTime < endTimeSeconds;
 
         return (
           <NavigatorCue
             label={text}
             startTime={startTime}
             active={active}
-            time={time}
+            time={startTimeSeconds}
             key={id}
           />
         );

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -126,7 +126,7 @@ const Header = styled("header", {
   span: {
     fontSize: "1.25rem",
     fontWeight: "700",
-    padding: "1rem 0 1.25rem",
+    padding: "0 0 1rem",
     fontFamily: theme.font.display,
   },
 });


### PR DESCRIPTION
This pull request handles a few quick things related to the styling of our Meadow integration.

![image](https://user-images.githubusercontent.com/7376450/139333926-877e2ef3-a72b-4522-9420-eed7b859d504.png)

- Fixes the issue with spinning indicator on active Cue in meadow. This was caused by the app inheriting Bulma's box-sizing CSS attribute. Our fix should override Bulma for the player indicator.
- Cleans up formatting a bit on the active cue logic. I thought there was an issue here but it turned out to be a bad WebVTT, but decided to leave my renaming of some things.
- Adjusts label top padding to fit more tightly in consuming apps.