### PR TITLE
Add resource type icons to thumbnails.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,18 @@
         "@hyperion-framework/types": "^1.0.0",
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
+        "@nulib/design-system": "^1.3.5",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
         "@types/openseadragon": "^2.4.8",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
+        "hls.js": "^1.0.10",
         "openseadragon": "^2.4.2",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "subtitles-parser-vtt": "^0.1.0",
-        "typescript": "^4.4.3"
+        "subtitles-parser-vtt": "^0.1.0"
       },
       "devDependencies": {
         "@testing-library/react": "^12.1.0",
@@ -38,19 +39,13 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.26.0",
-        "hls.js": "^1.0.10",
         "jest": "^27.2.1",
         "live-server": "^1.2.1",
         "prettier": "^2.4.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
-        "ts-node": "^10.2.1"
-      },
-      "peerDependencies": {
-        "@types/openseadragon": "^2.4.8",
-        "openseadragon": "^2.4.2",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "ts-node": "^10.2.1",
+        "typescript": "^4.4.3"
       }
     },
     "node_modules/@atlas-viewer/iiif-image-api": {
@@ -1151,12 +1146,54 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nulib/design-system": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.5.tgz",
+      "integrity": "sha512-RMoeNBYgOpcnhOg2ox7fDI71E4RIOd1HOVf8bFQRZPqR9E/qMia2SUA+YLMRPXaJWO6vKDbwIplJpl6wCdxfsw==",
+      "dependencies": {
+        "@radix-ui/colors": "^0.1.7",
+        "@radix-ui/react-popover": "^0.1.1",
+        "@stitches/react": "^1.2.5",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      }
+    },
+    "node_modules/@radix-ui/colors": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
+      "integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
+    },
+    "node_modules/@radix-ui/popper": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/popper/-/popper-0.1.0.tgz",
+      "integrity": "sha512-uzYeElL3w7SeNMuQpXiFlBhTT+JyaNMCwDfjKkrzugEcYrf5n52PHqncNdQPUtR42hJh8V9FsqyEDbDxkeNjJQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "csstype": "^3.0.4"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
       "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.1.tgz",
+      "integrity": "sha512-layhfVIJE/mahiHUi9YZ/k2Of41TO20y1kEynUEq3j+KLUy/pi0mjb+jrPYRqmlznEl8/jye2jwilyGs2Uyx/g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-collection": {
@@ -1196,6 +1233,48 @@
         "react": "^16.8 || ^17.0"
       }
     },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.1.tgz",
+      "integrity": "sha512-OrwRfYE3dqX6nbCnAcIaxsTg6QrLu/HT1GwzxpX0Mbx+AxFNBvE6czBTM5/a7D1CfK8jxORNZ/WsjoOTLudY+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-body-pointer-events": "0.1.0",
+        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-use-escape-keydown": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+      "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.1.tgz",
+      "integrity": "sha512-0b9MwvHwhuIhD46lrf4G2j53/oYzPa2hN9Ylu+4Jg0Qa0kW04/vpKCX2Gh8M8fTlI0YaGVQsN40sYc5fe8RBSA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
     "node_modules/@radix-ui/react-id": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.1.tgz",
@@ -1221,6 +1300,65 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.1.tgz",
+      "integrity": "sha512-kPcuzpB72MQMbnLg24NR4NgOLRL7so5/ApukDKGQqGXs/ZBtAUBTdtNSnQIyItT4rvoRbtUOOIH0jC7072yFMg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-dismissable-layer": "0.1.1",
+        "@radix-ui/react-focus-guards": "0.1.0",
+        "@radix-ui/react-focus-scope": "0.1.1",
+        "@radix-ui/react-id": "0.1.1",
+        "@radix-ui/react-popper": "0.1.1",
+        "@radix-ui/react-portal": "0.1.1",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.1.tgz",
+      "integrity": "sha512-LsjeV9MEdikDHi+uBvMpPyLHrDa7A8UlX2s7c9GPgqU9non7kjcijO4NERaoXvhEu6E7NTqApb5axhZxB23R4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/popper": "0.1.0",
+        "@radix-ui/react-arrow": "0.1.1",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-rect": "0.1.1",
+        "@radix-ui/react-use-size": "0.1.0",
+        "@radix-ui/rect": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.1.tgz",
+      "integrity": "sha512-ZJFgUBsaFS4cryONfRZXuYxtv87ziRGqFu+wP91rVKF8TpkeQgvPP2QBLIfIGzotr3G1n8t7gHaNJkZtKVeXvw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-presence": {
@@ -1318,6 +1456,18 @@
         "react": "^16.8 || ^17.0"
       }
     },
