### PR TITLE
Add hooks/state needed for a custom audio/video player to track VTT annotations

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 10
 
       - name: Setup NodeJS
         uses: actions/setup-node@v3

--- a/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
+++ b/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
@@ -38,6 +38,7 @@ const findScrollableParent = (
 const Cue: React.FC<Props> = ({ html, text, start, end }) => {
   const dispatch: any = useViewerDispatch();
   const {
+    activePlayer,
     configOptions,
     isAutoScrollEnabled,
     isUserScrolling,
@@ -48,9 +49,7 @@ const Cue: React.FC<Props> = ({ html, text, start, end }) => {
   const [isActive, updateIsActive] = useState(false);
   const ref = useRef<HTMLButtonElement>(null);
 
-  const video = document.getElementById(
-    "clover-iiif-video",
-  ) as HTMLVideoElement;
+  const video = activePlayer as HTMLVideoElement;
 
   useEffect(() => {
     video?.addEventListener("timeupdate", () => {

--- a/src/components/Viewer/Media/Controls.tsx
+++ b/src/components/Viewer/Media/Controls.tsx
@@ -113,7 +113,10 @@ const Controls: React.FC<ControlsProps> = ({
     handleFilter(event.target.value);
 
   return (
-    <Wrapper isToggle={toggleFilter}>
+    <Wrapper 
+      isToggle={toggleFilter} 
+      className="clover-viewer-media-controls"
+    >
       <Form>
         {toggleFilter && (
           <Input
@@ -123,7 +126,7 @@ const Controls: React.FC<ControlsProps> = ({
           />
         )}
         {!toggleFilter && (
-          <Direction>
+          <Direction className="clover-viewer-media-navigation">
             <Button
               onClick={() => handleCanvasToggle(-1)}
               disabled={isPreviousDisabled}

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -320,6 +320,7 @@ const Painting: React.FC<PaintingProps> = ({
           <CustomComponent
             id={activeCanvas}
             annotationBody={painting[annotationIndex]}
+            hooks={{ useViewerDispatch, useViewerState }}
             {...customDisplay?.display.componentProps}
           />
         )}

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -49,6 +49,10 @@ const Player: React.FC<PlayerProps> = ({
 
     if (playerRef?.current) {
       const video: HTMLVideoElement = playerRef.current;
+      viewerDispatch({
+        type: "updateActivePlayer",
+        player: video,
+      });
       video.src = painting.id as string;
       video.load();
     }
@@ -113,7 +117,12 @@ const Player: React.FC<PlayerProps> = ({
         video.currentTime = 0;
       }
     };
-  }, [configOptions.withCredentials, painting.id]);
+  }, [
+    configOptions.withCredentials,
+    painting.id,
+    painting.format,
+    viewerDispatch,
+  ]);
 
   useEffect(() => {
     const canvas: CanvasNormalized = vault.get(activeCanvas);

--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -184,6 +184,15 @@ describe("ViewerContent with Annotation Resources", () => {
         initialState={{
           ...defaultState,
           isInformationOpen: false,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              renderAnnotation: false,
+              open: false,
+              renderAbout: false,
+              renderToggle: false,
+            },
+          },
         }}
       >
         <ViewerContent {...propsWithAnnotationResources} />

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -62,8 +62,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
 
   const isForcedAside =
     hasAnnotations &&
-    informationPanel?.renderAnnotation &&
-    !informationPanel.open;
+    informationPanel?.renderAnnotation
 
   const isAside =
     (informationPanel?.renderAbout && isInformationOpen) || isForcedAside;

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -155,6 +155,7 @@ export type PluginConfig = {
 export interface ViewerContextStore {
   activeCanvas: string;
   activeManifest: string;
+  activePlayer: HTMLVideoElement | HTMLAudioElement | null;
   activeSelector?: string;
   OSDImageLoaded?: boolean;
   collection?: CollectionNormalized | Record<string, never>;
@@ -192,6 +193,7 @@ export interface ViewerAction {
   isUserScrolling: number | undefined;
   manifestId: string;
   OSDImageLoaded?: boolean;
+  player: HTMLVideoElement | HTMLAudioElement | null;
   sequence: [Reference<"Canvas">[], number[][]];
   vault: Vault;
   openSeadragonViewer: OpenSeadragon.Viewer;
@@ -229,6 +231,7 @@ const expandedAutoScrollOptions = expandAutoScrollOptions(
 export const defaultState: ViewerContextStore = {
   activeCanvas: "",
   activeManifest: "",
+  activePlayer: null,
   activeSelector: undefined,
   OSDImageLoaded: false,
   collection: {},
@@ -269,6 +272,12 @@ function viewerReducer(state: ViewerContextStore, action: ViewerAction) {
       return {
         ...state,
         activeManifest: action.manifestId,
+      };
+    }
+    case "updateActivePlayer": {
+      return {
+        ...state,
+        activePlayer: action.player,
       };
     }
     case "updateOSDImageLoaded": {


### PR DESCRIPTION
This PR updates several things:

1. It passes the `useViewerState` and `useViewerDispatch` hooks to custom displays so they can integrate more closely with the rest of the viewer.
2. It identifies the active audio/video player using a `ref` stored in Clover's state instead of a hardcoded element ID.
3. It removes an unnecessary check from the logic that determines whether the information panel should display (fixes #217)
4. It adds the `clover-viewer-media-controls` and `clover-viewer-media-navigation` classes to the media controls to allow styling (or hiding)

This allowed my custom audio display component to synchronize with the active VTT cue, as well as scrub to the right place when a cue is clicked.