### PR TITLE
Fixes import of node-webvtt package, ignores ts scream.

### DIFF
--- a/src/components/Navigator/Resource.tsx
+++ b/src/components/Navigator/Resource.tsx
@@ -4,7 +4,8 @@ import { getLabel } from "hooks/use-hyperion-framework";
 import { InternationalString } from "@hyperion-framework/types";
 import { Group } from "./Cue.styled";
 
-const webvtt = require("node-webvtt");
+// @ts-ignore
+import { parse } from "node-webvtt";
 
 interface Resource {
   currentTime: number;
@@ -31,7 +32,7 @@ const Resource: React.FC<Resource> = ({ currentTime, resource }) => {
     })
       .then((response) => response.text())
       .then((data) => {
-        setCues(webvtt.parse(data).cues as unknown as Array<Cue>);
+        setCues(parse(data).cues as unknown as Array<Cue>);
       })
       .catch((error) => console.error(id, error.toString()));
   }, [id]);


### PR DESCRIPTION
### Description
CodeSandbox was giving an ugly error due to how we were requiring the node-webvtt package. To fix, we are now importing `parse` from the package and including a `// @ts-ignore` to tone down the typescript screaming.

![image](https://user-images.githubusercontent.com/7376450/146429792-d744fe48-83f0-4f7f-ac7d-72def2d7ea5e.png)

### How to test
Things should run just as before locally, and the compiled build should be compatible with CodeSandbox.