### PR TITLE
Disable autoplay on initial canvas load.

### DIFF
--- a/public/fixtures/iiif/manifests/sample.json
+++ b/public/fixtures/iiif/manifests/sample.json
@@ -75,7 +75,7 @@
               "type": "Annotation",
               "motivation": "supplementing",
               "body": {
-                "id": "http://127.0.0.1:8080/fixtures/vtt/nested_chapters.vtt",
+                "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_en.vtt",
                 "type": "Text",
                 "format": "text/vtt",
                 "label": {
@@ -90,7 +90,7 @@
               "type": "Annotation",
               "motivation": "supplementing",
               "body": {
-                "id": "http://127.0.0.1:8080/fixtures/vtt/nested_chapters.vtt?garb=true",
+                "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_es.vtt",
                 "type": "Text",
                 "format": "text/vtt",
                 "label": {
@@ -250,7 +250,7 @@
               "type": "Annotation",
               "motivation": "supplementing",
               "body": {
-                "id": "http://127.0.0.1:8080/fixtures/vtt/nested_chapters.vtt",
+                "id": "https://raw.githubusercontent.com/mathewjordan/mirador-playground/main/assets/iiif/supplementing/new_airliner_en.vtt",
                 "type": "Text",
                 "format": "text/vtt",
                 "label": {

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -84,7 +84,8 @@ const Player: React.FC<PlayerProps> = ({ painting, resources }) => {
   React.useEffect(() => {
     let video: any = playerRef.current;
     if (video) video.currentTime = startTime;
-    video.play();
+
+    if (startTime !== 0) video.play();
   }, [startTime]);
 
   const handlePlay = () => {

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import App from "./index";
 
 let sampleManifest: string =
-  "https://iiif.stack.rdc.library.northwestern.edu/public/7c/16/60/e9/-e/a9/4-/4a/a4/-a/e4/e-/b7/a0/29/4b/e7/ee-manifest.json";
+  "http://127.0.0.1:8080/fixtures/iiif/manifests/sample.json";
 
 ReactDOM.render(
   <App manifestId={sampleManifest} />,


### PR DESCRIPTION
## Summary

This will disable autoplay for Sound and Video canvases on initial render. It does so by not running `play()` if **startTime** is _0_. It retains the ability to automatically play if a user clicks a cue in the navigator.