### PR TITLE
Hardcode boxSizing for open seadragon controls.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,10 @@
         background: #fff;
       }
 
+      button * {
+        box-sizing: border-box;
+      }
+
       header {
         background-color: #4e2a84;
       }

--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -16,6 +16,7 @@ const Item = styled("button", {
   backgroundColor: "#000D",
   filter: "drop-shadow(5px 5px 5px #0006)",
   transition: "$all",
+  boxSizing: "content-box",
 
   svg: {
     height: "70%",
@@ -25,6 +26,7 @@ const Item = styled("button", {
     stroke: "$secondary",
     filter: "drop-shadow(5px 5px 5px #000D)",
     transition: "$all",
+    boxSizing: "inherit",
   },
 
   "&:hover, &:focus": {


### PR DESCRIPTION
### Description

This fixes a minor issue related to box-sizing of the OpenSeadragon image viewer controls when the RMP component is embedded into a consuming app. RMP now hardcodes this value to avoid any issues with distortion of svgs embedded within a `<button>` element.

#### Before
![image](https://user-images.githubusercontent.com/7376450/144673777-3ac25089-c2f5-46ed-99d2-848640251751.png)

#### After
![image](https://user-images.githubusercontent.com/7376450/144673845-3bb005e7-2220-4cc5-8722-49d284c0a400.png)
