### PR TITLE
Make crossOrigin anonymous by default (fixes closed captioning and subtitles on demo)

### DIFF
--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -103,7 +103,7 @@ const defaultConfigOptions = {
       zoomLevel: 4,
     },
   },
-  crossOrigin: undefined,
+  crossOrigin: "anonymous",
   ignoreCaptionLabels: [],
   informationPanel: {
     vtt: {


### PR DESCRIPTION
This addresses [Issue-286](https://github.com/samvera-labs/clover-iiif/issues/286) and suggests making crossOrigin anonymous rather than undefined by default. With crossOrigin set to `undefined`, closed captioning won't work.