+    "node_modules/@radix-ui/react-use-body-pointer-events": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.0.tgz",
+      "integrity": "sha512-svPyoHCcwOq/vpWNEvdH/yD91vN9p8BtiozNQbjVmJRxQ/vS12zqk70AxTGWe+2ZKHq2sggpEQNTv1JHyVFlnQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
@@ -1333,6 +1483,18 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
       "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "0.1.0"
@@ -1363,6 +1525,18 @@
         "react": "^16.8 || ^17.0"
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.1.tgz",
+      "integrity": "sha512-kHNNXAsP3/PeszEmM/nxBBS9Jbo93sO+xuMTcRfwzXsmxT5gDXQzAiKbZQ0EecCPtJIzqvr7dlaQi/aP1PKYqQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.0.tgz",
@@ -1372,6 +1546,14 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-0.1.1.tgz",
+      "integrity": "sha512-g3hnE/UcOg7REdewduRPAK88EPuLZtaq7sA9ouu8S+YEtnyFRI16jgv6GZYe3VMoQLL1T171ebmEPtDjyxWLzw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2010,6 +2192,17 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
+      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
+      "dependencies": {
+        "tslib": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.5.0"
       }
     },
     "node_modules/aria-query": {
@@ -2972,6 +3165,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -4081,6 +4279,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4311,8 +4517,7 @@
     "node_modules/hls.js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.1.tgz",
-      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw==",
-      "dev": true
+      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -4522,6 +4727,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -7384,6 +7597,73 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "dependencies": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -8796,8 +9076,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -8868,6 +9147,7 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
       "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9010,6 +9290,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -10193,12 +10505,47 @@
         "fastq": "^1.6.0"
       }
     },
+    "@nulib/design-system": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.5.tgz",
+      "integrity": "sha512-RMoeNBYgOpcnhOg2ox7fDI71E4RIOd1HOVf8bFQRZPqR9E/qMia2SUA+YLMRPXaJWO6vKDbwIplJpl6wCdxfsw==",
+      "requires": {
+        "@radix-ui/colors": "^0.1.7",
+        "@radix-ui/react-popover": "^0.1.1",
+        "@stitches/react": "^1.2.5",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      }
+    },
+    "@radix-ui/colors": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
+      "integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
+    },
+    "@radix-ui/popper": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/popper/-/popper-0.1.0.tgz",
+      "integrity": "sha512-uzYeElL3w7SeNMuQpXiFlBhTT+JyaNMCwDfjKkrzugEcYrf5n52PHqncNdQPUtR42hJh8V9FsqyEDbDxkeNjJQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "csstype": "^3.0.4"
+      }
+    },
     "@radix-ui/primitive": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
       "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-arrow": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.1.tgz",
+      "integrity": "sha512-layhfVIJE/mahiHUi9YZ/k2Of41TO20y1kEynUEq3j+KLUy/pi0mjb+jrPYRqmlznEl8/jye2jwilyGs2Uyx/g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.1"
       }
     },
     "@radix-ui/react-collection": {
@@ -10229,6 +10576,39 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "@radix-ui/react-dismissable-layer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.1.tgz",
+      "integrity": "sha512-OrwRfYE3dqX6nbCnAcIaxsTg6QrLu/HT1GwzxpX0Mbx+AxFNBvE6czBTM5/a7D1CfK8jxORNZ/WsjoOTLudY+A==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-body-pointer-events": "0.1.0",
+        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-use-escape-keydown": "0.1.0"
+      }
+    },
+    "@radix-ui/react-focus-guards": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+      "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-focus-scope": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.1.tgz",
+      "integrity": "sha512-0b9MwvHwhuIhD46lrf4G2j53/oYzPa2hN9Ylu+4Jg0Qa0kW04/vpKCX2Gh8M8fTlI0YaGVQsN40sYc5fe8RBSA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      }
+    },
     "@radix-ui/react-id": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.1.tgz",
@@ -10248,6 +10628,54 @@
         "@radix-ui/react-context": "0.1.1",
         "@radix-ui/react-id": "0.1.1",
         "@radix-ui/react-primitive": "0.1.1"
