### PR TITLE
Responsive bug fixes.

### DIFF
--- a/src/components/Navigator/Cue.styled.tsx
+++ b/src/components/Navigator/Cue.styled.tsx
@@ -17,7 +17,6 @@ export const Item = styled(RadioGroup.Item, {
   cursor: "pointer",
   display: "flex",
   width: "100%",
-  flexGrow: "1",
   justifyContent: "space-between",
   textAlign: "left",
   margin: "0",

--- a/src/components/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer.styled.tsx
@@ -46,7 +46,7 @@ const CollapsibleTrigger = styled(Collapsible.Trigger, {
   "@sm": {
     display: "flex",
 
-    "> *": {
+    "> span": {
       display: "flex",
       flexGrow: "1",
       margin: "1rem 1rem 0",
@@ -124,6 +124,7 @@ const ViewerWrapper = styled("section", {
       width: "100%",
       top: "0",
       left: "0",
+      zIndex: "2500000000",
 
       [`& ${MediaWrapper}`]: {
         display: "none",

--- a/src/hooks/useBodyLocked.ts
+++ b/src/hooks/useBodyLocked.ts
@@ -10,12 +10,12 @@ export const useBodyLocked = (initialLocked = false): ReturnType => {
       return;
     }
 
-    const originalOverflow = document.body.style.overflow;
+    const originalOverflow = document.documentElement.style.overflow;
 
-    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
 
     return () => {
-      document.body.style.overflow = originalOverflow;
+      document.documentElement.style.overflow = originalOverflow;
     };
   }, [locked]);
 


### PR DESCRIPTION
This fixes a few small issues that I uncovered after importing v.1.6.0 into the Meadow and Digital Collections. Completing these should make the next patched version ready for deploy/staging on both applications.

**- Fix zIndex issue** - Present in both Meadow and DC where the expanded navigator on small viewports did not layer above relative or absolute content elsewhere on the page. This is set to an extreme value to ensure it lives over Radix UI portalled content.
- Fix cue flex-grow - Occurred when VTT cues did not extend beyond the vertical space. 
- Fix overflow bug - The body.overflow selector was not specific enough for Meadow or DC so moved this up a level to the HTML element.
- Fix button span child selector - This is a fix to make things a bit more explicit when targeting the span encased on a `<Button>` component.

Happy to walk through this if we have questions.
