### PR TITLE
Update build config 

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,13 +1,13 @@
 // Reference: https://github.com/souporserious/bundling-typescript-with-esbuild-for-npm
 
 const { build } = require("esbuild");
-const { peerDependencies } = require("./package.json");
+const { dependencies } = require("./package.json");
 
 const entryFile = "src/index.tsx";
 const shared = {
   bundle: true,
   entryPoints: [entryFile],
-  external: Object.keys(peerDependencies),
+  external: Object.keys(dependencies),
   logLevel: "info",
   minify: true,
   sourcemap: true,
@@ -15,7 +15,6 @@ const shared = {
 
 build({
   ...shared,
-  external: ["react", "react-dom"],
   format: "esm",
   outfile: "./dist/index.esm.js",
   target: ["esnext", "node12.22.0"],
@@ -23,7 +22,6 @@ build({
 
 build({
   ...shared,
-  external: ["react", "react-dom"],
   format: "cjs",
   outfile: "./dist/index.cjs.js",
   target: ["esnext", "node12.22.0"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nulib/react-media-player",
   "version": "1.4.4",
-  "description": "YouTube style media player for audio and video files driven by a IIIF manifest",
+  "description": "Viewer for audio, video and image file types driven by a IIIF manifest",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
@@ -10,10 +10,11 @@
     "url": "https://github.com/nulib/react-media-player.git"
   },
   "scripts": {
-    "build": "rm -rf dist && node build.js && tsc --emitDeclarationOnly --outDir dist",
+    "build": "npm run clean && node build.js && tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rimraf dist",
     "dev": "node serve.js",
     "test": "jest --watch",
-    "clean": "rimraf dist"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "IIIF",
@@ -34,13 +35,13 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.0",
-    "hls.js": "^1.0.10",
     "jest": "^27.2.1",
     "live-server": "^1.2.1",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.5",
-    "ts-node": "^10.2.1"
+    "ts-node": "^10.2.1",
+    "typescript": "^4.4.3"
   },
   "dependencies": {
     "@hyperion-framework/parser": "^1.0.0",
@@ -53,17 +54,11 @@
     "@types/openseadragon": "^2.4.8",
     "@types/react": "^17.0.21",
     "@types/react-dom": "^17.0.9",
+    "hls.js": "^1.0.10",
     "openseadragon": "^2.4.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "subtitles-parser-vtt": "^0.1.0",
-    "typescript": "^4.4.3"
-  },
-  "peerDependencies": {
-    "@types/openseadragon": "^2.4.8",
-    "openseadragon": "^2.4.2",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "subtitles-parser-vtt": "^0.1.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Update build config to add build command to npm publishing automatically.  Also converted all dependencies to externals, to force consuming apps to install the dependencies, reducing the weight of our package.

Now when we run `npm publish`, it'll pre-build the package which `npm` includes in it's tarball.  