### PR TITLE
Request tilesource from iiif service.

### DIFF
--- a/src/components/ImageViewer/ImageViewer.tsx
+++ b/src/components/ImageViewer/ImageViewer.tsx
@@ -6,6 +6,7 @@ import {
 } from "@hyperion-framework/types";
 import { Navigator, Viewport, Wrapper } from "./ImageViewer.styled";
 import Controls from "./Controls";
+import { getInfoResponse } from "services/iiif";
 
 const ImageViewer: React.FC<IIIFExternalWebResource> = ({ service }) => {
   const [openSeadragonInstance, setOpenSeadragonInstance] = useState<Viewer>();
@@ -33,7 +34,11 @@ const ImageViewer: React.FC<IIIFExternalWebResource> = ({ service }) => {
    * Loads tileSource of current canvas from IIIF image service
    */
   useEffect(() => {
-    if (imageService) openSeadragonInstance?.open(imageService.id);
+    if (imageService) {
+      getInfoResponse(imageService.id).then((tileSource) =>
+        openSeadragonInstance?.open(tileSource),
+      );
+    }
   }, [openSeadragonInstance, imageService]);
 
   /**

--- a/src/services/iiif.ts
+++ b/src/services/iiif.ts
@@ -1,0 +1,12 @@
+export const getInfoResponse = (id: string) =>
+  fetch(`${id.replace(/\/$/, "")}/info.json`)
+    .then((response) => response.json())
+    .then((json) => json)
+    .catch((error: any) => {
+      console.error(
+        `The IIIF tilesource ${id.replace(
+          /\/$/,
+          "",
+        )}/info.json failed to load: ${error}`,
+      );
+    });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/148413596-10446d02-2170-4cb6-93b8-b3a75fe53624.png)

## What does this do?
This pull request resolves and issue where some IIIF Image Services do not redirect to the info.json and thus do not hand off the tilesource json if the image service ID is directly handed to OpenSeadragon. This PR includes code that will request the rewrite the image service ID URI using regex (appending info.json) and then request the tilesource json first, then hand that promised json to OSD. If this fails to resolve, then a console error is displayed. This is similar logic to how Mirador seems to handle this issue.

## How do we review?
This PR includes a sample National Library of Scotland manifest that was previously failing to load in OpenSeadragon. It should now display as expected. 