+      }
+    },
+    "@radix-ui/react-popover": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.1.tgz",
+      "integrity": "sha512-kPcuzpB72MQMbnLg24NR4NgOLRL7so5/ApukDKGQqGXs/ZBtAUBTdtNSnQIyItT4rvoRbtUOOIH0jC7072yFMg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-dismissable-layer": "0.1.1",
+        "@radix-ui/react-focus-guards": "0.1.0",
+        "@radix-ui/react-focus-scope": "0.1.1",
+        "@radix-ui/react-id": "0.1.1",
+        "@radix-ui/react-popper": "0.1.1",
+        "@radix-ui/react-portal": "0.1.1",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.4.0"
+      }
+    },
+    "@radix-ui/react-popper": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.1.tgz",
+      "integrity": "sha512-LsjeV9MEdikDHi+uBvMpPyLHrDa7A8UlX2s7c9GPgqU9non7kjcijO4NERaoXvhEu6E7NTqApb5axhZxB23R4w==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/popper": "0.1.0",
+        "@radix-ui/react-arrow": "0.1.1",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-rect": "0.1.1",
+        "@radix-ui/react-use-size": "0.1.0",
+        "@radix-ui/rect": "0.1.1"
+      }
+    },
+    "@radix-ui/react-portal": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.1.tgz",
+      "integrity": "sha512-ZJFgUBsaFS4cryONfRZXuYxtv87ziRGqFu+wP91rVKF8TpkeQgvPP2QBLIfIGzotr3G1n8t7gHaNJkZtKVeXvw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
       }
     },
     "@radix-ui/react-presence": {
@@ -10327,6 +10755,15 @@
         "@radix-ui/react-use-controllable-state": "0.1.0"
       }
     },
+    "@radix-ui/react-use-body-pointer-events": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.0.tgz",
+      "integrity": "sha512-svPyoHCcwOq/vpWNEvdH/yD91vN9p8BtiozNQbjVmJRxQ/vS12zqk70AxTGWe+2ZKHq2sggpEQNTv1JHyVFlnQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      }
+    },
     "@radix-ui/react-use-callback-ref": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
@@ -10339,6 +10776,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
       "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      }
+    },
+    "@radix-ui/react-use-escape-keydown": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-use-callback-ref": "0.1.0"
@@ -10360,10 +10806,27 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "@radix-ui/react-use-rect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.1.tgz",
+      "integrity": "sha512-kHNNXAsP3/PeszEmM/nxBBS9Jbo93sO+xuMTcRfwzXsmxT5gDXQzAiKbZQ0EecCPtJIzqvr7dlaQi/aP1PKYqQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "0.1.1"
+      }
+    },
     "@radix-ui/react-use-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.0.tgz",
       "integrity": "sha512-TcZAsR+BYI46w/RbaSFCRACl+Jh6mDqhu6GS2r0iuJpIVrj8atff7qtTjmMmfGtEDNEjhl7DxN3pr1nTS/oruQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/rect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-0.1.1.tgz",
