### PR TITLE
Make content-box even more explicit.

### DIFF
--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -16,7 +16,7 @@ const Item = styled("button", {
   backgroundColor: "#000D",
   filter: "drop-shadow(5px 5px 5px #0006)",
   transition: "$all",
-  boxSizing: "content-box",
+  boxSizing: "content-box !important",
 
   svg: {
     height: "70%",


### PR DESCRIPTION
## Description

This is a quick fix that adds an `!important` to ensure box-sizing attribute is set to `content-box` on button icons in the OpenSeadgraon control. 