### PR TITLE
Baseline responsiveness.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
         "@nulib/design-system": "^1.3.5",
+        "@radix-ui/react-collapsible": "^0.1.1",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
@@ -1191,6 +1192,25 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.1.tgz",
+      "integrity": "sha512-GIiCo8wYz53ZZEbp4LOkSysK8B+gZSi8/X/5NotBvyZpKntnf93i+NXPmtPPr+l0uPBr4EnEG1aZnItnrJpSEQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-id": "0.1.1",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
@@ -10546,6 +10566,22 @@
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "0.1.1"
+      }
+    },
+    "@radix-ui/react-collapsible": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.1.tgz",
+      "integrity": "sha512-GIiCo8wYz53ZZEbp4LOkSysK8B+gZSi8/X/5NotBvyZpKntnf93i+NXPmtPPr+l0uPBr4EnEG1aZnItnrJpSEQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-id": "0.1.1",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
       }
     },
     "@radix-ui/react-collection": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@hyperion-framework/validator": "^1.0.0",
     "@hyperion-framework/vault": "^1.0.2",
     "@nulib/design-system": "^1.3.5",
+    "@radix-ui/react-collapsible": "^0.1.1",
     "@radix-ui/react-radio-group": "^0.1.1",
     "@radix-ui/react-tabs": "^0.1.1",
     "@stitches/react": "^1.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,12 @@
         background-color: #4e2a84;
       }
 
