### PR TITLE
Props no longer passed into ViewerHeader

### DIFF
--- a/src/components/Viewer/Viewer/Header.tsx
+++ b/src/components/Viewer/Viewer/Header.tsx
@@ -10,7 +10,7 @@ import { ViewerContextStore, useViewerState } from "src/context/viewer-context";
 import Collection from "src/components/Viewer/Collection/Collection";
 import CopyText from "src/components/Viewer/CopyText";
 import IIIFBadge from "src/components/Viewer/Viewer/IIIFBadge";
-import { InternationalString } from "@iiif/presentation-3";
+import { InternationalString, ManifestNormalized } from "@iiif/presentation-3";
 import { Label } from "src/components/Primitives";
 import { Popover } from "src/components/UI";
 import React from "react";
@@ -18,14 +18,13 @@ import Toggle from "./Toggle";
 import ViewerDownload from "./Download";
 import { useTranslation } from "react-i18next";
 
-interface Props {
-  manifestId: string;
-  manifestLabel: InternationalString;
-}
-
-const ViewerHeader: React.FC<Props> = ({ manifestId, manifestLabel }) => {
+const ViewerHeader: React.FC = () => {
   const viewerState: ViewerContextStore = useViewerState();
-  const { collection, configOptions } = viewerState;
+  const { collection, configOptions, activeManifest, vault } = viewerState;
+
+  const manifest: ManifestNormalized = vault.get(activeManifest),
+    manifestLabel = (manifest.label ?? "") as InternationalString,
+    manifestId = manifest.id;
 
   const { informationPanel, showDownload, showIIIFBadge, showTitle } =
     configOptions;

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -3,7 +3,6 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { AnnotationResource, AnnotationResources } from "src/types/annotations";
 import {
   ExternalResourceTypes,
-  InternationalString,
   ManifestNormalized,
 } from "@iiif/presentation-3";
 import React, { useCallback, useEffect, useState } from "react";
@@ -35,7 +34,7 @@ interface ViewerProps {
   iiifContentSearchQuery?: ContentSearchQuery;
 }
 
-const Viewer: React.FC<ViewerProps> = ({
+const Viewer: React.FC<ViewerProps> & { Header: React.FC } = ({
   manifest,
   theme,
   iiifContentSearchQuery,
@@ -175,10 +174,7 @@ const Viewer: React.FC<ViewerProps> = ({
           open={isInformationOpen}
           onOpenChange={setInformationOpen}
         >
-          <ViewerHeader
-            manifestLabel={manifest.label as InternationalString}
-            manifestId={manifest.id}
-          />
+          <ViewerHeader />
           <ViewerContent
             activeCanvas={activeCanvas}
             painting={painting}
@@ -194,5 +190,7 @@ const Viewer: React.FC<ViewerProps> = ({
     </ErrorBoundary>
   );
 };
+
+Viewer.Header = ViewerHeader;
 
 export default Viewer;


### PR DESCRIPTION
Props no longer passed down, but borrowed from the store. This will make it substantially easier to implement JSX dot-notation since props and their types no longer need to be passed down.