+      "integrity": "sha512-g3hnE/UcOg7REdewduRPAK88EPuLZtaq7sA9ouu8S+YEtnyFRI16jgv6GZYe3VMoQLL1T171ebmEPtDjyxWLzw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -10859,6 +11322,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
+      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
+      "requires": {
+        "tslib": "^1.0.0"
       }
     },
     "aria-query": {
@@ -11609,6 +12080,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "diff": {
       "version": "4.0.2",
@@ -12480,6 +12956,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -12642,8 +13123,7 @@
     "hls.js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.1.1.tgz",
-      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw==",
-      "dev": true
+      "integrity": "sha512-2VEVzO/gr5LOD6K/DEmBkKEary6hr4YZ/SLb0PV81jOAM/Tl9DviL0sFMoUHDq05/j4OZxIj691Zo0p40u3Gtw=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -12805,6 +13285,14 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "is-accessor-descriptor": {
@@ -14996,6 +15484,37 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "react-remove-scroll": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "requires": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -16088,8 +16607,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -16138,7 +16656,8 @@
     "typescript": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -16247,6 +16766,21 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
+      "requires": {}
+    },
+    "use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@hyperion-framework/types": "^1.0.0",
     "@hyperion-framework/validator": "^1.0.0",
     "@hyperion-framework/vault": "^1.0.2",
+    "@nulib/design-system": "^1.3.5",
     "@radix-ui/react-radio-group": "^0.1.1",
     "@radix-ui/react-tabs": "^0.1.1",
     "@stitches/react": "^1.2.0",

--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -1,8 +1,21 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { styled } from "stitches";
+import { Tag } from "@nulib/design-system";
+
+const Type = styled("span", {
+  display: "flex",
+});
+
+const Spacer = styled("span", {
+  display: "flex",
+  width: "1.2111rem",
+  height: "0.7222rem",
+});
 
 const Duration = styled("span", {
-  display: "flex",
+  display: "inline-flex",
+  marginLeft: "5px",
+  marginBottom: "-1px",
 });
 
 const Item = styled(RadioGroup.Item, {
@@ -29,6 +42,7 @@ const Item = styled(RadioGroup.Item, {
       width: "199px",
       height: "123px",
       overflow: "hidden",
+      borderRadius: "3px",
       transition: "$all",
 
       img: {
@@ -41,16 +55,19 @@ const Item = styled(RadioGroup.Item, {
         color: "transparent",
       },
 
-      [`& ${Duration}`]: {
+      [`& ${Type}`]: {
         position: "absolute",
-        right: "0",
-        bottom: "0",
-        padding: "0.25rem 0.5rem 0.2rem",
-        backgroundColor: "$primaryAlt",
-        color: "$secondary",
-        fontSize: "0.8333rem",
-        borderRadius: "1px",
-        opacity: "1",
+        right: "0.5rem",
+        bottom: "0.5rem",
+
+        [`& ${Tag}`]: {
+          margin: "0",
+          paddingLeft: "0",
+          fontSize: "0.7222rem",
+          backgroundColor: "#000d",
+          color: "$secondary",
+          fill: "$secondary",
+        },
       },
     },
 
@@ -90,8 +107,10 @@ const Item = styled(RadioGroup.Item, {
           filter: "blur(1px)",
         },
 
-        [`& ${Duration}`]: {
-          backgroundColor: "$accent",
+        [`& ${Type}`]: {
+          [`& ${Tag}`]: {
+            backgroundColor: "$accent",
+          },
         },
       },
     },
@@ -103,4 +122,4 @@ const Item = styled(RadioGroup.Item, {
   },
 });
 
-export { Duration, Item };
+export { Duration, Item, Spacer, Type };

--- a/src/components/Media/Thumbnail.tsx
+++ b/src/components/Media/Thumbnail.tsx
@@ -6,8 +6,32 @@ import {
   IIIFExternalWebResource,
   InternationalString,
 } from "@hyperion-framework/types";
-import { Duration, Item } from "./Thumbnail.styled";
+import { Icon, Tag } from "@nulib/design-system";
+import { Duration, Item, Spacer, Type } from "./Thumbnail.styled";
 
+/**
+ * Determine appropriate icon by resource type
+ */
+interface IconPathProps {
+  type: string;
+}
+
+const IconPath: React.FC<IconPathProps> = ({ type }) => {
+  switch (type) {
+    case "Sound":
+      return <Icon.Audio />;
+    case "Image":
+      return <Icon.Image />;
+    case "Video":
+      return <Icon.Video />;
+    default:
+      return <Icon.Image />;
+  }
+};
+
+/**
+ * Render thumbnail for IIIF canvas item
+ */
 export interface ThumbnailProps {
   canvas: CanvasNormalized;
   isActive: boolean;
@@ -35,9 +59,18 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
       <figure>
         <div>
           {thumbnail?.id && <img src={thumbnail.id} alt={label} />}
-          {["Video", "Sound"].includes(type) && (
-            <Duration>{convertTime(canvas.duration as number)}</Duration>
-          )}
+
+          <Type>
+            <Tag isIcon>
+              <Spacer />
+              <Icon aria-label={type}>
+                <IconPath type={type} />
+              </Icon>
+              {["Video", "Sound"].includes(type) && (
+                <Duration>{convertTime(canvas.duration as number)}</Duration>
+              )}
+            </Tag>
+          </Type>
         </div>
         <figcaption>{label}</figcaption>
       </figure>


### PR DESCRIPTION
### Description
This pull request adds work/resource type icons to the media thumbnails for Audio (Sound), Image, and Video. To implement, I merged it with the previously existing `<Duration/>` component. Now all canvas types will have some sort of `<Type>`  with an embedded `<Icon>` (from `@nulib/design-system`), and Audio/Video works will show duration as a label.

![image](https://user-images.githubusercontent.com/7376450/144669921-4a26ba9b-6435-4ee5-b74d-418f510da86b.png)

- Add resource type icons to Media thumbnails.
- Add in some transparency.
- Add IconPath and switch statement.
