### PR TITLE
fix: rotate icons now display correctly for non-English locales

### DIFF
--- a/src/components/Image/Controls/Button.tsx
+++ b/src/components/Image/Controls/Button.tsx
@@ -9,7 +9,13 @@ interface ButtonProps {
 }
 
 const Button: React.FC<ButtonProps> = ({ className, id, label, children }) => {
-  const dataButton = label.toLowerCase().replace(/\s/g, "-");
+  // Extract button type from id (e.g., "rotateLeft-abc123" → "rotate-left")
+  // This ensures data-button is language-independent for CSS selectors
+  const buttonType = id.split("-")[0];
+  const dataButton = buttonType
+    .replace(/([A-Z])/g, "-$1")
+    .toLowerCase()
+    .replace(/^-/, "");
   return (
     <Item
       id={id}


### PR DESCRIPTION
The data-button attribute was derived from the translated label, which caused CSS selectors for rotate-left to not match when using non-English languages like Chinese. Now the attribute is derived from the language-independent id prop instead.