### PR TITLE
Wrap the Viewer in an Error Boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "node-webvtt": "^1.9.3",
         "openseadragon": "^2.4.2",
         "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react-dom": "^17.0.0",
+        "react-error-boundary": "^3.1.4"
       },
       "devDependencies": {
         "@testing-library/react": "^12.1.0",
@@ -7631,6 +7632,21 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {
@@ -15539,6 +15555,14 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "node-webvtt": "^1.9.3",
     "openseadragon": "^2.4.2",
     "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react-dom": "^17.0.0",
+    "react-error-boundary": "^3.1.4"
   },
   "files": [
     "dist"

--- a/src/components/Viewer/ErrorFallback.styled.tsx
+++ b/src/components/Viewer/ErrorFallback.styled.tsx
@@ -1,0 +1,19 @@
+import { styled } from "stitches";
+
+const ErrorFallbackStyled = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+});
+
+const Headline = styled("p", {
+  fontFamily: "$display",
+  fontWeight: "bold",
+  fontSize: "x-large",
+});
+
+const ErrorBody = styled("span", {
+  fontSize: "medium",
+});
+
+export { ErrorFallbackStyled, ErrorBody, Headline };

--- a/src/components/Viewer/ErrorFallback.test.tsx
+++ b/src/components/Viewer/ErrorFallback.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import ErrorFallback from "./ErrorFallback";
+import { render, screen } from "@testing-library/react";
+
+describe("ErrorFallback component", () => {
+  const mockErrorObj = {
+    name: "ERROR 123",
+    message: "This is the error message",
+  };
+
+  test("renders the component", () => {
+    render(<ErrorFallback error={mockErrorObj} />);
+    expect(screen.getByRole("alert"));
+  });
+
+  test("displays the error headline and error message", () => {
+    render(<ErrorFallback error={mockErrorObj} />);
+    expect(screen.getByTestId("headline"));
+    expect(screen.getByText(mockErrorObj.message, { exact: false }));
+  });
+});

--- a/src/components/Viewer/ErrorFallback.tsx
+++ b/src/components/Viewer/ErrorFallback.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import {
+  ErrorFallbackStyled,
+  ErrorBody,
+  Headline,
+} from "components/Viewer/ErrorFallback.styled";
+
+interface ErrorFallbackProps {
+  error: Error;
+}
+
+const ErrorFallback: React.FC<ErrorFallbackProps> = ({ error }) => {
+  const { message } = error;
+
+  return (
+    <ErrorFallbackStyled role="alert">
+      <Headline data-testid="headline">Something went wrong</Headline>
+      {message && <ErrorBody>{`Error message: ${message}`} </ErrorBody>}
+    </ErrorFallbackStyled>
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer.tsx
@@ -18,6 +18,8 @@ import ViewerHeader from "./Header";
 import ViewerContent from "./Content";
 import { LabeledResource } from "hooks/use-hyperion-framework/getSupplementingResources";
 import { IIIFExternalWebResource } from "@hyperion-framework/types";
+import ErrorFallback from "components/Viewer/ErrorFallback";
+import { ErrorBoundary } from "react-error-boundary";
 
 interface ViewerProps {
   manifest: ManifestNormalized;
@@ -84,32 +86,34 @@ const Viewer: React.FC<ViewerProps> = ({ manifest, theme }) => {
   }, [activeCanvas]);
 
   return (
-    <Wrapper
-      className={theme}
-      data-body-locked={isBodyLocked}
-      data-navigator={isNavigator}
-      data-navigator-open={isNavigatorOpen}
-    >
-      <Collapsible.Root
-        open={isNavigatorOpen}
-        onOpenChange={setIsNavigatorOpen}
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <Wrapper
+        className={theme}
+        data-body-locked={isBodyLocked}
+        data-navigator={isNavigator}
+        data-navigator-open={isNavigatorOpen}
       >
-        <ViewerHeader
-          manifestLabel={manifest.label as InternationalString}
-          manifestId={manifest.id}
-          options={configOptions}
-        />
-        <ViewerContent
-          activeCanvas={activeCanvas}
-          painting={painting as IIIFExternalWebResource}
-          resources={resources}
-          items={manifest.items}
-          isMedia={isMedia}
-          isNavigator={isNavigator}
-          isNavigatorOpen={isNavigatorOpen}
-        />
-      </Collapsible.Root>
-    </Wrapper>
+        <Collapsible.Root
+          open={isNavigatorOpen}
+          onOpenChange={setIsNavigatorOpen}
+        >
+          <ViewerHeader
+            manifestLabel={manifest.label as InternationalString}
+            manifestId={manifest.id}
+            options={configOptions}
+          />
+          <ViewerContent
+            activeCanvas={activeCanvas}
+            painting={painting as IIIFExternalWebResource}
+            resources={resources}
+            items={manifest.items}
+            isMedia={isMedia}
+            isNavigator={isNavigator}
+            isNavigatorOpen={isNavigatorOpen}
+          />
+        </Collapsible.Root>
+      </Wrapper>
+    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
This PR wraps the main Viewer in a React Error Boundary to prevent non-network related crashes of the app in the browser.   If there's a need in the future, we can wrap parts of the app in their own Error Boundaries (ie. Player, Media Tray, Navigator, etc.)

![image](https://user-images.githubusercontent.com/3020266/150001778-843f9780-18d3-4273-bf06-4dbae0b8f7e9.png)

### To Test:
In some child component, initiate a syntax error, or insert a `throw new Error("hey I just errored")`.  Notice the Error Boundary catches the error.

