### PR TITLE
2710 create static site hosting

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DEV_URL=http://127.0.0.1:8080
+STATIC_URL=.

--- a/.github/workflows/gh-pages.deploy.yml
+++ b/.github/workflows/gh-pages.deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      NEXT_PUBLIC_BASE_PATH: /clover-iiif
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Get files
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install packages
+        run: npm ci
+      - name: Export static files
+        run: npm run build:static
+      - name: Add .nojekyll file
+        run: touch ./static/.nojekyll
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: static

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 node_modules
 public/script.js
 public/script.js.map
+static
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ This will build and package the component
 npm run build
 ```
 
+This will create a static version of the site to the `/static` directory
+
+```
+npm run build:static
+```
+
 #### Notes
 
 - ESBuild compiles TypeScript to JavaScript, but does not do type checking. To view type checking errors (in addtion to what your IDE will be complaining about), run:

--- a/build-static.js
+++ b/build-static.js
@@ -1,0 +1,41 @@
+const { build } = require("esbuild");
+const envFilePlugin = require("esbuild-envfile-plugin");
+const fs = require("fs-extra");
+
+const { OUT_DIR } = process.env;
+
+const filterFunc = (src, dest) => {
+  console.log("copying: ", src);
+  return !src.includes("script.js");
+};
+
+async function emptyDir() {
+  try {
+    await fs.emptyDir(OUT_DIR);
+    console.log("/static directory emptied");
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function copyFiles() {
+  try {
+    await fs.copy("public", OUT_DIR, { filter: filterFunc });
+    console.log("Success copying files");
+  } catch (err) {
+    console.error("Error copying files: ", err);
+  }
+}
+
+(async () => {
+  await emptyDir();
+  await copyFiles();
+
+  await build({
+    bundle: true,
+    entryPoints: ["src/dev.tsx"],
+    outfile: `${OUT_DIR}/script.js`,
+    plugins: [envFilePlugin],
+    sourcemap: true,
+  });
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,12 +38,15 @@
         "@typescript-eslint/eslint-plugin": "^4.31.2",
         "@typescript-eslint/parser": "^4.31.2",
         "chokidar": "^3.5.2",
+        "dotenv": "^16.0.0",
         "esbuild": "^0.12.28",
         "esbuild-css-modules-plugin": "^2.0.9",
+        "esbuild-envfile-plugin": "^1.0.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.26.0",
+        "fs-extra": "^10.0.1",
         "jest": "^27.2.1",
         "live-server": "^1.2.1",
         "prettier": "^2.4.1",
@@ -3576,6 +3579,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -3718,6 +3730,39 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/esbuild-css-modules-plugin/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/esbuild-envfile-plugin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/esbuild-envfile-plugin/-/esbuild-envfile-plugin-1.0.2.tgz",
+      "integrity": "sha512-eNjOpWQ4f+tYYgsKeZmK+cqsEZd/yEmD0pLxu7CmIx31wZ1B52iqwDdn5aPgRNvYvAuzEvzqlvz07iVHOr67Vw==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "10.0.0"
+      }
+    },
+    "node_modules/esbuild-envfile-plugin/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/escalade": {
@@ -4553,18 +4598,17 @@
       "dev": true
     },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -11717,7 +11761,8 @@
     "@stitches/react": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.6.tgz",
-      "integrity": "sha512-gRVITYj8W4jJmoiVxWDv72yCvd12VvtUUAnTzs07EqmtvGCVgKZu3Dx0x5KVCcb0b6tfgvvNH2L84YrzdM4Mag=="
+      "integrity": "sha512-gRVITYj8W4jJmoiVxWDv72yCvd12VvtUUAnTzs07EqmtvGCVgKZu3Dx0x5KVCcb0b6tfgvvNH2L84YrzdM4Mag==",
+      "requires": {}
     },
     "@testing-library/dom": {
       "version": "8.11.3",
@@ -12114,7 +12159,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -13038,6 +13084,12 @@
         }
       }
     },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -13149,6 +13201,37 @@
         "postcss": "^8.2.7",
         "postcss-modules": "^4.0.0",
         "tmp": "^0.2.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
+    "esbuild-envfile-plugin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/esbuild-envfile-plugin/-/esbuild-envfile-plugin-1.0.2.tgz",
+      "integrity": "sha512-eNjOpWQ4f+tYYgsKeZmK+cqsEZd/yEmD0pLxu7CmIx31wZ1B52iqwDdn5aPgRNvYvAuzEvzqlvz07iVHOr67Vw==",
+      "dev": true,
+      "requires": {
+        "dotenv": "10.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "dev": true
+        }
       }
     },
     "escalade": {
@@ -13319,7 +13402,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -13800,12 +13884,11 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
@@ -14144,7 +14227,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ignore": {
       "version": "5.2.0",
@@ -14920,7 +15004,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -16409,7 +16494,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -17916,7 +18002,8 @@
     "use-callback-ref": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
-      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.0.5",
@@ -18118,7 +18205,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "scripts": {
     "build": "npm run clean && node build.js && tsc --emitDeclarationOnly --outDir dist",
+    "build:static": "NODE_ENV=static OUT_DIR=static node build-static.js",
     "clean": "rimraf dist",
-    "dev": "node serve.js",
+    "dev": "NODE_ENV=development node serve.js",
     "test": "jest --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "ts-lint": "tsc --noEmit --incremental --watch"
   },
   "keywords": [
     "IIIF",
@@ -31,12 +33,15 @@
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.31.2",
     "chokidar": "^3.5.2",
+    "dotenv": "^16.0.0",
     "esbuild": "^0.12.28",
     "esbuild-css-modules-plugin": "^2.0.9",
+    "esbuild-envfile-plugin": "^1.0.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.0",
+    "fs-extra": "^10.0.1",
     "jest": "^27.2.1",
     "live-server": "^1.2.1",
     "prettier": "^2.4.1",

--- a/public/index.html
+++ b/public/index.html
@@ -73,6 +73,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="/script.js"></script>
+    <script src="./script.js"></script>
   </body>
 </html>

--- a/serve.js
+++ b/serve.js
@@ -6,6 +6,7 @@
 const { build } = require("esbuild");
 const chokidar = require("chokidar");
 const liveServer = require("live-server");
+const envFilePlugin = require("esbuild-envfile-plugin");
 
 (async () => {
   const builder = await build({
@@ -20,12 +21,11 @@ const liveServer = require("live-server");
     entryPoints: ["src/dev.tsx"],
     // Uses incremental compilation (see `chokidar.on`).
     incremental: true,
-    // Removes whitespace, etc. depending on `NODE_ENV=...`.
-    minify: process.env.NODE_ENV === "production",
     outfile: "public/script.js",
     sourcemap: true,
+    plugins: [envFilePlugin],
   });
-  // `chokidar` watcher source changes.
+
   chokidar
     // Watches TypeScript and React TypeScript.
     .watch("src/**/*.{ts,tsx}", {
@@ -35,7 +35,7 @@ const liveServer = require("live-server");
     .on("all", () => {
       builder.rebuild();
     });
-  // `liveServer` local server for hot reload.
+
   liveServer.start({
     // Opens the local server on start.
     open: true,

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -2,8 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./index";
 
-let sampleManifest: string =
-  "http://127.0.0.1:8080/fixtures/iiif/manifests/audio-accompanying-canvas.json";
+// NOTE: "env" is available via the DotEnv ES Build Plugin defined in serve.js
+import { NODE_ENV, DEV_URL, STATIC_URL } from "env";
+
+const host = NODE_ENV === "development" ? DEV_URL : STATIC_URL;
+let sampleManifest: string = `${host}/fixtures/iiif/manifests/sample.json`;
 
 const options: any = {
   ignoreCaptionLabels: ["Chapters"],


### PR DESCRIPTION
@mathewjordan I'll need to get this merged in before being able to test if it actually works or not.  So this PR comes in 2 parts:

1. You can now generate a static version of the site by running `npm run build:static`.  This will create a static version of the dev environment, so whatever IIIF manifest is being sent into the component, is what the static site will generate as well.
2. Start up a local server (ie. `npx serve`) and navigate to the `/static` directory to verify if serves ok for you.

### Static build notes
I had to manually wire this up, and what happens is it copies over all the files, except ESBuild's `script.js` bundled file, from `/public` to `/static`.  This currently is `/fixtures` and `index.html`.

Then ESBuild bundles the code, using a few environmental variables, and puts the `script.js` into the `/static` folder.

![image](https://user-images.githubusercontent.com/3020266/158249244-b6d607c5-8f1a-4682-8eda-ee291e248f38.png)


~~Next steps will be on merge to see if it triggers a build to the `gh-pages` branch.~~