+      p {
+        padding: 1rem;
+        font-size: 1rem;
+        line-height: 1.55em;
+      }
+
       @font-face {
         font-family: "Akkurat Pro Regular";
         src: url("https://common.northwestern.edu/v8/css/fonts/AkkuratProRegular.woff")

--- a/src/components/ImageViewer/ImageViewer.styled.tsx
+++ b/src/components/ImageViewer/ImageViewer.styled.tsx
@@ -1,4 +1,4 @@
-import { styled } from "@stitches/react";
+import { styled } from "stitches";
 
 const Navigator = styled("div", {
   position: "absolute !important",
@@ -9,10 +9,16 @@ const Navigator = styled("div", {
   height: "100px",
   backgroundColor: "#000D",
   boxShadow: "5px 5px 5px #0002",
+  borderRadius: "3px",
 
   "#openseadragon-navigator-displayregion": {
     border: " 3px solid $accent !important",
     boxShadow: "0 0 3px #0006",
+  },
+
+  "@sm": {
+    width: "123px",
+    height: "76px",
   },
 });
 
@@ -30,6 +36,8 @@ const Wrapper = styled("div", {
   backgroundSize: "contain",
   color: "white",
   position: "relative",
+  zIndex: "1",
+  overflow: "hidden",
 });
 
 export { Navigator, Viewport, Wrapper };

--- a/src/components/ImageViewer/ImageViewer.tsx
+++ b/src/components/ImageViewer/ImageViewer.tsx
@@ -7,18 +7,9 @@ import {
 import { Navigator, Viewport, Wrapper } from "./ImageViewer.styled";
 import Controls from "./Controls";
 
-const ImageViewer: React.FC<IIIFExternalWebResource> = ({
-  height,
-  service,
-  width,
-}) => {
+const ImageViewer: React.FC<IIIFExternalWebResource> = ({ service }) => {
   const [openSeadragonInstance, setOpenSeadragonInstance] = useState<Viewer>();
   const [imageService, setImageService] = useState<ImageService>();
-
-  let navigatorWidth = 100;
-
-  if (width && height)
-    navigatorWidth = ((width as number) / (height as number)) * 100;
 
   /**
    * Initiate OpenSeadragon
@@ -75,10 +66,7 @@ const ImageViewer: React.FC<IIIFExternalWebResource> = ({
   return (
     <Wrapper data-testid="image-viewer">
       <Controls />
-      <Navigator
-        id="openseadragon-navigator"
-        style={{ width: navigatorWidth }}
-      />
+      <Navigator id="openseadragon-navigator" />
       <Viewport id="openseadragon-viewport" />
     </Wrapper>
   );

--- a/src/components/Media/Media.styled.tsx
+++ b/src/components/Media/Media.styled.tsx
@@ -1,5 +1,5 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
-import { styled } from "@stitches/react";
+import { styled } from "stitches";
 
 const Group = styled(RadioGroup.Root, {
   display: "flex",
@@ -7,6 +7,10 @@ const Group = styled(RadioGroup.Root, {
   flexGrow: "1",
   padding: "1.618rem 0.618rem 1.618rem 0 ",
   overflowX: "scroll",
+
+  "@sm": {
+    padding: "1rem",
+  },
 });
 
 export { Group };

--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -31,19 +31,35 @@ const Item = styled(RadioGroup.Item, {
   fontSize: "1rem",
   textAlign: "left",
 
+  "@sm": {
+    margin: "0 1rem 0 0",
+
+    "&:last-child": {
+      marginRight: "0",
+    },
+  },
+
   figure: {
     margin: "0",
-    width: "199px",
+    width: "161.8px",
+
+    "@sm": {
+      width: "123px",
+    },
 
     "> div": {
       position: "relative",
       display: "flex",
       backgroundColor: "$secondaryAlt",
-      width: "199px",
-      height: "123px",
+      width: "inherit",
+      height: "100px",
       overflow: "hidden",
       borderRadius: "3px",
       transition: "$all",
+
+      "@sm": {
+        height: "76px",
+      },
 
       img: {
         width: "100%",
@@ -60,6 +76,11 @@ const Item = styled(RadioGroup.Item, {
         right: "0.5rem",
         bottom: "0.5rem",
 
+        "@sm": {
+          right: "0",
+          bottom: "0",
+        },
+
         [`& ${Tag}`]: {
           margin: "0",
           paddingLeft: "0",
@@ -67,6 +88,11 @@ const Item = styled(RadioGroup.Item, {
           backgroundColor: "#000d",
           color: "$secondary",
           fill: "$secondary",
+
+          "@sm": {
+            borderBottomLeftRadius: "0",
+            borderTopRightRadius: "0",
+          },
         },
       },
     },
@@ -76,6 +102,10 @@ const Item = styled(RadioGroup.Item, {
       color: "$primaryMuted",
       fontSize: "1rem",
       fontWeight: "400",
+
+      "@sm": {
+        fontSize: "0.8333rem",
+      },
     },
   },
 
@@ -99,6 +129,10 @@ const Item = styled(RadioGroup.Item, {
           flexDirection: "column",
           justifyContent: "center",
           textAlign: "center",
+
+          "@sm": {
+            fontSize: "0.6111rem",
+          },
         },
 
         img: {

--- a/src/components/Navigator/Cue.styled.tsx
+++ b/src/components/Navigator/Cue.styled.tsx
@@ -6,7 +6,11 @@ const spin = keyframes({
   to: { transform: "rotate(0deg)" },
 });
 
-export const Group = styled(RadioGroup.Root, {});
+export const Group = styled(RadioGroup.Root, {
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+});
 
 export const Item = styled(RadioGroup.Item, {
   position: "relative",
@@ -17,13 +21,18 @@ export const Item = styled(RadioGroup.Item, {
   justifyContent: "space-between",
   textAlign: "left",
   margin: "0",
-  padding: "0.55rem 1.618rem 0.45rem",
+  padding: "0.5rem 1.618rem",
   fontFamily: "inherit",
   lineHeight: "1.25em",
   fontSize: "1rem",
   color: "$primaryMuted",
   border: "none",
   background: "none",
+
+  "@sm": {
+    padding: "0.5rem 1rem",
+    fontSize: "0.8333rem",
+  },
 
   "&::before": {
     content: "",
@@ -34,8 +43,12 @@ export const Item = styled(RadioGroup.Item, {
     backgroundColor: "$primaryMuted",
     opacity: "0",
     left: "8px",
-    marginTop: "5px",
+    marginTop: "3px",
     boxSizing: "content-box",
+
+    "@sm": {
+      content: "unset",
+    },
   },
 
   "&::after": {
@@ -47,8 +60,12 @@ export const Item = styled(RadioGroup.Item, {
     opacity: "0",
     clipPath: "polygon(100% 50%, 0 100%, 0 0)",
     left: "13px",
-    marginTop: "8px",
+    marginTop: "6px",
     boxSizing: "content-box",
+
+    "@sm": {
+      content: "unset",
+    },
   },
 
   strong: {
@@ -92,6 +109,10 @@ export const Item = styled(RadioGroup.Item, {
       animation: "1s linear infinite",
       animationName: spin,
       boxSizing: "content-box",
+
+      "@sm": {
+        content: "unset",
+      },
     },
 
     "&::after": {
@@ -109,6 +130,10 @@ export const Item = styled(RadioGroup.Item, {
       animation: "1.5s linear infinite",
       animationName: spin,
       boxSizing: "content-box",
+
+      "@sm": {
+        content: "unset",
+      },
     },
   },
 

--- a/src/components/Navigator/Navigator.styled.tsx
+++ b/src/components/Navigator/Navigator.styled.tsx
@@ -12,6 +12,11 @@ const Wrapper = styled(Tabs.Root, {
   zIndex: "1",
   boxShadow: "-5px -5px 5px #00000011",
 
+  "@sm": {
+    marginTop: "0.5rem",
+    boxShadow: "none",
+  },
+
   "&:after": {
     position: "absolute",
     bottom: 0,
@@ -20,21 +25,29 @@ const Wrapper = styled(Tabs.Root, {
     height: "1rem",
     backgroundImage: `linear-gradient(0deg, #FFFFFF 0%, #FFFFFF00 100%)`,
     zIndex: 1,
+
+    "@sm": {
+      backgroundImage: "none",
+    },
   },
 });
 
 const List = styled(Tabs.List, {
   display: "flex",
   flexGrow: "0",
-  margin: "0 1.618rem 0",
+  margin: "0 1.618rem",
   borderBottom: "4px solid $secondaryAlt",
   backgroundColor: "$secondary",
+
+  "@sm": {
+    margin: "0 1rem",
+  },
 });
 
 const Trigger = styled(Tabs.Trigger, {
   display: "flex",
   position: "relative",
-  padding: "0.6rem 1rem 0.5rem",
+  padding: "0.5rem 1rem",
   background: "none",
   backgroundColor: "transparent",
   color: "$primaryMuted",

--- a/src/components/Player/Player.styled.tsx
+++ b/src/components/Player/Player.styled.tsx
@@ -7,6 +7,7 @@ export const PlayerWrapper = styled("div", {
   flexGrow: "0",
   flexShrink: "1",
   maxHeight: "450px",
+  zIndex: "1",
 
   video: {
     backgroundColor: "transparent",

--- a/src/components/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer.styled.tsx
@@ -1,19 +1,19 @@
 import { styled } from "stitches";
+import * as Collapsible from "@radix-ui/react-collapsible";
 
-const ViewerWrapper = styled("section", {
-  display: "flex",
-  flexDirection: "column",
-  padding: "1.618rem",
-  fontFamily: "$sans",
-  backgroundColor: "$secondary",
-  fontSmooth: "auto",
-  webkitFontSmoothing: "antialiased",
+const MediaWrapper = styled("div", {
+  position: "relative",
+  zIndex: "0",
 });
 
 const ViewerInner = styled("div", {
   display: "flex",
   flexDirection: "row",
   overflow: "hidden",
+
+  "@sm": {
+    flexDirection: "column",
+  },
 });
 
 const Main = styled("div", {
@@ -22,6 +22,41 @@ const Main = styled("div", {
   flexGrow: "1",
   flexShrink: "1",
   width: "61.8%",
+
+  "@sm": {
+    width: "100%",
+  },
+});
+
+const CollapsibleTrigger = styled(Collapsible.Trigger, {
+  display: "none",
+  background: "transparent",
+  border: "none",
+  margin: "0",
+  padding: "0",
+  transition: "$all",
+  opacity: "1",
+  marginTop: "0",
+
+  "&[data-navigator='false']": {
+    opacity: "0",
+    marginTop: "-59px",
+  },
+
+  "@sm": {
+    display: "flex",
+
+    "> *": {
+      display: "flex",
+      flexGrow: "1",
+      margin: "1rem 1rem 0",
+    },
+  },
+});
+
+const CollapsibleContent = styled(Collapsible.Content, {
+  width: "100%",
+  display: "flex",
 });
 
 const Aside = styled("aside", {
@@ -29,6 +64,10 @@ const Aside = styled("aside", {
   flexGrow: "1",
   flexShrink: "0",
   width: "38.2%",
+
+  "@sm": {
+    width: "100%",
+  },
 });
 
 const Header = styled("header", {
@@ -40,7 +79,70 @@ const Header = styled("header", {
     fontWeight: "700",
     padding: "0 0 1rem",
     fontFamily: "$display",
+
+    "@sm": {
+      padding: "1rem",
+      fontSize: "1rem",
+    },
   },
 });
 
-export { ViewerWrapper, ViewerInner, Main, Aside, Header };
+const ViewerWrapper = styled("section", {
+  display: "flex",
+  flexDirection: "column",
+  padding: "1.618rem",
+  fontFamily: "$sans",
+  backgroundColor: "$secondary",
+  fontSmooth: "auto",
+  webkitFontSmoothing: "antialiased",
+
+  "> div": {
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: "1",
+    justifyContent: "flex-start",
+
+    "@sm": {
+      [`& ${ViewerInner}`]: {
+        flexGrow: "1",
+      },
+
+      [`& ${Main}`]: {
+        flexGrow: "0",
+      },
+    },
+  },
+
+  "@sm": {
+    padding: "0",
+  },
+
+  "&[data-navigator-open='true']": {
+    "@sm": {
+      position: "fixed",
+      height: "100%",
+      width: "100%",
+      top: "0",
+      left: "0",
+
+      [`& ${MediaWrapper}`]: {
+        display: "none",
+      },
+
+      [`& ${CollapsibleContent}`]: {
+        height: "100%",
+      },
+    },
+  },
+});
+
+export {
+  ViewerWrapper,
+  ViewerInner,
+  Main,
+  MediaWrapper,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Aside,
+  Header,
+};

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   ExternalResourceTypes,
   IIIFExternalWebResource,
@@ -19,9 +19,18 @@ import {
   ViewerWrapper,
   ViewerInner,
   Main,
+  CollapsibleTrigger,
+  CollapsibleContent,
+  MediaWrapper,
   Header,
   Aside,
 } from "./Viewer.styled";
+import { Button } from "@nulib/design-system";
+import { useMediaQuery } from "hooks/useMediaQuery";
+import { useBodyLocked } from "hooks/useBodyLocked";
+import { media } from "stitches";
+import { LabeledResource } from "hooks/use-hyperion-framework/getSupplementingResources";
+import * as Collapsible from "@radix-ui/react-collapsible";
 
 interface ViewerProps {
   manifest: ManifestNormalized;
@@ -29,20 +38,45 @@ interface ViewerProps {
 }
 
 const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
-  // Get Context state
+  // context state
   const viewerState: any = useViewerState();
   const { activeCanvas, configOptions, vault } = viewerState;
 
-  // Track some local state
-  const [painting, setPainting] = React.useState<
-    IIIFExternalWebResource | undefined
-  >(undefined);
-  const [isMedia, setIsMedia] = React.useState(false);
-  const [currentTime, setCurrentTime] = React.useState<number>(0);
+  // local state
+  const [painting, setPainting] = useState<IIIFExternalWebResource | undefined>(
+    undefined,
+  );
+  const [resources, setResources] = useState<LabeledResource[]>([]);
+  const [isMedia, setIsMedia] = useState(false);
+  const [currentTime, setCurrentTime] = useState<number>(0);
+  const [isNavigator, setIsNavigator] = useState<boolean>(false);
+  const [isNavigatorOpen, setIsNavigatorOpen] = useState<boolean>(true);
+  const [isBodyLocked, setIsBodyLocked] = useBodyLocked(false);
+  const isSmallViewport = useMediaQuery(media.sm);
 
-  // Runs every time a new viewer item is clicked
-  React.useEffect(() => {
+  useEffect(() => {
+    if (!isSmallViewport) {
+      setIsNavigatorOpen(true);
+      return;
+    }
+    setIsNavigatorOpen(false);
+  }, [isSmallViewport]);
+
+  useEffect(() => {
+    if (!isSmallViewport) {
+      setIsBodyLocked(false);
+      return;
+    }
+    setIsBodyLocked(isNavigatorOpen);
+  }, [isNavigatorOpen]);
+
+  useEffect(() => {
     const painting = getPaintingResource(vault, activeCanvas);
+    const resources = getSupplementingResources(
+      vault,
+      activeCanvas,
+      "text/vtt",
+    );
     if (painting) {
       setIsMedia(
         ["Sound", "Video"].indexOf(painting.type as ExternalResourceTypes) > -1
@@ -51,45 +85,62 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
       );
       setPainting({ ...painting });
     }
+    setResources(resources);
+    setIsNavigator(resources.length !== 0);
   }, [activeCanvas]);
 
-  const resources = getSupplementingResources(vault, activeCanvas, "text/vtt");
-
-  const handleCurrentTime = (t: number) => {
-    setCurrentTime(t);
-  };
+  const handleCurrentTime = (t: number) => setCurrentTime(t);
 
   return (
-    <ViewerWrapper className={theme}>
-      {configOptions.showTitle && (
-        <Header>
-          <span>{getLabel(manifest.label as InternationalString, "en")}</span>
-        </Header>
-      )}
-      <ViewerInner>
-        <Main>
-          {isMedia ? (
-            <Player
-              painting={painting as IIIFExternalWebResource}
-              resources={resources}
-              currentTime={handleCurrentTime}
-            />
-          ) : (
-            <ImageViewer {...(painting as IIIFExternalWebResource)} />
-          )}
-          <Media items={manifest.items} activeItem={0} />
-        </Main>
-        {resources.length > 0 && (
-          <Aside>
-            <Navigator
-              activeCanvas={activeCanvas}
-              currentTime={currentTime}
-              defaultResource={resources[0].id as string}
-              resources={resources}
-            />
-          </Aside>
+    <ViewerWrapper
+      className={theme}
+      data-body-locked={isBodyLocked}
+      data-navigator={isNavigator}
+      data-navigator-open={isNavigatorOpen}
+    >
+      <Collapsible.Root
+        open={isNavigatorOpen}
+        onOpenChange={setIsNavigatorOpen}
+      >
+        {configOptions.showTitle && (
+          <Header>
+            <span>{getLabel(manifest.label as InternationalString, "en")}</span>
+          </Header>
         )}
-      </ViewerInner>
+        <ViewerInner>
+          <Main>
+            {isMedia ? (
+              <Player
+                painting={painting as IIIFExternalWebResource}
+                resources={resources}
+                currentTime={handleCurrentTime}
+              />
+            ) : (
+              <ImageViewer {...(painting as IIIFExternalWebResource)} />
+            )}
+            <CollapsibleTrigger data-navigator={isNavigator}>
+              <Button as="span">
+                {isNavigatorOpen ? "View Media Items" : "View Navigator"}
+              </Button>
+            </CollapsibleTrigger>
+            <MediaWrapper>
+              <Media items={manifest.items} activeItem={0} />
+            </MediaWrapper>
+          </Main>
+          {isNavigator && (
+            <Aside>
+              <CollapsibleContent>
+                <Navigator
+                  activeCanvas={activeCanvas}
+                  currentTime={currentTime}
+                  defaultResource={resources[0].id as string}
+                  resources={resources}
+                />
+              </CollapsibleContent>
+            </Aside>
+          )}
+        </ViewerInner>
+      </Collapsible.Root>
     </ViewerWrapper>
   );
 };

--- a/src/hooks/useBodyLocked.ts
+++ b/src/hooks/useBodyLocked.ts
@@ -1,0 +1,29 @@
+import { useEffect, useLayoutEffect, useState } from "react";
+
+type ReturnType = [boolean, (locked: boolean) => void];
+
+export const useBodyLocked = (initialLocked = false): ReturnType => {
+  const [locked, setLocked] = useState(initialLocked);
+
+  useLayoutEffect(() => {
+    if (!locked) {
+      return;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [locked]);
+
+  useEffect(() => {
+    if (locked !== initialLocked) {
+      setLocked(initialLocked);
+    }
+  }, [initialLocked]);
+
+  return [locked, setLocked];
+};

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export const useMediaQuery = (mediaQuery: string) => {
+  const match = () => {
+    if (!window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia(mediaQuery).matches;
+  };
+
+  const [isMatch, setIsMatch] = useState<boolean>(match);
+
+  useEffect(() => {
+    const handler = () => setIsMatch(match);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  });
+
+  return isMatch;
+};

--- a/src/stitches.tsx
+++ b/src/stitches.tsx
@@ -31,10 +31,20 @@ export const theme = {
     display: "Campton, 'Akkurat Pro Regular', Arial, sans-serif",
   },
   transitions: {
-    all: "all 200ms ease-in-out",
+    all: "all 500ms cubic-bezier(0.16, 1, 0.3, 1)",
   },
+};
+
+export const media = {
+  xxs: "(max-width: 349px)",
+  xs: "(max-width: 575px)",
+  sm: "(max-width: 767px)",
+  md: "(max-width: 991px)",
+  xl: "(max-width: 1199px)",
+  lg: "(min-width: 1200px)",
 };
 
 export const { styled, css, keyframes, createTheme } = createStitches({
   theme,
+  media,
 });


### PR DESCRIPTION
### Description

The work included here adds baseline responsive behavior to the project. Most of this is based around a specific breakpoint of `sm` defined in the stitches configuration file. When this breakpoint is reached and true, the navigator (if present) collapse under the Player and Media elements. 

By default the navigator will not be displayed, however, toggle with the title **View Navigator** will be shown to the user on canvases where the Navigator is available. When expanded, the player goes into a emulated modal state where navigator contents are shown and scrollable. This behavior exists to limit the possibility of multiple scrollbars. When the user clicks **Media Items**, scrolling functionality on the consuming page is present once again.

![image](https://user-images.githubusercontent.com/7376450/145402922-8e650195-d279-45d7-abd7-c2e04607a4c2.png)

![image](https://user-images.githubusercontent.com/7376450/145403032-00966a88-1223-4edf-9db6-189d5a2f2533.png)

### Notes
Included as well are various touchups to refine font-sizing project wide and thumbnail sizing in the media tray at the `sm` viewport. This project now directly imports the Radix UI element **Collapsible**. Our use of it for the navigator toggle functionality is rather boutique and I don't image that we'd want to leverage a potential design-system version of this.

