### PR TITLE
Update Readme documentation for options config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,30 @@ return <ReactMediaPlayer manifestId={manifestId} customTheme={customTheme} />;
 
 ## Reference
 
-| Prop               | Type     | Required |
-| ------------------ | -------- | -------- |
-| `manifestId`       | String   | Yes      |
-| `canvasIdCallback` | Function | No       |
-| `customTheme`      | Object   | No       |
+| Prop                | Type     | Required | Default |
+| ------------------- | -------- | -------- | ------- |
+| `manifestId`        | String   | Yes      |         |
+| `canvasIdCallback`  | Function | No       |         |
+| `customTheme`       | Object   | No       |         |
+| `options`           | Object   | No       |         |
+| `options.showTitle` | Boolean  | No       | true    |
+
+RMP version 1.4.0, introduces an `options` prop, which will serve as a configuration object for common configuration options.
+
+```jsx
+import ReactMediaPlayer from "@nulib/react-media-player";
+
+...
+
+// Supported options
+const options = {
+  // Primary title (IIIF label) for top level canvas.  Defaults to true
+  showTitle: false
+}
+...
+
+<ReactMediaPlayer manifestId={...} options={options} />
+```
 
 ---
 


### PR DESCRIPTION
Updates the Readme docs to explain what the `options` prop does.