### PR TITLE
Add ability to search/filter canvases by label.

### DIFF
--- a/src/components/ImageViewer/Button.styled.tsx
+++ b/src/components/ImageViewer/Button.styled.tsx
@@ -19,9 +19,9 @@ const Item = styled("button", {
   boxSizing: "content-box !important",
 
   svg: {
-    height: "70%",
-    width: "70%",
-    padding: "15%",
+    height: "60%",
+    width: "60%",
+    padding: "20%",
     fill: "$secondary",
     stroke: "$secondary",
     filter: "drop-shadow(5px 5px 5px #000D)",

--- a/src/components/Media/Filter.styled.tsx
+++ b/src/components/Media/Filter.styled.tsx
@@ -1,0 +1,87 @@
+import { styled } from "stitches";
+
+const Form = styled("div", {
+  position: "absolute",
+  right: "1rem",
+  top: "1rem",
+  display: "flex",
+  justifyContent: "flex-end",
+});
+
+const Input = styled("input", {
+  flexGrow: "1",
+  border: "none",
+  outline: "none",
+  backgroundColor: "$secondaryMuted",
+  color: "$primary",
+  marginRight: "1rem",
+  height: "2rem",
+  padding: "0 1rem",
+  borderRadius: "2rem",
+  fontFamily: "$sans",
+  fontSize: "1rem",
+  lineHeight: "1rem",
+  boxShadow: "inset 1px 1px 2px #0003",
+
+  "&::placeholder": {
+    color: "$primaryMuted",
+  },
+});
+
+const Toggle = styled("button", {
+  display: "flex",
+  background: "none",
+  border: "none",
+  width: "2rem !important",
+  height: "2rem !important",
+  padding: "0",
+  margin: "0",
+  fontWeight: "700",
+  borderRadius: "50%",
+  backgroundColor: "$accent",
+  color: "$secondary",
+  boxShadow: "5px 5px 5px #0003",
+  cursor: "pointer",
+  boxSizing: "content-box !important",
+
+  svg: {
+    height: "60%",
+    width: "60%",
+    padding: "20%",
+    fill: "$secondary",
+    stroke: "$secondary",
+    filter: "drop-shadow(5px 5px 5px #000D)",
+    boxSizing: "inherit",
+  },
+});
+
+const Wrapper = styled("div", {
+  display: "flex",
+  position: "relative",
+  zIndex: "1",
+  width: "100%",
+  padding: "0",
+  transition: "$all",
+
+  variants: {
+    isToggle: {
+      true: {
+        paddingTop: "2.618rem",
+
+        [`& ${Form}`]: {
+          width: "calc(100% - 1rem)",
+
+          "@sm": {
+            width: "calc(100% - 2rem)",
+          },
+        },
+
+        [`& ${Toggle}`]: {
+          backgroundColor: "$primaryMuted",
+        },
+      },
+    },
+  },
+});
+
+export { Form, Input, Toggle, Wrapper };

--- a/src/components/Media/Filter.tsx
+++ b/src/components/Media/Filter.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { Form, Input, Toggle, Wrapper } from "./Filter.styled";
+import useKeyPress from "hooks/useKeyPress";
+
+interface Props {
+  handleFilter: (arg0: String) => void;
+}
+
+const CloseIcon: React.FC = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+      <title>Close</title>
+      <path d="M289.94 256l95-95A24 24 0 00351 127l-95 95-95-95a24 24 0 00-34 34l95 95-95 95a24 24 0 1034 34l95-95 95 95a24 24 0 0034-34z" />
+    </svg>
+  );
+};
+
+const SearchIcon: React.FC = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+      <title>Search</title>
+      <path d="M456.69 421.39L362.6 327.3a173.81 173.81 0 0034.84-104.58C397.44 126.38 319.06 48 222.72 48S48 126.38 48 222.72s78.38 174.72 174.72 174.72A173.81 173.81 0 00327.3 362.6l94.09 94.09a25 25 0 0035.3-35.3zM97.92 222.72a124.8 124.8 0 11124.8 124.8 124.95 124.95 0 01-124.8-124.8z" />
+    </svg>
+  );
+};
+
+const Filter: React.FC<Props> = ({ handleFilter }) => {
+  const [toggleFilter, setToggleFilter] = useState<boolean>(false);
+
+  /**
+   * dismiss filtering if Escape key is pressed
+   */
+  useKeyPress("Escape", () => {
+    setToggleFilter(false);
+    handleFilter("");
+  });
+
+  /**
+   * reset filtering on manual toggle button press
+   */
+  const handleToggle = () => {
+    setToggleFilter((prevToggleFilter) => !prevToggleFilter);
+    handleFilter("");
+  };
+
+  /**
+   * handle value changes on Input
+   */
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    handleFilter(event.target.value);
+
+  return (
+    <Wrapper isToggle={toggleFilter}>
+      <Form>
+        {toggleFilter && (
+          <Input autoFocus onChange={handleChange} placeholder="Search" />
+        )}
+        <Toggle onClick={handleToggle} type="button">
+          {toggleFilter ? <CloseIcon /> : <SearchIcon />}
+        </Toggle>
+      </Form>
+    </Wrapper>
+  );
+};
+
+export default Filter;

--- a/src/components/Media/Thumbnail.styled.tsx
+++ b/src/components/Media/Thumbnail.styled.tsx
@@ -31,6 +31,10 @@ const Item = styled(RadioGroup.Item, {
   fontSize: "1rem",
   textAlign: "left",
 
+  "&:last-child": {
+    marginRight: "1rem",
+  },
+
   "@sm": {
     margin: "0 1rem 0 0",
 

--- a/src/hooks/use-hyperion-framework/getLabel.ts
+++ b/src/hooks/use-hyperion-framework/getLabel.ts
@@ -6,9 +6,9 @@ export const getLabel = (
   language: string = "en",
 ) => {
   /*
-   * If no label exists, return a hardcoded string.
+   * If no label exists, return an empty string.
    */
-  if (!label) return "Untitled";
+  if (!label) return "";
 
   /*
    * If InternationalString code does not exist on label, then

--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+/**
+ * useKeyPress
+ * @param {string} key - the name of the key to respond to, compared against event.key
+ * @param {function} action - the action to perform on key press
+ */
+const useKeyPress = (key, action) => {
+  useEffect(() => {
+    function onKeyup(e) {
+      if (e.key === key) action();
+    }
+    window.addEventListener("keyup", onKeyup);
+    return () => window.removeEventListener("keyup", onKeyup);
+  }, []);
+};
+
+export default useKeyPress;


### PR DESCRIPTION
## What does this do?
This introduces basic search/filter functionality to the Viewer, allowing as user to filter the string value of the canvas label. The search button toggles and auto-focuses an input for a user to input this value. Upon filtering, the media items in the `<Media />` component are filtered and mapped. A close button is rendered allowing the user to toggle this off. Upon closing, the filter value is reset. Hitting the `esc` "Escape" keyboard button will close filter input as well. 

## What this doesn't do.
This filtering is pretty basic and somewhat requires the manifest canvases to have label values useful the the user. This does not filter by index or canvas number, in cases where a user might expect typing "10" would take them to the 10th canvas, unless of course the label for that canvas contained "10" within it's value.

## How do we test this?
A manifest with ~30 canvases and long canvas labels is ready for testing on this branch.
1. Click **Search icon**
2. Type **asmara**
3. Items will filter
4. Try your own

## Future considerations
1. This is not debounced. For performance reasons in the future we may want to debounce at some time interval.
2. The SVG icons in the `<Filter />` component might want to be moved to a central location and handled in some uniform pattern with others in the viewer.