### PR TITLE
feat: respect viewingDirection for RTL paged manifests

### DIFF
--- a/public/manifest/behavior/paged-rtl.json
+++ b/public/manifest/behavior/paged-rtl.json
@@ -1,0 +1,8457 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "behavior": [
+    "paged"
+  ],
+  "id": "https://gsh.etu.wiki/3/manifest/31f4a710-ee58-11e8-82c9-ef1fde907138",
+  "items": [
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4023494e-2640-5cc0-8774-6cea5907c9d7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0001"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/cf44dbce-f7e8-40fe-8347-5df594666e89/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/cf44dbce-f7e8-40fe-8347-5df594666e89/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e0f13281d8a80cef7d1f6526e508240a",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e0f13281d8a80cef7d1f6526e508240a",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4023494e-2640-5cc0-8774-6cea5907c9d7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e0f13281d8a80cef7d1f6526e508240a/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e0f13281d8a80cef7d1f6526e508240a",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/d36ece99-eb37-598e-a539-e077fe5239a3",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0002"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/40c6efb9-3750-448f-b7c0-42cc03501dd6/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/40c6efb9-3750-448f-b7c0-42cc03501dd6/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/72cd103070e3780a097cff716e46e440",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/72cd103070e3780a097cff716e46e440",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/d36ece99-eb37-598e-a539-e077fe5239a3"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/72cd103070e3780a097cff716e46e440/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/72cd103070e3780a097cff716e46e440",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/606e499d-52ef-54e4-be45-1e0da7c6927f",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0003"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f2d74591-36de-4b69-89fa-33048fd4c62d/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f2d74591-36de-4b69-89fa-33048fd4c62d/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8cdbb144e60dc79683851d34fd05e3ad",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8cdbb144e60dc79683851d34fd05e3ad",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/606e499d-52ef-54e4-be45-1e0da7c6927f"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8cdbb144e60dc79683851d34fd05e3ad/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8cdbb144e60dc79683851d34fd05e3ad",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/089a7d91-bcef-5e75-b335-36ab63b77b4c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0004"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/bf988fc5-7f41-4586-8dcf-1d65082b5afe/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/bf988fc5-7f41-4586-8dcf-1d65082b5afe/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8349b089adcfce365d72f13c34f3b69f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8349b089adcfce365d72f13c34f3b69f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/089a7d91-bcef-5e75-b335-36ab63b77b4c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8349b089adcfce365d72f13c34f3b69f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8349b089adcfce365d72f13c34f3b69f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/162ed8cd-5a9d-5c9f-9dd3-c51734270421",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0005"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/aa562c47-b5ec-49f7-aec9-ea208c7d15bc/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/aa562c47-b5ec-49f7-aec9-ea208c7d15bc/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/5bf89350c7d74c31dae43069d77662dc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/5bf89350c7d74c31dae43069d77662dc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/162ed8cd-5a9d-5c9f-9dd3-c51734270421"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/5bf89350c7d74c31dae43069d77662dc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/5bf89350c7d74c31dae43069d77662dc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/66703cac-c507-516c-9b78-1ce2ec17a51c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0006"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/105eb21b-2417-444e-8058-e1766408c5e1/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/105eb21b-2417-444e-8058-e1766408c5e1/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/9ba4600ff2eeb59e1196c8373d8c01f2",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/9ba4600ff2eeb59e1196c8373d8c01f2",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/66703cac-c507-516c-9b78-1ce2ec17a51c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/9ba4600ff2eeb59e1196c8373d8c01f2/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/9ba4600ff2eeb59e1196c8373d8c01f2",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/18289571-8f29-54d5-a628-2bbe348a2aa5",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0007"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/63e669b4-c90c-4206-bd82-7a4d03df0aac/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/63e669b4-c90c-4206-bd82-7a4d03df0aac/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/fc8abdcf21948d3df95278d09a431f06",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/fc8abdcf21948d3df95278d09a431f06",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/18289571-8f29-54d5-a628-2bbe348a2aa5"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/fc8abdcf21948d3df95278d09a431f06/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/fc8abdcf21948d3df95278d09a431f06",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/6794bbf8-59b3-5d40-8715-47e963caf54a",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0008"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0af17a1a-a966-4f0c-a960-9c813af9e999/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0af17a1a-a966-4f0c-a960-9c813af9e999/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ab9fd87368a0e6e1333b3da1a27da296",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ab9fd87368a0e6e1333b3da1a27da296",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/6794bbf8-59b3-5d40-8715-47e963caf54a"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ab9fd87368a0e6e1333b3da1a27da296/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ab9fd87368a0e6e1333b3da1a27da296",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b1c6bad1-9c59-5a68-a71b-45158e10e8b0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0009"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c16e12dd-78b8-4e17-8f05-eda9c2502b45/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c16e12dd-78b8-4e17-8f05-eda9c2502b45/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/254d2ee5850c603099b01ac1fceeed5f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/254d2ee5850c603099b01ac1fceeed5f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b1c6bad1-9c59-5a68-a71b-45158e10e8b0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/254d2ee5850c603099b01ac1fceeed5f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/254d2ee5850c603099b01ac1fceeed5f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/56f32499-c9ca-56a5-882d-a35e0593346e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0010"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/cd0b3453-b3e9-4e76-802c-4b94454efef3/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/cd0b3453-b3e9-4e76-802c-4b94454efef3/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c7c9e7937d25bdaa321249216d730f3c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c7c9e7937d25bdaa321249216d730f3c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/56f32499-c9ca-56a5-882d-a35e0593346e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c7c9e7937d25bdaa321249216d730f3c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c7c9e7937d25bdaa321249216d730f3c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/411d92cc-b981-579b-bb06-0308ca35d762",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0011"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/54866e28-f31b-4765-ab42-a0d1daecb670/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/54866e28-f31b-4765-ab42-a0d1daecb670/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/bc6935a376c27d017e100a7eab116e4c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/bc6935a376c27d017e100a7eab116e4c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/411d92cc-b981-579b-bb06-0308ca35d762"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/bc6935a376c27d017e100a7eab116e4c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/bc6935a376c27d017e100a7eab116e4c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7402cbdd-4c41-569c-a059-2d426a4be626",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0012"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/84b57dd0-873a-4bde-a6eb-0bf6d3ecdaed/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/84b57dd0-873a-4bde-a6eb-0bf6d3ecdaed/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/78acc8c7c9e0fd5227d4e7582fb4a0de",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/78acc8c7c9e0fd5227d4e7582fb4a0de",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7402cbdd-4c41-569c-a059-2d426a4be626"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/78acc8c7c9e0fd5227d4e7582fb4a0de/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/78acc8c7c9e0fd5227d4e7582fb4a0de",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4ab91797-29ac-5786-bb0c-049509e7482e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0013"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/188c0b1b-47b3-45d2-beac-57aef4f8f1ad/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/188c0b1b-47b3-45d2-beac-57aef4f8f1ad/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e069f681c0ec8476c31134e2f9a7d9be",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e069f681c0ec8476c31134e2f9a7d9be",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4ab91797-29ac-5786-bb0c-049509e7482e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e069f681c0ec8476c31134e2f9a7d9be/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e069f681c0ec8476c31134e2f9a7d9be",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/ac3ac1f4-2dec-5fba-93a9-7aa43ecf0128",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0014"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/53844774-ff9a-44ca-a505-be7af5fd2442/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/53844774-ff9a-44ca-a505-be7af5fd2442/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4a03875def626dd60cf527625575417f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4a03875def626dd60cf527625575417f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/ac3ac1f4-2dec-5fba-93a9-7aa43ecf0128"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4a03875def626dd60cf527625575417f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4a03875def626dd60cf527625575417f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2ee8825b-7aab-5750-9be2-fdb82bc1ec26",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0015"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/94af303d-d33b-4c6b-913a-3a988950cec6/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/94af303d-d33b-4c6b-913a-3a988950cec6/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6d9facb00441ae7d2c04aec2a391bd6d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6d9facb00441ae7d2c04aec2a391bd6d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2ee8825b-7aab-5750-9be2-fdb82bc1ec26"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6d9facb00441ae7d2c04aec2a391bd6d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6d9facb00441ae7d2c04aec2a391bd6d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/cf59f4a9-9def-58b6-9ef9-657cdb4d6adc",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0016"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f04dce81-b0cb-4bec-aa8f-0fbe752daeae/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f04dce81-b0cb-4bec-aa8f-0fbe752daeae/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4163f88171bf43f4c42ac2911d25782e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4163f88171bf43f4c42ac2911d25782e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/cf59f4a9-9def-58b6-9ef9-657cdb4d6adc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4163f88171bf43f4c42ac2911d25782e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4163f88171bf43f4c42ac2911d25782e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/87226010-5534-5909-9c7a-f3eaf7260f9c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0017"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0634512d-69be-4405-81a0-7395b5c11556/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0634512d-69be-4405-81a0-7395b5c11556/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/a26d7dcb5b07bae9c8cae7018221170c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/a26d7dcb5b07bae9c8cae7018221170c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/87226010-5534-5909-9c7a-f3eaf7260f9c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/a26d7dcb5b07bae9c8cae7018221170c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/a26d7dcb5b07bae9c8cae7018221170c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/c41e1e02-2677-562b-934e-d6af9a37a07d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0018"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/47d1fa2d-72d9-4671-b61f-5715cd04dbb5/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/47d1fa2d-72d9-4671-b61f-5715cd04dbb5/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/137975a651f25e52eb66fc923b7a83d4",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/137975a651f25e52eb66fc923b7a83d4",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/c41e1e02-2677-562b-934e-d6af9a37a07d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/137975a651f25e52eb66fc923b7a83d4/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/137975a651f25e52eb66fc923b7a83d4",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0c886455-0589-521c-a732-db2348b3e174",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0019"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/db05a6b7-4002-4214-918d-88abdb3da1b4/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/db05a6b7-4002-4214-918d-88abdb3da1b4/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/b7c5363cfc3bca8fa5b663018531b7f0",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/b7c5363cfc3bca8fa5b663018531b7f0",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0c886455-0589-521c-a732-db2348b3e174"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/b7c5363cfc3bca8fa5b663018531b7f0/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/b7c5363cfc3bca8fa5b663018531b7f0",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f94fb79a-1b08-52f2-9f0d-91165efae56f",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0020"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/703a84eb-1fae-4b75-9478-10999ddc3066/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/703a84eb-1fae-4b75-9478-10999ddc3066/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/9746f3ce27e92591c3f162f5641404cc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/9746f3ce27e92591c3f162f5641404cc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f94fb79a-1b08-52f2-9f0d-91165efae56f"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/9746f3ce27e92591c3f162f5641404cc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/9746f3ce27e92591c3f162f5641404cc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/1a7e6bf0-fc48-51d4-ae0b-b5a24309e14d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0021"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/9bc43980-5f2d-48d7-a893-1e6b43508387/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/9bc43980-5f2d-48d7-a893-1e6b43508387/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/255c863ba645de5647f96691ad0b9334",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/255c863ba645de5647f96691ad0b9334",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/1a7e6bf0-fc48-51d4-ae0b-b5a24309e14d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/255c863ba645de5647f96691ad0b9334/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/255c863ba645de5647f96691ad0b9334",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/38ba6d92-4bb8-55a8-ae6c-37de04ded024",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0022"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8d6a5df2-2270-48a9-bb98-c62f042410a9/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8d6a5df2-2270-48a9-bb98-c62f042410a9/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4ac2266e33effc53fe914dc270de0d03",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4ac2266e33effc53fe914dc270de0d03",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/38ba6d92-4bb8-55a8-ae6c-37de04ded024"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4ac2266e33effc53fe914dc270de0d03/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4ac2266e33effc53fe914dc270de0d03",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/10d9ad43-0628-5784-9266-3bced0b7c552",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0023"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/3719e6e1-a00e-4dde-a849-6edfc6952980/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/3719e6e1-a00e-4dde-a849-6edfc6952980/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e964602fc20849a4ac596d27f6d9aaa3",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e964602fc20849a4ac596d27f6d9aaa3",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/10d9ad43-0628-5784-9266-3bced0b7c552"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e964602fc20849a4ac596d27f6d9aaa3/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e964602fc20849a4ac596d27f6d9aaa3",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b3b575f2-53f0-583a-9500-77873870da53",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0024"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/96d453fb-ee2d-48ec-9532-fae9baada04a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/96d453fb-ee2d-48ec-9532-fae9baada04a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/acd0c80467c7c4943e627a8931d5a534",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/acd0c80467c7c4943e627a8931d5a534",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b3b575f2-53f0-583a-9500-77873870da53"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/acd0c80467c7c4943e627a8931d5a534/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/acd0c80467c7c4943e627a8931d5a534",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/da404850-894d-53f4-8702-a8b2da661ab4",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0025"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d758bda6-62c1-424f-a952-ac372d02aa2e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d758bda6-62c1-424f-a952-ac372d02aa2e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d455ab3f4ed7a8195c41978967e9ebf3",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d455ab3f4ed7a8195c41978967e9ebf3",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/da404850-894d-53f4-8702-a8b2da661ab4"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d455ab3f4ed7a8195c41978967e9ebf3/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d455ab3f4ed7a8195c41978967e9ebf3",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2f547de9-8436-5fee-b8a9-7203bb719eda",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0026"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/206a870f-cb95-4cb4-8304-021cbe89e9d3/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/206a870f-cb95-4cb4-8304-021cbe89e9d3/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4e3ca303c198d34c19d3c59aa22a7c7c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4e3ca303c198d34c19d3c59aa22a7c7c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2f547de9-8436-5fee-b8a9-7203bb719eda"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4e3ca303c198d34c19d3c59aa22a7c7c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4e3ca303c198d34c19d3c59aa22a7c7c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/66ea5a45-ae32-5f74-87b2-62c20bd36d5c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0027"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/263d2740-578d-4abd-947b-c52adf75c8dd/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/263d2740-578d-4abd-947b-c52adf75c8dd/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/84f06f5860e39cca8bef0e11795eded8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/84f06f5860e39cca8bef0e11795eded8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/66ea5a45-ae32-5f74-87b2-62c20bd36d5c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/84f06f5860e39cca8bef0e11795eded8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/84f06f5860e39cca8bef0e11795eded8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/98a19152-305d-5947-8652-71eb6456c7b1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0028"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/87935685-f575-4d57-bb8b-697305a2f79f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/87935685-f575-4d57-bb8b-697305a2f79f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/89567a7dc92f88adc3db23a510c13dc4",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/89567a7dc92f88adc3db23a510c13dc4",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/98a19152-305d-5947-8652-71eb6456c7b1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/89567a7dc92f88adc3db23a510c13dc4/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/89567a7dc92f88adc3db23a510c13dc4",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a847f391-0308-5cfa-8f2b-59bf2f54f2d7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0029"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2001dae9-69c4-40df-a324-17dd415d5e22/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2001dae9-69c4-40df-a324-17dd415d5e22/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8c86902a2dab483225a4ecbd86ae3d3d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8c86902a2dab483225a4ecbd86ae3d3d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a847f391-0308-5cfa-8f2b-59bf2f54f2d7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8c86902a2dab483225a4ecbd86ae3d3d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8c86902a2dab483225a4ecbd86ae3d3d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f700c561-c166-5a7c-ab3d-1dc621a14ae8",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0030"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/58322021-0576-4b1f-bb6b-3827e7f4160e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/58322021-0576-4b1f-bb6b-3827e7f4160e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6a6eb9afc5b5a92ec560cfb68fed89e5",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6a6eb9afc5b5a92ec560cfb68fed89e5",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f700c561-c166-5a7c-ab3d-1dc621a14ae8"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6a6eb9afc5b5a92ec560cfb68fed89e5/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6a6eb9afc5b5a92ec560cfb68fed89e5",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2f118b54-cff6-5ed7-a5a1-a5ccf0376c6b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0031"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/88cc15d8-aaca-4e4a-a167-bfe32a8f410f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/88cc15d8-aaca-4e4a-a167-bfe32a8f410f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/250e3621adbbd791a2f4b1f851eebc13",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/250e3621adbbd791a2f4b1f851eebc13",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2f118b54-cff6-5ed7-a5a1-a5ccf0376c6b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/250e3621adbbd791a2f4b1f851eebc13/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/250e3621adbbd791a2f4b1f851eebc13",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/229b612c-d42e-59af-934e-28c9a118b6ce",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0032"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f7de522d-4b5c-4524-a442-e547058ec65b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f7de522d-4b5c-4524-a442-e547058ec65b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/79d6b345c2db58f2b08fd7b10b4692df",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/79d6b345c2db58f2b08fd7b10b4692df",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/229b612c-d42e-59af-934e-28c9a118b6ce"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/79d6b345c2db58f2b08fd7b10b4692df/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/79d6b345c2db58f2b08fd7b10b4692df",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/119f96cd-57ad-5a85-acee-25242542ffa8",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0033"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c3f51932-f5b7-40d6-a719-2e4f3d596714/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c3f51932-f5b7-40d6-a719-2e4f3d596714/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/54860fc90a41ffcbb4d929fd61d9c086",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/54860fc90a41ffcbb4d929fd61d9c086",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/119f96cd-57ad-5a85-acee-25242542ffa8"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/54860fc90a41ffcbb4d929fd61d9c086/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/54860fc90a41ffcbb4d929fd61d9c086",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/18177e4b-e38e-5c6f-b49f-eaad98420997",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0034"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4974f72f-baa8-4256-a1e5-307464a2fe59/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4974f72f-baa8-4256-a1e5-307464a2fe59/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/870092c8e4ba289c945be3cc19742e4b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/870092c8e4ba289c945be3cc19742e4b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/18177e4b-e38e-5c6f-b49f-eaad98420997"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/870092c8e4ba289c945be3cc19742e4b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/870092c8e4ba289c945be3cc19742e4b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/5cf17e62-804f-5eaf-b1c5-fde138e074ce",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0035"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0680bfc9-4dce-40fd-af64-a9d12329a950/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0680bfc9-4dce-40fd-af64-a9d12329a950/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/07de906eb78261eb739520f936718a76",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/07de906eb78261eb739520f936718a76",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/5cf17e62-804f-5eaf-b1c5-fde138e074ce"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/07de906eb78261eb739520f936718a76/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/07de906eb78261eb739520f936718a76",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/894c3c7b-3d0e-5d44-8801-d23ac0302bf7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0036"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/9eb86cd8-a30d-4daf-979c-f439d3ef0421/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/9eb86cd8-a30d-4daf-979c-f439d3ef0421/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/f07587bf0542f20151ed2d980069e7bc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/f07587bf0542f20151ed2d980069e7bc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/894c3c7b-3d0e-5d44-8801-d23ac0302bf7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/f07587bf0542f20151ed2d980069e7bc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/f07587bf0542f20151ed2d980069e7bc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7f78883e-b200-519a-aba9-875f7c5721ca",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0037"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f9e26d13-a62c-469b-9732-08646394f85f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f9e26d13-a62c-469b-9732-08646394f85f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c43a6b33e18947ade7fb95ca644f13da",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c43a6b33e18947ade7fb95ca644f13da",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7f78883e-b200-519a-aba9-875f7c5721ca"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c43a6b33e18947ade7fb95ca644f13da/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c43a6b33e18947ade7fb95ca644f13da",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/da8d2c38-19ca-56b0-97bf-aa35a60f8fbb",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0038"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8caca6df-302d-401c-aeb0-b55d21036ee4/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8caca6df-302d-401c-aeb0-b55d21036ee4/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/69664b3e9e114d30f092453439cfd4f2",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/69664b3e9e114d30f092453439cfd4f2",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/da8d2c38-19ca-56b0-97bf-aa35a60f8fbb"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/69664b3e9e114d30f092453439cfd4f2/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/69664b3e9e114d30f092453439cfd4f2",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/3239d615-c9b3-53ba-b489-8b2e19954259",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0039"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/577925f0-7605-4a23-9fa2-b513c09b11d6/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/577925f0-7605-4a23-9fa2-b513c09b11d6/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/acfc2ebefcbdeb84eb81a20eb146d623",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/acfc2ebefcbdeb84eb81a20eb146d623",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/3239d615-c9b3-53ba-b489-8b2e19954259"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/acfc2ebefcbdeb84eb81a20eb146d623/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/acfc2ebefcbdeb84eb81a20eb146d623",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/1fc98a54-8344-55fc-9a87-d1a32083b4d6",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0040"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b67b8d86-d60b-4b90-ba22-3dbdee4d4312/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b67b8d86-d60b-4b90-ba22-3dbdee4d4312/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/7b43f224067b4c35e95279a32a977728",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/7b43f224067b4c35e95279a32a977728",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/1fc98a54-8344-55fc-9a87-d1a32083b4d6"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/7b43f224067b4c35e95279a32a977728/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/7b43f224067b4c35e95279a32a977728",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a678098f-d95c-5062-8200-48b0857b9a48",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0041"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/a91b53f9-1435-479e-9c17-352953dba552/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/a91b53f9-1435-479e-9c17-352953dba552/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/5642af1bfd5620a0c46ba32ffee48a06",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/5642af1bfd5620a0c46ba32ffee48a06",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a678098f-d95c-5062-8200-48b0857b9a48"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/5642af1bfd5620a0c46ba32ffee48a06/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/5642af1bfd5620a0c46ba32ffee48a06",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/663cfa51-a130-5fdb-97b2-6de7bec235ca",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0042"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/447a36a5-03c6-42e2-b7d7-5639090e3f90/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/447a36a5-03c6-42e2-b7d7-5639090e3f90/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/26ed8d46f1f40c222187a69a6134a7f6",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/26ed8d46f1f40c222187a69a6134a7f6",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/663cfa51-a130-5fdb-97b2-6de7bec235ca"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/26ed8d46f1f40c222187a69a6134a7f6/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/26ed8d46f1f40c222187a69a6134a7f6",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4e97fb73-ee27-5209-af33-4d0661deb153",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0043"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/ddfe4171-d255-4d96-a93a-b26530fe16a3/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/ddfe4171-d255-4d96-a93a-b26530fe16a3/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ffd6ff8eb0d5ee047c34083daa7299d6",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ffd6ff8eb0d5ee047c34083daa7299d6",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4e97fb73-ee27-5209-af33-4d0661deb153"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ffd6ff8eb0d5ee047c34083daa7299d6/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ffd6ff8eb0d5ee047c34083daa7299d6",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/70d7dd5b-171f-5d6e-82b1-104f418997ee",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0044"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/55fdfaa0-093e-46c3-a294-2af0acda7802/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/55fdfaa0-093e-46c3-a294-2af0acda7802/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/293b848a4be51e72db5de489c298a67e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/293b848a4be51e72db5de489c298a67e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/70d7dd5b-171f-5d6e-82b1-104f418997ee"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/293b848a4be51e72db5de489c298a67e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/293b848a4be51e72db5de489c298a67e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/51c98605-2881-5d27-94f5-e0969c42e425",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0045"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d41abd9a-530f-4901-9b65-c08d2dc01c1c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d41abd9a-530f-4901-9b65-c08d2dc01c1c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8d55b520af4acc2ea9b7730317f84829",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8d55b520af4acc2ea9b7730317f84829",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/51c98605-2881-5d27-94f5-e0969c42e425"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8d55b520af4acc2ea9b7730317f84829/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8d55b520af4acc2ea9b7730317f84829",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/82f6a23d-feff-5936-a7db-df28e08696e1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0046"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/9e48f87f-439d-4d62-a8fb-a98834b02532/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/9e48f87f-439d-4d62-a8fb-a98834b02532/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/7779f4320a445e57a2862bc56e65b5e6",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/7779f4320a445e57a2862bc56e65b5e6",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/82f6a23d-feff-5936-a7db-df28e08696e1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/7779f4320a445e57a2862bc56e65b5e6/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/7779f4320a445e57a2862bc56e65b5e6",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7518dc39-da67-5141-ade5-a8e00a654b91",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0047"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/cd01b128-2696-49d7-9fb7-bdbcecf21700/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/cd01b128-2696-49d7-9fb7-bdbcecf21700/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0a0bd526b9bc4d7f8943d1131659caeb",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0a0bd526b9bc4d7f8943d1131659caeb",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7518dc39-da67-5141-ade5-a8e00a654b91"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0a0bd526b9bc4d7f8943d1131659caeb/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0a0bd526b9bc4d7f8943d1131659caeb",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/471d16cf-8e7a-55ce-b8cc-d14e63bd6fbf",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0048"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/903f735e-3b6d-4f1f-a58e-9bcaee85e041/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/903f735e-3b6d-4f1f-a58e-9bcaee85e041/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/19a41dd509942edba0ef56f7cf83440c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/19a41dd509942edba0ef56f7cf83440c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/471d16cf-8e7a-55ce-b8cc-d14e63bd6fbf"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/19a41dd509942edba0ef56f7cf83440c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/19a41dd509942edba0ef56f7cf83440c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/279f5714-b941-5eaa-881a-3c45f753bb6b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0049"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/fa824118-3c31-425e-8320-b951cff3d414/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/fa824118-3c31-425e-8320-b951cff3d414/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0a91670a4dec2dee68a0d440687775f7",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0a91670a4dec2dee68a0d440687775f7",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/279f5714-b941-5eaa-881a-3c45f753bb6b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0a91670a4dec2dee68a0d440687775f7/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0a91670a4dec2dee68a0d440687775f7",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/96a54771-c1d1-5224-b513-f37a54b205b2",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0050"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/1adef4a7-1996-4da8-809f-a9bac220dadf/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/1adef4a7-1996-4da8-809f-a9bac220dadf/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8e444f309ec7c29b5a907af672479df9",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8e444f309ec7c29b5a907af672479df9",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/96a54771-c1d1-5224-b513-f37a54b205b2"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8e444f309ec7c29b5a907af672479df9/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8e444f309ec7c29b5a907af672479df9",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/71ee4a0b-b242-586f-9623-71a7cd86ccbb",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0051"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0806b78b-0e8d-4df8-ae05-d3cd859ae83c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0806b78b-0e8d-4df8-ae05-d3cd859ae83c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c613fe78714111acb43443b6571ab178",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c613fe78714111acb43443b6571ab178",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/71ee4a0b-b242-586f-9623-71a7cd86ccbb"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c613fe78714111acb43443b6571ab178/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c613fe78714111acb43443b6571ab178",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8917d0ee-648a-537b-b1d4-1dcb5b4bd960",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0052"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/44cd0e93-5721-43cd-9b92-150fdaebbcc2/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/44cd0e93-5721-43cd-9b92-150fdaebbcc2/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/acd4011ebf966d319722c85d9ef79d73",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/acd4011ebf966d319722c85d9ef79d73",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8917d0ee-648a-537b-b1d4-1dcb5b4bd960"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/acd4011ebf966d319722c85d9ef79d73/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/acd4011ebf966d319722c85d9ef79d73",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b561b0d2-070f-5846-b4f3-cfe61579496a",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0053"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d282c201-be93-4e70-b45e-2f3947bf5c1f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d282c201-be93-4e70-b45e-2f3947bf5c1f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/475f5abecda0aee71f36910235a6c2e8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/475f5abecda0aee71f36910235a6c2e8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b561b0d2-070f-5846-b4f3-cfe61579496a"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/475f5abecda0aee71f36910235a6c2e8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/475f5abecda0aee71f36910235a6c2e8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/aefb0e07-1fef-5ef6-b6fb-05f99826c6be",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0054"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/46faa7ed-f32c-49a9-9ba7-9dbda98c6c6d/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/46faa7ed-f32c-49a9-9ba7-9dbda98c6c6d/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/33abf6c92e3a792278b1934ff284d93d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/33abf6c92e3a792278b1934ff284d93d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/aefb0e07-1fef-5ef6-b6fb-05f99826c6be"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/33abf6c92e3a792278b1934ff284d93d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/33abf6c92e3a792278b1934ff284d93d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/94df0586-f0b3-5709-a8d3-72e667e3e491",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0055"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f43660e3-fed2-41e3-868d-2c420b510855/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f43660e3-fed2-41e3-868d-2c420b510855/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/17fa9b767926f60a466f68bcfbdbe862",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/17fa9b767926f60a466f68bcfbdbe862",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/94df0586-f0b3-5709-a8d3-72e667e3e491"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/17fa9b767926f60a466f68bcfbdbe862/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/17fa9b767926f60a466f68bcfbdbe862",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/6b2756a0-b879-5249-807b-3f544b0d98fa",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0056"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/28cc0ce2-891d-43c1-845e-3fd2f38c3c64/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/28cc0ce2-891d-43c1-845e-3fd2f38c3c64/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/cf6f53b4f8ee0fa8c28352e2dc8c451a",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/cf6f53b4f8ee0fa8c28352e2dc8c451a",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/6b2756a0-b879-5249-807b-3f544b0d98fa"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/cf6f53b4f8ee0fa8c28352e2dc8c451a/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/cf6f53b4f8ee0fa8c28352e2dc8c451a",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0c2f8a2f-53ee-586f-900f-0457447ca4cb",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0057"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/72e3db51-dbbb-4450-8dc8-5bb4dfa2849f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/72e3db51-dbbb-4450-8dc8-5bb4dfa2849f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/95ec44fdd8e333841c95515f4bf4d002",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/95ec44fdd8e333841c95515f4bf4d002",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0c2f8a2f-53ee-586f-900f-0457447ca4cb"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/95ec44fdd8e333841c95515f4bf4d002/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/95ec44fdd8e333841c95515f4bf4d002",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a79f571d-90fa-57ba-8d2d-4c372e614a18",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0058"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/ad22f9da-1d65-4479-8c6d-e93460d7249e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/ad22f9da-1d65-4479-8c6d-e93460d7249e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/858cc21883d7d921c936c6d3cff118c1",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/858cc21883d7d921c936c6d3cff118c1",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a79f571d-90fa-57ba-8d2d-4c372e614a18"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/858cc21883d7d921c936c6d3cff118c1/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/858cc21883d7d921c936c6d3cff118c1",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/d0948584-b3fc-5d4a-bbcd-1ed2582cffdf",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0059"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/65fb904b-0c7a-4783-9e20-1b09e23d0d35/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/65fb904b-0c7a-4783-9e20-1b09e23d0d35/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/b3a660fa8bad5c31c600d382ebb9516a",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/b3a660fa8bad5c31c600d382ebb9516a",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/d0948584-b3fc-5d4a-bbcd-1ed2582cffdf"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/b3a660fa8bad5c31c600d382ebb9516a/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/b3a660fa8bad5c31c600d382ebb9516a",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bf465aad-2ee8-566c-988d-fc85fe802132",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0060"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/9b32177c-4f19-46de-952c-dd505f2c106b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/9b32177c-4f19-46de-952c-dd505f2c106b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/cbff119de4799ec988112e6faf4e892e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/cbff119de4799ec988112e6faf4e892e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bf465aad-2ee8-566c-988d-fc85fe802132"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/cbff119de4799ec988112e6faf4e892e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/cbff119de4799ec988112e6faf4e892e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/c2196bc0-2e2f-5170-8f77-c2b3b2f62479",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0061"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/a6191af0-e46f-4c4e-9544-cfcd76ea36a4/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/a6191af0-e46f-4c4e-9544-cfcd76ea36a4/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6453ecb68f071f2dcf120e8ef73db6d5",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6453ecb68f071f2dcf120e8ef73db6d5",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/c2196bc0-2e2f-5170-8f77-c2b3b2f62479"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6453ecb68f071f2dcf120e8ef73db6d5/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6453ecb68f071f2dcf120e8ef73db6d5",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/03ef858d-508d-5f59-a673-19ef5ebd54d2",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0062"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/10e62efc-59e8-4692-a643-abacb21af22b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/10e62efc-59e8-4692-a643-abacb21af22b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/04b40fc4d6cf7f4a58b4aa69b4912f7b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/04b40fc4d6cf7f4a58b4aa69b4912f7b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/03ef858d-508d-5f59-a673-19ef5ebd54d2"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/04b40fc4d6cf7f4a58b4aa69b4912f7b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/04b40fc4d6cf7f4a58b4aa69b4912f7b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/01eb8701-4dcb-5075-9482-f6f319b7ec2d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0063"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/fb0d1871-15bf-41a7-8d38-8dfd3a52aac9/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/fb0d1871-15bf-41a7-8d38-8dfd3a52aac9/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/f79f3f0b261db3e80863dd606ea0d818",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/f79f3f0b261db3e80863dd606ea0d818",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/01eb8701-4dcb-5075-9482-f6f319b7ec2d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/f79f3f0b261db3e80863dd606ea0d818/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/f79f3f0b261db3e80863dd606ea0d818",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b6212c28-63ca-591e-b95c-5701bb940a8b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0064"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/073886d8-f085-4c82-8e34-b96c1b0d560b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/073886d8-f085-4c82-8e34-b96c1b0d560b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/35f727761b552d18f96b0d1599720f3d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/35f727761b552d18f96b0d1599720f3d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b6212c28-63ca-591e-b95c-5701bb940a8b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/35f727761b552d18f96b0d1599720f3d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/35f727761b552d18f96b0d1599720f3d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4476eb70-0777-520c-9f3e-d8a8ba4e9d2e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0065"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4b381295-0db6-42d9-b631-6bb11c8aec53/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4b381295-0db6-42d9-b631-6bb11c8aec53/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/01f51f5d9ed64ba65acff3bb26a99ade",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/01f51f5d9ed64ba65acff3bb26a99ade",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4476eb70-0777-520c-9f3e-d8a8ba4e9d2e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/01f51f5d9ed64ba65acff3bb26a99ade/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/01f51f5d9ed64ba65acff3bb26a99ade",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/6dfccdb2-6829-5969-a1f7-50e39367a96c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0066"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b0554abe-bb5d-4daf-81be-fb905f8099d9/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b0554abe-bb5d-4daf-81be-fb905f8099d9/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/bb0b5256ade5b6416ee644c4fb8ce327",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/bb0b5256ade5b6416ee644c4fb8ce327",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/6dfccdb2-6829-5969-a1f7-50e39367a96c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/bb0b5256ade5b6416ee644c4fb8ce327/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/bb0b5256ade5b6416ee644c4fb8ce327",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/af2810db-c82d-5822-baf1-a6199b6ffe74",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0067"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d69574a8-9b80-4acb-a43b-a23377403201/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d69574a8-9b80-4acb-a43b-a23377403201/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0b7648f8297d4d21edcddb4aa01f829e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0b7648f8297d4d21edcddb4aa01f829e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/af2810db-c82d-5822-baf1-a6199b6ffe74"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0b7648f8297d4d21edcddb4aa01f829e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0b7648f8297d4d21edcddb4aa01f829e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a37890f6-eed7-5f8b-bc89-7206c8c23b69",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0068"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/a896ef2c-b704-44d7-922a-ae29ee09d73c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/a896ef2c-b704-44d7-922a-ae29ee09d73c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4d3732e1d689f935b20b4bf840b7a84f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4d3732e1d689f935b20b4bf840b7a84f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a37890f6-eed7-5f8b-bc89-7206c8c23b69"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4d3732e1d689f935b20b4bf840b7a84f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4d3732e1d689f935b20b4bf840b7a84f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b00c67cc-7ed1-5a45-894b-b903a2bc1c25",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0069"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d0125ddb-8ecf-458a-9224-cfc5da665927/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d0125ddb-8ecf-458a-9224-cfc5da665927/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/08c8f64be322140c2a43656c2533b83f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/08c8f64be322140c2a43656c2533b83f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b00c67cc-7ed1-5a45-894b-b903a2bc1c25"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/08c8f64be322140c2a43656c2533b83f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/08c8f64be322140c2a43656c2533b83f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f0449703-d24c-597b-bf4d-ef472bc3ff1b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0070"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e48e9a9d-2622-4c95-9123-2080da1bcbd0/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e48e9a9d-2622-4c95-9123-2080da1bcbd0/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/7d81d0daaf155e15f590ca2d4f3385fc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/7d81d0daaf155e15f590ca2d4f3385fc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f0449703-d24c-597b-bf4d-ef472bc3ff1b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/7d81d0daaf155e15f590ca2d4f3385fc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/7d81d0daaf155e15f590ca2d4f3385fc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/04e6e2b1-d87f-5ff5-9c40-897f9ec4334e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0071"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/da5e59f4-f5f2-4c1d-909a-a2f0ea450eee/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/da5e59f4-f5f2-4c1d-909a-a2f0ea450eee/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3cd56081dc064a62c409101d6ad9b709",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3cd56081dc064a62c409101d6ad9b709",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/04e6e2b1-d87f-5ff5-9c40-897f9ec4334e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3cd56081dc064a62c409101d6ad9b709/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3cd56081dc064a62c409101d6ad9b709",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4567f284-9dd9-5bfb-80ec-47eae79a6161",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0072"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2e85de9b-0e7e-4790-86f1-c7ab6458c287/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2e85de9b-0e7e-4790-86f1-c7ab6458c287/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c98097e0cea4783ed49487c682498f51",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c98097e0cea4783ed49487c682498f51",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4567f284-9dd9-5bfb-80ec-47eae79a6161"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c98097e0cea4783ed49487c682498f51/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c98097e0cea4783ed49487c682498f51",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bb2c9bca-a529-5eed-bf5b-aa6b19d7d46c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0073"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2a889fab-2562-410d-b218-55297739b8e9/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2a889fab-2562-410d-b218-55297739b8e9/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d3075f3f9085a4029261898964de2e18",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d3075f3f9085a4029261898964de2e18",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bb2c9bca-a529-5eed-bf5b-aa6b19d7d46c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d3075f3f9085a4029261898964de2e18/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d3075f3f9085a4029261898964de2e18",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/64663e01-3eb7-55d9-bd11-9e4de25e45fb",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0074"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/6b30c99e-b1e0-4f60-8d40-c84942ffa15a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/6b30c99e-b1e0-4f60-8d40-c84942ffa15a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/894805d1b487c176677434a88f6451c8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/894805d1b487c176677434a88f6451c8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/64663e01-3eb7-55d9-bd11-9e4de25e45fb"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/894805d1b487c176677434a88f6451c8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/894805d1b487c176677434a88f6451c8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/dd6d3131-a22a-538c-b3ee-b73eb1504776",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0075"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/cc6499b4-abcc-4656-a63f-4b6034f7c555/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/cc6499b4-abcc-4656-a63f-4b6034f7c555/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/559870baee7a347d7c7f9617083bb98e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/559870baee7a347d7c7f9617083bb98e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/dd6d3131-a22a-538c-b3ee-b73eb1504776"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/559870baee7a347d7c7f9617083bb98e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/559870baee7a347d7c7f9617083bb98e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b8dd0dfb-c089-52ae-9ee9-fbf9ddaa3a84",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0076"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/6dc3e14e-b703-4a95-854e-2c0675bbc155/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/6dc3e14e-b703-4a95-854e-2c0675bbc155/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3e57c4e893c80607b388c89fac6e2b2a",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3e57c4e893c80607b388c89fac6e2b2a",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b8dd0dfb-c089-52ae-9ee9-fbf9ddaa3a84"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3e57c4e893c80607b388c89fac6e2b2a/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3e57c4e893c80607b388c89fac6e2b2a",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2958992f-fb77-5cc5-9f2a-2310df8fbc27",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0077"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/64b0f41f-c9a6-42c5-bf0a-a7fc5092d90a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/64b0f41f-c9a6-42c5-bf0a-a7fc5092d90a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3806b3ffa9ca712837780eaeda3d486e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3806b3ffa9ca712837780eaeda3d486e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2958992f-fb77-5cc5-9f2a-2310df8fbc27"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3806b3ffa9ca712837780eaeda3d486e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3806b3ffa9ca712837780eaeda3d486e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7ed371ab-dace-5c5c-9fcb-5b056c2d52f0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0078"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8ea0684d-2893-4a20-8fda-b5904f6a7868/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8ea0684d-2893-4a20-8fda-b5904f6a7868/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/548bf2a23910e3f16bdc79cecdedab81",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/548bf2a23910e3f16bdc79cecdedab81",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7ed371ab-dace-5c5c-9fcb-5b056c2d52f0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/548bf2a23910e3f16bdc79cecdedab81/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/548bf2a23910e3f16bdc79cecdedab81",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/910e6af6-53ad-5e4c-ab6d-28de8d845d07",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0079"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/713ef599-67b2-489b-a1fa-8d609dc65dc0/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/713ef599-67b2-489b-a1fa-8d609dc65dc0/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/a7c2dfa2eb5cdc8b64b049892deafc0e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/a7c2dfa2eb5cdc8b64b049892deafc0e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/910e6af6-53ad-5e4c-ab6d-28de8d845d07"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/a7c2dfa2eb5cdc8b64b049892deafc0e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/a7c2dfa2eb5cdc8b64b049892deafc0e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8a36695b-e0c7-5f95-96ef-90b070ad3094",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0080"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/721dd021-a79b-4060-8e3c-57c0ac9f2f24/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/721dd021-a79b-4060-8e3c-57c0ac9f2f24/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d8c18414463dcdaa4a73ceb81363678b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d8c18414463dcdaa4a73ceb81363678b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8a36695b-e0c7-5f95-96ef-90b070ad3094"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d8c18414463dcdaa4a73ceb81363678b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d8c18414463dcdaa4a73ceb81363678b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/fb3d5310-fbbb-5aab-9f91-12be3fb89133",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0081"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4e8b96b4-1276-483d-acd9-11de94bbbfbd/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4e8b96b4-1276-483d-acd9-11de94bbbfbd/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6e6dfc518dd95c75de5836bf0d763bfc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6e6dfc518dd95c75de5836bf0d763bfc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/fb3d5310-fbbb-5aab-9f91-12be3fb89133"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6e6dfc518dd95c75de5836bf0d763bfc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6e6dfc518dd95c75de5836bf0d763bfc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bc67e383-0d18-54bd-9c12-f41780b9c495",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0082"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/88b9151e-ba23-456f-b680-7884d33a82b5/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/88b9151e-ba23-456f-b680-7884d33a82b5/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/379921174c18d74dde710037740e4d63",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/379921174c18d74dde710037740e4d63",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bc67e383-0d18-54bd-9c12-f41780b9c495"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/379921174c18d74dde710037740e4d63/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/379921174c18d74dde710037740e4d63",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/1a98db7b-e045-541a-9b96-169724f01892",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0083"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4698e5c9-704c-465a-8cdf-c4c7aee66a51/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4698e5c9-704c-465a-8cdf-c4c7aee66a51/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/bb9f3437cdb077e86d9aab0909c2c60d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/bb9f3437cdb077e86d9aab0909c2c60d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/1a98db7b-e045-541a-9b96-169724f01892"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/bb9f3437cdb077e86d9aab0909c2c60d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/bb9f3437cdb077e86d9aab0909c2c60d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b9193caf-ed7c-507d-abd4-20e5ec282074",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0084"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/7fd958a5-2d70-426a-8a6c-31b5734e7ad8/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/7fd958a5-2d70-426a-8a6c-31b5734e7ad8/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/313f66ef8ad81c7cc3ccf7b81eb2dd54",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/313f66ef8ad81c7cc3ccf7b81eb2dd54",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b9193caf-ed7c-507d-abd4-20e5ec282074"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/313f66ef8ad81c7cc3ccf7b81eb2dd54/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/313f66ef8ad81c7cc3ccf7b81eb2dd54",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/661bbb8a-3b7a-50d2-941f-4001ba225854",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0085"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/38df1dad-e9f5-43d6-bcf2-c30ede7ad046/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/38df1dad-e9f5-43d6-bcf2-c30ede7ad046/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/129784bae60dd2df738fe40c6979f6c8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/129784bae60dd2df738fe40c6979f6c8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/661bbb8a-3b7a-50d2-941f-4001ba225854"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/129784bae60dd2df738fe40c6979f6c8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/129784bae60dd2df738fe40c6979f6c8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0c9bc220-7d9c-586f-aa79-09ac5bcab16a",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0086"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c25247b0-d183-4a1e-bb2f-0b7894c7f316/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c25247b0-d183-4a1e-bb2f-0b7894c7f316/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c2358d227f7134d11c9ad23810670ca2",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c2358d227f7134d11c9ad23810670ca2",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0c9bc220-7d9c-586f-aa79-09ac5bcab16a"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c2358d227f7134d11c9ad23810670ca2/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c2358d227f7134d11c9ad23810670ca2",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/b844cf68-219a-5f7a-85f7-ac60f6211129",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0087"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c1706fdc-12c1-452d-9f2c-aeaf59fab571/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c1706fdc-12c1-452d-9f2c-aeaf59fab571/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/caebd2ccc52feed6a9ddd4c539076b06",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/caebd2ccc52feed6a9ddd4c539076b06",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/b844cf68-219a-5f7a-85f7-ac60f6211129"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/caebd2ccc52feed6a9ddd4c539076b06/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/caebd2ccc52feed6a9ddd4c539076b06",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f92306ef-44c5-5996-8e1f-853c1381a0d7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0088"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/15b63d06-c110-4d7a-aac1-c068de1c6826/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/15b63d06-c110-4d7a-aac1-c068de1c6826/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/622e20fd7d8978aa9f44a1595122cb95",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/622e20fd7d8978aa9f44a1595122cb95",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f92306ef-44c5-5996-8e1f-853c1381a0d7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/622e20fd7d8978aa9f44a1595122cb95/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/622e20fd7d8978aa9f44a1595122cb95",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2a710fbf-b141-5b4a-84a6-b869edec93e0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0089"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c628954c-3781-4330-ba4a-563d1761f14c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c628954c-3781-4330-ba4a-563d1761f14c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c443874c29a90f0a1b2a17cf23a1c47f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c443874c29a90f0a1b2a17cf23a1c47f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2a710fbf-b141-5b4a-84a6-b869edec93e0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c443874c29a90f0a1b2a17cf23a1c47f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c443874c29a90f0a1b2a17cf23a1c47f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0936318a-a406-5898-9f1c-15cad7501f8e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0090"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/73e936c7-11f8-4c98-bb59-e84371f1025a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/73e936c7-11f8-4c98-bb59-e84371f1025a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/acdf6a68e5b39bb9f1a394ca1bc9b98b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/acdf6a68e5b39bb9f1a394ca1bc9b98b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0936318a-a406-5898-9f1c-15cad7501f8e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/acdf6a68e5b39bb9f1a394ca1bc9b98b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/acdf6a68e5b39bb9f1a394ca1bc9b98b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/37b0fc04-810f-5af5-901e-e253a1861375",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0091"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/eff92b9d-cc25-4e41-b14e-08709c26671a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/eff92b9d-cc25-4e41-b14e-08709c26671a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6a5deca5c20da7dbfdac2ed556b1994b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6a5deca5c20da7dbfdac2ed556b1994b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/37b0fc04-810f-5af5-901e-e253a1861375"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6a5deca5c20da7dbfdac2ed556b1994b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6a5deca5c20da7dbfdac2ed556b1994b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/de190dea-2b6c-5156-aa92-6146dca3cfc4",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0092"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0a6a038b-6d62-4dde-a1db-e59fadb015d5/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0a6a038b-6d62-4dde-a1db-e59fadb015d5/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6b8874264d96917e263b5b11b8f9d64d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6b8874264d96917e263b5b11b8f9d64d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/de190dea-2b6c-5156-aa92-6146dca3cfc4"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6b8874264d96917e263b5b11b8f9d64d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6b8874264d96917e263b5b11b8f9d64d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8d9e728f-fc77-5e45-95d1-796ddb88db91",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0093"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/dd648848-c456-4eba-afbb-b802cd3c80fa/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/dd648848-c456-4eba-afbb-b802cd3c80fa/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3cbc0000b3a6e00b354917441c007567",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3cbc0000b3a6e00b354917441c007567",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8d9e728f-fc77-5e45-95d1-796ddb88db91"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3cbc0000b3a6e00b354917441c007567/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3cbc0000b3a6e00b354917441c007567",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/fc188181-f9b2-5eac-a3a2-503f3a40ce4b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0094"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e9cab333-7e56-4241-8ef4-1c14860fd3e2/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e9cab333-7e56-4241-8ef4-1c14860fd3e2/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2571036ea2da2b0a44705ea24d37ea67",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2571036ea2da2b0a44705ea24d37ea67",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/fc188181-f9b2-5eac-a3a2-503f3a40ce4b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2571036ea2da2b0a44705ea24d37ea67/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2571036ea2da2b0a44705ea24d37ea67",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/dda32584-edef-5f45-9955-3643308b37c7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0095"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e68ffbcb-f226-4af5-bce5-3d11dc75063c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e68ffbcb-f226-4af5-bce5-3d11dc75063c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d0c557b1c3d3d79f37471ded2a6321c7",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d0c557b1c3d3d79f37471ded2a6321c7",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/dda32584-edef-5f45-9955-3643308b37c7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d0c557b1c3d3d79f37471ded2a6321c7/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d0c557b1c3d3d79f37471ded2a6321c7",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/1590c14a-e24a-5693-a6b5-bda0d4821544",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0096"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/57c9f292-4751-4bf1-a14d-249584edcb31/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/57c9f292-4751-4bf1-a14d-249584edcb31/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6d8ea949e7bc912d1a7d327a77650bae",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6d8ea949e7bc912d1a7d327a77650bae",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/1590c14a-e24a-5693-a6b5-bda0d4821544"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6d8ea949e7bc912d1a7d327a77650bae/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6d8ea949e7bc912d1a7d327a77650bae",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/9370e2c1-ef8b-5332-b113-93978c88ff1f",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0097"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c41806b5-da05-4873-b8a7-32380d0efc89/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c41806b5-da05-4873-b8a7-32380d0efc89/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2525ca5ef0b97ff48d52476704e56616",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2525ca5ef0b97ff48d52476704e56616",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/9370e2c1-ef8b-5332-b113-93978c88ff1f"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2525ca5ef0b97ff48d52476704e56616/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2525ca5ef0b97ff48d52476704e56616",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/74f5cccd-bbcc-5287-957d-9ba91fbe59e3",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0098"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/3ad9fcbb-19ba-42a9-9e4b-90555601ac48/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/3ad9fcbb-19ba-42a9-9e4b-90555601ac48/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6b44c5b04a181c2dbb028ecc156e66e1",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6b44c5b04a181c2dbb028ecc156e66e1",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/74f5cccd-bbcc-5287-957d-9ba91fbe59e3"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6b44c5b04a181c2dbb028ecc156e66e1/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6b44c5b04a181c2dbb028ecc156e66e1",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/270287fa-b642-569f-a6f3-b557fb237b92",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0099"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/6fe458d2-43b6-4348-b39c-66b298a5d86f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/6fe458d2-43b6-4348-b39c-66b298a5d86f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/120139b0dc9a4b192749080ad991e6f8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/120139b0dc9a4b192749080ad991e6f8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/270287fa-b642-569f-a6f3-b557fb237b92"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/120139b0dc9a4b192749080ad991e6f8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/120139b0dc9a4b192749080ad991e6f8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/aaa803aa-01e1-53e9-9323-673f8643c864",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0100"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/22c9e313-12ea-456a-acdc-2de31f447f42/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/22c9e313-12ea-456a-acdc-2de31f447f42/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ead49a3f797629a12eb4cee8ded6f1df",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ead49a3f797629a12eb4cee8ded6f1df",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/aaa803aa-01e1-53e9-9323-673f8643c864"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ead49a3f797629a12eb4cee8ded6f1df/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ead49a3f797629a12eb4cee8ded6f1df",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/670ee8ad-9ec9-5f3a-9d25-5a3245499060",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0101"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d23b4fa7-7503-4adf-9401-824e0c053e11/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d23b4fa7-7503-4adf-9401-824e0c053e11/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/10d81ea3dfcda2645945fee4f39b47e9",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/10d81ea3dfcda2645945fee4f39b47e9",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/670ee8ad-9ec9-5f3a-9d25-5a3245499060"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/10d81ea3dfcda2645945fee4f39b47e9/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/10d81ea3dfcda2645945fee4f39b47e9",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bedaaabc-b4bd-5a9b-a191-a9988ce68a9c",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0102"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8d2f2f2f-a2f3-4e9e-a166-efc0c1c20bd1/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8d2f2f2f-a2f3-4e9e-a166-efc0c1c20bd1/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/292556ef1b98e46a9561593b855cc698",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/292556ef1b98e46a9561593b855cc698",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bedaaabc-b4bd-5a9b-a191-a9988ce68a9c"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/292556ef1b98e46a9561593b855cc698/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/292556ef1b98e46a9561593b855cc698",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/05f904df-0451-523f-812f-49d9ef3b8190",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0103"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2ead928e-6d1b-45f2-80b6-26f23e64c437/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2ead928e-6d1b-45f2-80b6-26f23e64c437/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/9092df7f7bbdcc2c80084dc3dd7bc1c0",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/9092df7f7bbdcc2c80084dc3dd7bc1c0",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/05f904df-0451-523f-812f-49d9ef3b8190"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/9092df7f7bbdcc2c80084dc3dd7bc1c0/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/9092df7f7bbdcc2c80084dc3dd7bc1c0",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/520dcd9f-166d-5f87-8631-d10bdf20ac46",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0104"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/abb1de5e-03b6-4644-a9bc-98d702626abb/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/abb1de5e-03b6-4644-a9bc-98d702626abb/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ac5d65fb96eb6847f54665e8f23bc568",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ac5d65fb96eb6847f54665e8f23bc568",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/520dcd9f-166d-5f87-8631-d10bdf20ac46"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ac5d65fb96eb6847f54665e8f23bc568/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ac5d65fb96eb6847f54665e8f23bc568",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/56354a65-fd27-5779-af97-2e12d72d87fd",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0105"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/9e04a30b-7087-447a-8a9d-97201d6982c4/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/9e04a30b-7087-447a-8a9d-97201d6982c4/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/59028dec2acca899940024df17a86416",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/59028dec2acca899940024df17a86416",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/56354a65-fd27-5779-af97-2e12d72d87fd"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/59028dec2acca899940024df17a86416/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/59028dec2acca899940024df17a86416",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/61be9e2a-78b4-5e44-b64e-f1c256b69b0b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0106"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b53f1543-a3b7-40dc-9361-5c203ea6eb37/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b53f1543-a3b7-40dc-9361-5c203ea6eb37/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c089e148254d71ee864ef45f342c0e5d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c089e148254d71ee864ef45f342c0e5d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/61be9e2a-78b4-5e44-b64e-f1c256b69b0b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c089e148254d71ee864ef45f342c0e5d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c089e148254d71ee864ef45f342c0e5d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a5cd1d92-a98e-5967-86f5-bc5825dc9f60",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0107"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/69309561-375b-4dad-8b2e-da18a9cfc3df/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/69309561-375b-4dad-8b2e-da18a9cfc3df/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/7259014475f1d04661199c4ae4cc3cab",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/7259014475f1d04661199c4ae4cc3cab",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a5cd1d92-a98e-5967-86f5-bc5825dc9f60"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/7259014475f1d04661199c4ae4cc3cab/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/7259014475f1d04661199c4ae4cc3cab",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4fc22115-06da-59ed-b6d3-85b7de7f7ac9",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0108"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f75dca07-b329-4d43-871b-8951c56d96ca/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f75dca07-b329-4d43-871b-8951c56d96ca/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0eb459b9fda7f06cf924910a1fd4e0cd",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0eb459b9fda7f06cf924910a1fd4e0cd",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4fc22115-06da-59ed-b6d3-85b7de7f7ac9"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0eb459b9fda7f06cf924910a1fd4e0cd/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0eb459b9fda7f06cf924910a1fd4e0cd",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f566a63c-90c4-5762-931a-8fe67c63ac67",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0109"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/1c87c02d-6d57-433b-8bc6-be9d848af664/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/1c87c02d-6d57-433b-8bc6-be9d848af664/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8e5da1c7ce3fb2116703e24c5f36a917",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8e5da1c7ce3fb2116703e24c5f36a917",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f566a63c-90c4-5762-931a-8fe67c63ac67"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8e5da1c7ce3fb2116703e24c5f36a917/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8e5da1c7ce3fb2116703e24c5f36a917",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7ee5e732-69aa-5417-a8bc-022696ea0317",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0110"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e7d3bd40-af2e-4565-8061-5bf4d4d575b7/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e7d3bd40-af2e-4565-8061-5bf4d4d575b7/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/9fbdf51387bb39c1a302f5c0f4923a95",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/9fbdf51387bb39c1a302f5c0f4923a95",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7ee5e732-69aa-5417-a8bc-022696ea0317"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/9fbdf51387bb39c1a302f5c0f4923a95/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/9fbdf51387bb39c1a302f5c0f4923a95",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a6ca847e-c48c-59b8-82ac-b9043e35c790",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0111"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c918ecae-2ac6-430c-9f80-5476a1218c95/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c918ecae-2ac6-430c-9f80-5476a1218c95/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/519c4c40c1eb1e698ca84e7fd08bad6d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/519c4c40c1eb1e698ca84e7fd08bad6d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a6ca847e-c48c-59b8-82ac-b9043e35c790"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/519c4c40c1eb1e698ca84e7fd08bad6d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/519c4c40c1eb1e698ca84e7fd08bad6d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7d67a571-959f-5b5d-9723-56e29cf4f4bc",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0112"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4043a064-7e96-47a0-b445-4b4b6452fdf5/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4043a064-7e96-47a0-b445-4b4b6452fdf5/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/24ad9b375f858ef93d5f8196ca0c722e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/24ad9b375f858ef93d5f8196ca0c722e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7d67a571-959f-5b5d-9723-56e29cf4f4bc"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/24ad9b375f858ef93d5f8196ca0c722e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/24ad9b375f858ef93d5f8196ca0c722e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/da4b0897-c265-587d-b679-dd9c0a3272f1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0113"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/fdba833a-acb8-4207-9a94-4439afeb73e1/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/fdba833a-acb8-4207-9a94-4439afeb73e1/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/afcee019ff457417504df935711d602f",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/afcee019ff457417504df935711d602f",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/da4b0897-c265-587d-b679-dd9c0a3272f1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/afcee019ff457417504df935711d602f/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/afcee019ff457417504df935711d602f",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/06134c85-e2ca-5d81-b741-5f5791bcea2b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0114"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b5eee803-44f9-4ac4-9b7d-7078a0d5368e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b5eee803-44f9-4ac4-9b7d-7078a0d5368e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/5ea187f618c4a0d9fb5305c25fd1c286",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/5ea187f618c4a0d9fb5305c25fd1c286",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/06134c85-e2ca-5d81-b741-5f5791bcea2b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/5ea187f618c4a0d9fb5305c25fd1c286/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/5ea187f618c4a0d9fb5305c25fd1c286",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8134c289-23a8-5d70-8780-4f21ca74721f",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0115"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/49090022-c510-464a-aab1-2c91c9541642/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/49090022-c510-464a-aab1-2c91c9541642/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ea8b70448a7ebc1975d814e93f21ca5e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ea8b70448a7ebc1975d814e93f21ca5e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8134c289-23a8-5d70-8780-4f21ca74721f"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ea8b70448a7ebc1975d814e93f21ca5e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ea8b70448a7ebc1975d814e93f21ca5e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/89397aa0-0e05-5ee6-9ba3-9f64ad3a94e8",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0116"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4c3c02eb-80ac-4adf-bc93-f43d10d2df44/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4c3c02eb-80ac-4adf-bc93-f43d10d2df44/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/41e55a905afc20fcad3f46dd6e8d5ecc",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/41e55a905afc20fcad3f46dd6e8d5ecc",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/89397aa0-0e05-5ee6-9ba3-9f64ad3a94e8"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/41e55a905afc20fcad3f46dd6e8d5ecc/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/41e55a905afc20fcad3f46dd6e8d5ecc",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/e44226bd-5882-5654-9084-86154b79900a",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0117"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/21ca7770-bd88-4bfb-a4b9-b88848dcca31/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/21ca7770-bd88-4bfb-a4b9-b88848dcca31/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c77ebd903e743e918e65b588f38434d5",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c77ebd903e743e918e65b588f38434d5",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/e44226bd-5882-5654-9084-86154b79900a"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c77ebd903e743e918e65b588f38434d5/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c77ebd903e743e918e65b588f38434d5",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/802bc9a8-107e-5fa2-b971-6513335fc33d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0118"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/1d1f10f4-6371-4a52-96d8-304d731fefbb/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/1d1f10f4-6371-4a52-96d8-304d731fefbb/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/beb1c7381e75b4a74add40948e7d81e0",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/beb1c7381e75b4a74add40948e7d81e0",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/802bc9a8-107e-5fa2-b971-6513335fc33d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/beb1c7381e75b4a74add40948e7d81e0/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/beb1c7381e75b4a74add40948e7d81e0",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/3acc5d92-8715-5733-bc96-1b3b25c35e18",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0119"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/cb9abe82-b26a-403c-8146-d8979f08d4a9/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/cb9abe82-b26a-403c-8146-d8979f08d4a9/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e23ea878e5ecc42b3a72e464aaa3ea32",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e23ea878e5ecc42b3a72e464aaa3ea32",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/3acc5d92-8715-5733-bc96-1b3b25c35e18"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e23ea878e5ecc42b3a72e464aaa3ea32/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e23ea878e5ecc42b3a72e464aaa3ea32",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7210ea4d-e98d-577b-a703-b45d7c7c62e7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0120"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/a7e5cd79-db77-48cd-81d1-d5c91fbe1212/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/a7e5cd79-db77-48cd-81d1-d5c91fbe1212/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c33bd31f94700d7114103a70c2680066",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c33bd31f94700d7114103a70c2680066",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7210ea4d-e98d-577b-a703-b45d7c7c62e7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c33bd31f94700d7114103a70c2680066/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c33bd31f94700d7114103a70c2680066",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/249bebac-9ff4-5d5e-8914-7a2249cc8a0e",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0121"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d4ced301-a5a4-43bd-8c3a-0022444d82fe/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d4ced301-a5a4-43bd-8c3a-0022444d82fe/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/a825e2ee6be5fc4812860b37bd73b633",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/a825e2ee6be5fc4812860b37bd73b633",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/249bebac-9ff4-5d5e-8914-7a2249cc8a0e"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/a825e2ee6be5fc4812860b37bd73b633/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/a825e2ee6be5fc4812860b37bd73b633",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/7b75494a-1587-5878-b286-1c1596279808",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0122"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/784e28ff-c26c-4344-add6-f9a0c5c57bea/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/784e28ff-c26c-4344-add6-f9a0c5c57bea/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e3492392d7767eed5380f4b4dab76542",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e3492392d7767eed5380f4b4dab76542",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/7b75494a-1587-5878-b286-1c1596279808"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e3492392d7767eed5380f4b4dab76542/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e3492392d7767eed5380f4b4dab76542",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8c50d51b-7639-5135-85db-5e57b7169895",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0123"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e6862102-bd86-4487-bf21-7acf9fec8028/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e6862102-bd86-4487-bf21-7acf9fec8028/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d3a02df39957f2abe3719ea8d3dc731d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d3a02df39957f2abe3719ea8d3dc731d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8c50d51b-7639-5135-85db-5e57b7169895"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d3a02df39957f2abe3719ea8d3dc731d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d3a02df39957f2abe3719ea8d3dc731d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/72f953bb-59a4-5bfe-9fa2-d3734748c020",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0124"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/47552116-3722-47a6-bab9-e1c7fa6f51c3/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/47552116-3722-47a6-bab9-e1c7fa6f51c3/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3d1e7fa7b80913960dba12585d378f05",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3d1e7fa7b80913960dba12585d378f05",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/72f953bb-59a4-5bfe-9fa2-d3734748c020"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3d1e7fa7b80913960dba12585d378f05/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3d1e7fa7b80913960dba12585d378f05",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f7ce189c-53e8-558b-9ac3-b059a08391ef",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0125"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/1bb54baf-31c0-44ca-ba55-d93c9e295b0b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/1bb54baf-31c0-44ca-ba55-d93c9e295b0b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/87aa340298c53114a13692d2cbc66d4b",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/87aa340298c53114a13692d2cbc66d4b",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f7ce189c-53e8-558b-9ac3-b059a08391ef"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/87aa340298c53114a13692d2cbc66d4b/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/87aa340298c53114a13692d2cbc66d4b",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/316b7a43-5e4c-5cd3-adbb-45f63edae861",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0126"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/a6ec4220-57d5-429f-9abb-9242bdb47a36/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/a6ec4220-57d5-429f-9abb-9242bdb47a36/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2fb5accb2c858e78c991abf8cde29449",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2fb5accb2c858e78c991abf8cde29449",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/316b7a43-5e4c-5cd3-adbb-45f63edae861"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2fb5accb2c858e78c991abf8cde29449/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2fb5accb2c858e78c991abf8cde29449",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0c6d781f-31bb-5e16-8e34-be4b251404d8",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0127"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/ef9fbced-5a84-4f27-8ecb-45dccbc78e2c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/ef9fbced-5a84-4f27-8ecb-45dccbc78e2c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e25df2f8641343df9287dbbee5daee33",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e25df2f8641343df9287dbbee5daee33",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0c6d781f-31bb-5e16-8e34-be4b251404d8"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e25df2f8641343df9287dbbee5daee33/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e25df2f8641343df9287dbbee5daee33",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bd00c243-7a1a-5ccc-b334-3186eac48f13",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0128"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/564daa2b-f308-43b0-ac32-e67f09da765c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/564daa2b-f308-43b0-ac32-e67f09da765c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/f145b07e8e2713a6aa5cb1400c8122c9",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/f145b07e8e2713a6aa5cb1400c8122c9",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bd00c243-7a1a-5ccc-b334-3186eac48f13"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/f145b07e8e2713a6aa5cb1400c8122c9/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/f145b07e8e2713a6aa5cb1400c8122c9",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/64f852ed-7b9a-5bfc-97c9-5bfbd8306598",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0129"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/946c4b31-2bbb-4656-818d-1fddc19590fa/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/946c4b31-2bbb-4656-818d-1fddc19590fa/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/20fcfe0deef3c8d298f61be4405ef236",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/20fcfe0deef3c8d298f61be4405ef236",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/64f852ed-7b9a-5bfc-97c9-5bfbd8306598"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/20fcfe0deef3c8d298f61be4405ef236/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/20fcfe0deef3c8d298f61be4405ef236",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/240b7104-42f8-5a33-823d-4f339aa87f3a",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0130"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e253adcd-4d35-43bf-b12d-dbfae6b81a52/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e253adcd-4d35-43bf-b12d-dbfae6b81a52/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/70bbbf56f1f115e13c0ceda0618f01c0",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/70bbbf56f1f115e13c0ceda0618f01c0",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/240b7104-42f8-5a33-823d-4f339aa87f3a"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/70bbbf56f1f115e13c0ceda0618f01c0/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/70bbbf56f1f115e13c0ceda0618f01c0",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/ddaab609-d45a-57e1-8d8a-09c82b7eb749",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0131"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/215d21d9-143c-46ae-a30b-a5f2a2260f05/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/215d21d9-143c-46ae-a30b-a5f2a2260f05/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c531defa2606039af8d43c4fd69e5edb",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c531defa2606039af8d43c4fd69e5edb",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/ddaab609-d45a-57e1-8d8a-09c82b7eb749"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c531defa2606039af8d43c4fd69e5edb/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c531defa2606039af8d43c4fd69e5edb",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2cab2623-107f-5a56-841a-edce2dedab4b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0132"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/18fcab91-5008-4d42-b456-69c39a9260e0/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/18fcab91-5008-4d42-b456-69c39a9260e0/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d9163505533a06baffa129475c873bf9",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d9163505533a06baffa129475c873bf9",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2cab2623-107f-5a56-841a-edce2dedab4b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d9163505533a06baffa129475c873bf9/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d9163505533a06baffa129475c873bf9",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/de216adc-1509-5c61-81a8-6b3f442e4201",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0133"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/ac8cc576-c0c4-4b59-b31c-874d20eb0b4a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/ac8cc576-c0c4-4b59-b31c-874d20eb0b4a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/035e8c13fc8cadaf00d797af05082bc0",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/035e8c13fc8cadaf00d797af05082bc0",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/de216adc-1509-5c61-81a8-6b3f442e4201"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/035e8c13fc8cadaf00d797af05082bc0/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/035e8c13fc8cadaf00d797af05082bc0",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/03b56435-5f23-554d-a48e-d56eb6b0a004",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0134"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8bcb82de-14d8-4af1-840c-b4a1523cada4/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8bcb82de-14d8-4af1-840c-b4a1523cada4/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/96d3b5f74f4b9dcf94c876a7a0cfeba4",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/96d3b5f74f4b9dcf94c876a7a0cfeba4",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/03b56435-5f23-554d-a48e-d56eb6b0a004"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/96d3b5f74f4b9dcf94c876a7a0cfeba4/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/96d3b5f74f4b9dcf94c876a7a0cfeba4",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/65922e76-a742-5ddd-a82a-1ce32baa0ce1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0135"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d8a7e1c6-beec-4570-90fd-4fcb9ac7133b/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d8a7e1c6-beec-4570-90fd-4fcb9ac7133b/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ca38e976dae4f0965cb1294a86c9941e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ca38e976dae4f0965cb1294a86c9941e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/65922e76-a742-5ddd-a82a-1ce32baa0ce1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ca38e976dae4f0965cb1294a86c9941e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ca38e976dae4f0965cb1294a86c9941e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/51aae2e9-9b25-54fc-ba3d-fe3799e1b5fb",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0136"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b2f429d2-16ec-4928-9dd2-1984bd630833/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b2f429d2-16ec-4928-9dd2-1984bd630833/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/997c9938d1618bccda3c3d3c6c21e272",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/997c9938d1618bccda3c3d3c6c21e272",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/51aae2e9-9b25-54fc-ba3d-fe3799e1b5fb"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/997c9938d1618bccda3c3d3c6c21e272/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/997c9938d1618bccda3c3d3c6c21e272",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/57f975e2-3276-5e02-b232-3d2c751dd1c1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0137"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/e6680992-0af6-4d55-8ee4-287eaf41cb51/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/e6680992-0af6-4d55-8ee4-287eaf41cb51/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/46a368d5b1313e3e5a435ca2ecf290ea",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/46a368d5b1313e3e5a435ca2ecf290ea",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/57f975e2-3276-5e02-b232-3d2c751dd1c1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/46a368d5b1313e3e5a435ca2ecf290ea/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/46a368d5b1313e3e5a435ca2ecf290ea",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/ec1aaa11-fd63-5f67-828c-699f87bfd131",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0138"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/5c1048b9-c22d-4646-804d-7aa357f1b963/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/5c1048b9-c22d-4646-804d-7aa357f1b963/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/4aa7cf4e461e12daafd45cff069575bb",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/4aa7cf4e461e12daafd45cff069575bb",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/ec1aaa11-fd63-5f67-828c-699f87bfd131"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/4aa7cf4e461e12daafd45cff069575bb/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/4aa7cf4e461e12daafd45cff069575bb",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f57ae285-3621-5020-9c4b-0cb6d6540009",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0139"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/4c609ac1-4acc-485e-b6ad-88bdc5dd12bf/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/4c609ac1-4acc-485e-b6ad-88bdc5dd12bf/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0feb16597a4253e44f4bc52baa349182",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0feb16597a4253e44f4bc52baa349182",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f57ae285-3621-5020-9c4b-0cb6d6540009"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0feb16597a4253e44f4bc52baa349182/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0feb16597a4253e44f4bc52baa349182",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4dc6bf9f-59e5-55ec-a397-8a5ff3da2d5b",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0140"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/ba5bd854-3214-457a-8193-4e4d7565d750/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/ba5bd854-3214-457a-8193-4e4d7565d750/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/c1ab29b3aa1aafacd15829b5cea51df4",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/c1ab29b3aa1aafacd15829b5cea51df4",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4dc6bf9f-59e5-55ec-a397-8a5ff3da2d5b"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/c1ab29b3aa1aafacd15829b5cea51df4/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/c1ab29b3aa1aafacd15829b5cea51df4",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/0e5faf34-768e-52b5-a85c-39da0b0430ea",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0141"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2a7559a4-438b-4dcd-9fdd-24498337c193/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2a7559a4-438b-4dcd-9fdd-24498337c193/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/699b9219865caa1d72022d9e5cbbf1bd",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/699b9219865caa1d72022d9e5cbbf1bd",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/0e5faf34-768e-52b5-a85c-39da0b0430ea"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/699b9219865caa1d72022d9e5cbbf1bd/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/699b9219865caa1d72022d9e5cbbf1bd",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4c888689-1109-5252-9bd3-a9420d5d5b91",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0142"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/89ef576e-3a97-4277-83fd-ecaae934eddd/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/89ef576e-3a97-4277-83fd-ecaae934eddd/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/470c0293e99b362c5819a53386e2ded8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/470c0293e99b362c5819a53386e2ded8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4c888689-1109-5252-9bd3-a9420d5d5b91"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/470c0293e99b362c5819a53386e2ded8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/470c0293e99b362c5819a53386e2ded8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f8ce77be-5117-56c9-8561-9fdcce4c95a0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0143"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/55753dd0-6893-4e1f-987b-6294ee03be90/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/55753dd0-6893-4e1f-987b-6294ee03be90/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2280c632ca21da1aba59d3417229a39e",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2280c632ca21da1aba59d3417229a39e",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f8ce77be-5117-56c9-8561-9fdcce4c95a0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2280c632ca21da1aba59d3417229a39e/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2280c632ca21da1aba59d3417229a39e",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8a7d468a-052a-5eac-8809-d5d7469f10e7",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0144"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/6220f494-3784-4333-b55b-a3f2090cb654/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/6220f494-3784-4333-b55b-a3f2090cb654/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d7ba212cae6ced83285d08fe17dd2e78",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d7ba212cae6ced83285d08fe17dd2e78",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8a7d468a-052a-5eac-8809-d5d7469f10e7"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d7ba212cae6ced83285d08fe17dd2e78/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d7ba212cae6ced83285d08fe17dd2e78",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/de35a06e-4cd3-5434-87b1-4837450ab663",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0145"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d34e4538-d70f-40de-beef-1e7f13f1d71c/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d34e4538-d70f-40de-beef-1e7f13f1d71c/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/26150964cda571442e31c8999caacaea",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/26150964cda571442e31c8999caacaea",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/de35a06e-4cd3-5434-87b1-4837450ab663"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/26150964cda571442e31c8999caacaea/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/26150964cda571442e31c8999caacaea",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/2cc30dcc-f606-5aa0-8d16-c94f4a3c82a1",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0146"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c8c7e0b5-5494-461f-baf4-0253ca64f0d7/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c8c7e0b5-5494-461f-baf4-0253ca64f0d7/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/a9dba536f8ee16b9744b7ece0f538ea3",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/a9dba536f8ee16b9744b7ece0f538ea3",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/2cc30dcc-f606-5aa0-8d16-c94f4a3c82a1"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/a9dba536f8ee16b9744b7ece0f538ea3/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/a9dba536f8ee16b9744b7ece0f538ea3",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/19b33a5d-83c6-5266-9f79-43bc792ed350",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0147"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8161a851-d90f-4522-97be-db7b35f49f74/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8161a851-d90f-4522-97be-db7b35f49f74/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/8a4dfa387f68c9d55803f0b78978235d",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/8a4dfa387f68c9d55803f0b78978235d",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/19b33a5d-83c6-5266-9f79-43bc792ed350"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/8a4dfa387f68c9d55803f0b78978235d/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/8a4dfa387f68c9d55803f0b78978235d",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/ce98b5c5-e0cc-5221-9056-aef00fc57821",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0148"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/029fb739-3536-4a93-aabe-b7cab95bbbf2/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/029fb739-3536-4a93-aabe-b7cab95bbbf2/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/0dc005f677a07f33a5533f7a5bcda747",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/0dc005f677a07f33a5533f7a5bcda747",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/ce98b5c5-e0cc-5221-9056-aef00fc57821"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/0dc005f677a07f33a5533f7a5bcda747/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/0dc005f677a07f33a5533f7a5bcda747",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/a22463d0-64a2-5790-9829-472109daacb3",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0149"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/10a8ee8a-be24-4e40-945f-021bd33ad0e8/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/10a8ee8a-be24-4e40-945f-021bd33ad0e8/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/d1ff1490fd21406662af764acd221969",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/d1ff1490fd21406662af764acd221969",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/a22463d0-64a2-5790-9829-472109daacb3"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/d1ff1490fd21406662af764acd221969/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/d1ff1490fd21406662af764acd221969",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/f2f00c42-b6ca-5c4c-a4a3-f4744c170c46",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0150"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/feb4b4af-1157-4ca8-968d-cd1499fe9c97/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/feb4b4af-1157-4ca8-968d-cd1499fe9c97/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6e8a7fd795667f030be06d0b0c89ebb8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6e8a7fd795667f030be06d0b0c89ebb8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/f2f00c42-b6ca-5c4c-a4a3-f4744c170c46"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6e8a7fd795667f030be06d0b0c89ebb8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6e8a7fd795667f030be06d0b0c89ebb8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/e14ca2cb-7f14-5f7d-b7e9-d50b9ccc7a15",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0151"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/d2290b65-1efc-4fe4-8c93-c24fbd0c5323/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/d2290b65-1efc-4fe4-8c93-c24fbd0c5323/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/cf88e605fa45e4cbc9bd1f94eca52168",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/cf88e605fa45e4cbc9bd1f94eca52168",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/e14ca2cb-7f14-5f7d-b7e9-d50b9ccc7a15"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/cf88e605fa45e4cbc9bd1f94eca52168/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/cf88e605fa45e4cbc9bd1f94eca52168",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/e7a98436-7132-5a41-890a-0b1f2ebd5a87",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0152"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/3b1e5958-d887-4274-b5b7-1cdcf7b8f19a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/3b1e5958-d887-4274-b5b7-1cdcf7b8f19a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2a4ce69ae730c304ff9057d914dbab8a",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2a4ce69ae730c304ff9057d914dbab8a",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/e7a98436-7132-5a41-890a-0b1f2ebd5a87"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2a4ce69ae730c304ff9057d914dbab8a/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2a4ce69ae730c304ff9057d914dbab8a",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/bf7df4d8-fb49-552d-8bd1-17685f5a5d77",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0153"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f7e70548-0583-4d84-b533-98786be6eb51/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f7e70548-0583-4d84-b533-98786be6eb51/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/cb149fe1702a3e0445fabbead5c3cab9",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/cb149fe1702a3e0445fabbead5c3cab9",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/bf7df4d8-fb49-552d-8bd1-17685f5a5d77"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/cb149fe1702a3e0445fabbead5c3cab9/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/cb149fe1702a3e0445fabbead5c3cab9",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/1cfb7e0e-6e9c-5003-bed7-298c978cace3",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0154"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/b56ba4bb-ae56-4b2e-b8b8-cd857003569d/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/b56ba4bb-ae56-4b2e-b8b8-cd857003569d/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/ec0770736edf714f606a6e8f9c036535",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/ec0770736edf714f606a6e8f9c036535",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/1cfb7e0e-6e9c-5003-bed7-298c978cace3"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/ec0770736edf714f606a6e8f9c036535/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/ec0770736edf714f606a6e8f9c036535",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/3139caff-3ee4-5639-97b2-cf3a3ddd987d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0155"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/8d3d8c1f-93c2-490d-9a35-da3bfcbb8ff0/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/8d3d8c1f-93c2-490d-9a35-da3bfcbb8ff0/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/e3cff57c892d15d11a0f915a16891154",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/e3cff57c892d15d11a0f915a16891154",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/3139caff-3ee4-5639-97b2-cf3a3ddd987d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/e3cff57c892d15d11a0f915a16891154/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/e3cff57c892d15d11a0f915a16891154",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/c72a1862-f690-528c-9c86-e20eee3c0db5",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0156"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/2af120c1-ebed-4892-a267-b3854b58ee8e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/2af120c1-ebed-4892-a267-b3854b58ee8e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/1044a8deadbdd9e0ce8b71f337bb2586",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/1044a8deadbdd9e0ce8b71f337bb2586",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/c72a1862-f690-528c-9c86-e20eee3c0db5"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/1044a8deadbdd9e0ce8b71f337bb2586/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/1044a8deadbdd9e0ce8b71f337bb2586",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/8502a249-2ad4-56fd-9467-d852a9632b81",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0157"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f3ac1422-6f4c-43ce-b696-63ada2ff731a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f3ac1422-6f4c-43ce-b696-63ada2ff731a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/2b0ac61186ae9b3437e234e0b8ff2059",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/2b0ac61186ae9b3437e234e0b8ff2059",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/8502a249-2ad4-56fd-9467-d852a9632b81"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/2b0ac61186ae9b3437e234e0b8ff2059/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/2b0ac61186ae9b3437e234e0b8ff2059",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/d01e4e89-3aef-5aea-9dfe-18e19508c800",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0158"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/7b6dba21-7ce0-4482-a2d3-086f015c413f/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/7b6dba21-7ce0-4482-a2d3-086f015c413f/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/65ea0380078709ef8e19540b579e7f23",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/65ea0380078709ef8e19540b579e7f23",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/d01e4e89-3aef-5aea-9dfe-18e19508c800"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/65ea0380078709ef8e19540b579e7f23/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/65ea0380078709ef8e19540b579e7f23",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/ff0f68e2-c109-53f9-8585-726b555122a6",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0159"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/89e18b58-69a5-45da-b5d8-9bb3bb454f82/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/89e18b58-69a5-45da-b5d8-9bb3bb454f82/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3ffed9a523251cf268a738d3d4e27078",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3ffed9a523251cf268a738d3d4e27078",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/ff0f68e2-c109-53f9-8585-726b555122a6"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3ffed9a523251cf268a738d3d4e27078/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3ffed9a523251cf268a738d3d4e27078",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/d0cbee1c-5426-5c73-916c-6af2265a3d81",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0160"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/0c12a007-1c4c-4273-92ac-e0525f8d9bcc/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/0c12a007-1c4c-4273-92ac-e0525f8d9bcc/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/653f6eb448229097cb46288e9839dfde",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/653f6eb448229097cb46288e9839dfde",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/d0cbee1c-5426-5c73-916c-6af2265a3d81"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/653f6eb448229097cb46288e9839dfde/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/653f6eb448229097cb46288e9839dfde",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/4abe03fe-6fd3-5876-af3a-3b71c50fc04d",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0161"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/c958baab-af55-424a-83ae-7418266f9897/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/c958baab-af55-424a-83ae-7418266f9897/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/dc9c148445fc176f546861a767486991",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/dc9c148445fc176f546861a767486991",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/4abe03fe-6fd3-5876-af3a-3b71c50fc04d"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/dc9c148445fc176f546861a767486991/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/dc9c148445fc176f546861a767486991",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/33a00b70-2db1-5308-857a-28a3396842c0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0162"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/40811c50-b310-46d1-bc2b-f584bc2975f0/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/40811c50-b310-46d1-bc2b-f584bc2975f0/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/71649a9c83d7f6bba7bcbd2edd8e403c",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/71649a9c83d7f6bba7bcbd2edd8e403c",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/33a00b70-2db1-5308-857a-28a3396842c0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/71649a9c83d7f6bba7bcbd2edd8e403c/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/71649a9c83d7f6bba7bcbd2edd8e403c",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/381df0a0-8967-5eeb-9f67-7904794288da",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0163"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/f7a4507e-2891-42c6-a414-72cb4827d22e/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/f7a4507e-2891-42c6-a414-72cb4827d22e/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/3abb222a3a5f12c214bfc0b08be297b8",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/3abb222a3a5f12c214bfc0b08be297b8",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/381df0a0-8967-5eeb-9f67-7904794288da"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/3abb222a3a5f12c214bfc0b08be297b8/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/3abb222a3a5f12c214bfc0b08be297b8",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/01a56bf5-5845-59c3-a779-e443ccded0a0",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0164"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/983e59b7-dd11-4707-85d1-f7fad5409530/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/983e59b7-dd11-4707-85d1-f7fad5409530/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/6065d941cb31307a4a0efe732a045eac",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/6065d941cb31307a4a0efe732a045eac",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/01a56bf5-5845-59c3-a779-e443ccded0a0"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/6065d941cb31307a4a0efe732a045eac/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/6065d941cb31307a4a0efe732a045eac",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://gsh.etu.wiki/3/canvas/cd101ada-fbf0-5d25-ab40-db48269778fd",
+      "type": "Canvas",
+      "label": {
+        "zh-Hant": [
+          "0165"
+        ]
+      },
+      "height": 1187,
+      "width": 1500,
+      "items": [
+        {
+          "id": "https://gsh.etu.wiki/3/annopage/839293e6-ad9e-46f5-8552-8cdd02e3665a/motivation/p",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://gsh.etu.wiki/3/anno/839293e6-ad9e-46f5-8552-8cdd02e3665a/motivation/p",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://gsh.etu.wiki/3/image/54ba2452b62493bddea0bf2d8a43fa14",
+                "type": "Image",
+                "service": [
+                  {
+                    "id": "https://gsh.etu.wiki/3/image/54ba2452b62493bddea0bf2d8a43fa14",
+                    "type": "ImageService3",
+                    "profile": "level2"
+                  }
+                ]
+              },
+              "target": "https://gsh.etu.wiki/3/canvas/cd101ada-fbf0-5d25-ab40-db48269778fd"
+            }
+          ]
+        }
+      ],
+      "annotations": [],
+      "thumbnail": [
+        {
+          "id": "https://gsh.etu.wiki/3/image/54ba2452b62493bddea0bf2d8a43fa14/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "service": [
+            {
+              "id": "https://gsh.etu.wiki/3/image/54ba2452b62493bddea0bf2d8a43fa14",
+              "type": "ImageService3",
+              "profile": "level2"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "label": {
+    "zh-Hant": [
+      "清 李漁 芥子園畫傳龍穀大學藏本"
+    ],
+    "zh-CN": [
+      "清 李渔 芥子园画传龙谷大学藏本"
+    ],
+    "en": [
+      "Qing Dynasty Li Yu The Mustard Seed Garden Manual of Painting, held in the collection of Longgu University."
+    ],
+    "ja": [
+      "清 李漁 芥子園画伝竜穀大学蔵本"
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "zh-Hant": [
+          "朝代"
+        ],
+        "zh-CN": [
+          "朝代"
+        ],
+        "en": [
+          "Dynasty"
+        ],
+        "ja": [
+          "王朝"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "清"
+        ],
+        "zh-CN": [
+          "清"
+        ],
+        "en": [
+          "Qing Dynasty"
+        ],
+        "ja": [
+          "清"
+        ]
+      }
+    },
+    {
+      "label": {
+        "zh-Hant": [
+          "創建者"
+        ],
+        "zh-CN": [
+          "创建者"
+        ],
+        "en": [
+          "Creator"
+        ],
+        "ja": [
+          "創設者"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "李漁"
+        ],
+        "zh-CN": [
+          "李渔"
+        ],
+        "en": [
+          "Li Yu"
+        ],
+        "ja": [
+          "李漁"
+        ]
+      }
+    },
+    {
+      "label": {
+        "zh-Hant": [
+          "題名"
+        ],
+        "zh-CN": [
+          "题名"
+        ],
+        "en": [
+          "Title"
+        ],
+        "ja": [
+          "タイトル"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "芥子園畫傳龍穀大學藏本"
+        ],
+        "zh-CN": [
+          "芥子园画传龙谷大学藏本"
+        ],
+        "en": [
+          "The Mustard Seed Garden Manual of Painting, held in the collection of Longgu University."
+        ],
+        "ja": [
+          "芥子園画伝竜穀大学蔵本"
+        ]
+      }
+    },
+    {
+      "label": {
+        "zh-Hant": [
+          "格式"
+        ],
+        "zh-CN": [
+          "格式"
+        ],
+        "en": [
+          "Format"
+        ],
+        "ja": [
+          "フォーマット"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "籍"
+        ],
+        "zh-CN": [
+          "籍"
+        ],
+        "en": [
+          "membership"
+        ],
+        "ja": [
+          "会員"
+        ]
+      }
+    },
+    {
+      "label": {
+        "zh-Hant": [
+          "類型"
+        ],
+        "zh-CN": [
+          "类型"
+        ],
+        "en": [
+          "Type"
+        ],
+        "ja": [
+          "タイプ"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "繪畫"
+        ],
+        "zh-CN": [
+          "绘画"
+        ],
+        "en": [
+          "painting"
+        ],
+        "ja": [
+          "絵画"
+        ]
+      }
+    },
+    {
+      "label": {
+        "zh-Hant": [
+          "主題"
+        ],
+        "zh-CN": [
+          "主题"
+        ],
+        "en": [
+          "Subject"
+        ],
+        "ja": [
+          "テーマ"
+        ]
+      },
+      "value": {
+        "zh-Hant": [
+          "山水"
+        ],
+        "zh-CN": [
+          "山水"
+        ],
+        "en": [
+          "landscape"
+        ],
+        "ja": [
+          "風景"
+        ]
+      }
+    }
+  ],
+  "type": "Manifest",
+  "viewingDirection": "right-to-left"
+}

--- a/src/components/Viewer/Media/Controls.tsx
+++ b/src/components/Viewer/Media/Controls.tsx
@@ -15,6 +15,7 @@ interface ControlsProps {
   handleFilter: (arg0: string) => void;
   activeIndex: number;
   canvasLength: number;
+  isRtlPaged?: boolean;
 }
 
 const PreviousIcon = ({ title }: { title: string }) => {
@@ -74,6 +75,7 @@ const Controls: React.FC<ControlsProps> = ({
   handleFilter,
   activeIndex,
   canvasLength,
+  isRtlPaged = false,
 }) => {
   const [toggleFilter, setToggleFilter] = useState<boolean>(false);
   const [isNextDisabled, setIsNextDisabled] = useState<boolean>(false);
@@ -126,24 +128,48 @@ const Controls: React.FC<ControlsProps> = ({
           />
         )}
         {!toggleFilter && (
-          <Direction className="clover-viewer-media-navigation">
-            <Button
-              onClick={() => handleCanvasToggle(-1)}
-              disabled={isPreviousDisabled}
-              type="button"
-            >
-              <PreviousIcon title={t("commonPrevious")} />
-            </Button>
-            <span>
-              {activeIndex + 1} <em>/</em> {canvasLength}
-            </span>
-            <Button
-              onClick={() => handleCanvasToggle(1)}
-              disabled={isNextDisabled}
-              type="button"
-            >
-              <NextIcon title={t("commonNext")} />
-            </Button>
+          <Direction className="clover-viewer-media-navigation" data-rtl-paged={isRtlPaged}>
+            {isRtlPaged ? (
+              <>
+                <Button
+                  onClick={() => handleCanvasToggle(1)}
+                  disabled={isNextDisabled}
+                  type="button"
+                >
+                  <PreviousIcon title={t("commonNext")} />
+                </Button>
+                <span>
+                  {activeIndex + 1} <em>/</em> {canvasLength}
+                </span>
+                <Button
+                  onClick={() => handleCanvasToggle(-1)}
+                  disabled={isPreviousDisabled}
+                  type="button"
+                >
+                  <NextIcon title={t("commonPrevious")} />
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  onClick={() => handleCanvasToggle(-1)}
+                  disabled={isPreviousDisabled}
+                  type="button"
+                >
+                  <PreviousIcon title={t("commonPrevious")} />
+                </Button>
+                <span>
+                  {activeIndex + 1} <em>/</em> {canvasLength}
+                </span>
+                <Button
+                  onClick={() => handleCanvasToggle(1)}
+                  disabled={isNextDisabled}
+                  type="button"
+                >
+                  <NextIcon title={t("commonNext")} />
+                </Button>
+              </>
+            )}
           </Direction>
         )}
         <Button

--- a/src/components/Viewer/Media/Media.tsx
+++ b/src/components/Viewer/Media/Media.tsx
@@ -32,7 +32,12 @@ const Media: React.FC<MediaProps> = ({ items }) => {
   const { t } = useCloverTranslation();
   const dispatch: any = useViewerDispatch();
   const state: ViewerContextStore = useViewerState();
-  const { activeCanvas, vault, sequence } = state;
+  const { activeCanvas, isPaged, vault, sequence, viewingDirection } = state;
+
+  /**
+   * Determine if RTL paged navigation should be used
+   */
+  const isRtlPaged = isPaged && viewingDirection === "right-to-left";
 
   const [filter, setFilter] = useState<string>("");
   const [mediaItems, setMediaItems] = useState<Array<CanvasEntity>>([]);
@@ -110,6 +115,7 @@ const Media: React.FC<MediaProps> = ({ items }) => {
         handleCanvasToggle={handleCanvasToggle}
         activeIndex={activeIndex}
         canvasLength={items.length}
+        isRtlPaged={isRtlPaged}
       />
       <StyledSequence
         aria-label={t("media.selectItem")}
@@ -117,7 +123,9 @@ const Media: React.FC<MediaProps> = ({ items }) => {
         data-active-canvas={items[activeIndex].id}
         data-canvas-length={items.length}
         data-filter={filter}
+        data-rtl-paged={isRtlPaged}
         ref={scrollRef}
+        style={{ direction: isRtlPaged ? "rtl" : "ltr" }}
       >
         {sequence[1]
           .filter((groups) => {

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -47,11 +47,19 @@ const Painting: React.FC<PaintingProps> = ({
     customDisplays,
     contentStateAnnotation,
     informationPanelResource,
+    isPaged,
     openSeadragonViewer,
     vault,
     viewerId,
+    viewingDirection,
     visibleCanvases,
   } = useViewerState();
+
+  /**
+   * Determine if canvases should be displayed in reverse order
+   * for right-to-left viewing direction when behavior is paged
+   */
+  const isRtlPaged = isPaged && viewingDirection === "right-to-left";
   const [annotations, setAnnotations] = React.useState<
     Array<{
       annotation: Annotation;
@@ -208,7 +216,15 @@ const Painting: React.FC<PaintingProps> = ({
     if (isMedia) {
       return;
     } else {
-      const body = visibleCanvases
+      /**
+       * For RTL paged content, we reverse the order of visible canvases
+       * so that the rightmost canvas appears on the left side of the display
+       */
+      const orderedCanvases = isRtlPaged
+        ? [...visibleCanvases].reverse()
+        : visibleCanvases;
+
+      const body = orderedCanvases
         .map((canvas) => {
           const canvasId = canvas.id;
           const painting = getPaintingResource(vault, canvasId);
@@ -216,7 +232,7 @@ const Painting: React.FC<PaintingProps> = ({
         })
         .filter(Boolean) as LabeledIIIFExternalWebResource[];
 
-      const placeholders = visibleCanvases
+      const placeholders = orderedCanvases
         .map((entry) => {
           const canvasId = entry.id;
 
@@ -239,6 +255,7 @@ const Painting: React.FC<PaintingProps> = ({
   }, [
     annotationIndex,
     activeCanvas,
+    isRtlPaged,
     visibleCanvases,
     isMedia,
     normalizedCanvas,

--- a/src/components/Viewer/Painting/Placeholder.tsx
+++ b/src/components/Viewer/Painting/Placeholder.tsx
@@ -5,6 +5,11 @@ import { InternationalString } from "@iiif/presentation-3";
 import { PlaceholderStyled } from "./Placeholder.styled";
 import { useViewerState } from "src/context/viewer-context";
 
+/**
+ * Note: The items array passed to this component is already ordered
+ * correctly for RTL paged content by the parent Painting component.
+ */
+
 interface Props {
   isActive: boolean;
   isMedia: boolean;

--- a/src/components/Viewer/Player/Player.test.tsx
+++ b/src/components/Viewer/Player/Player.test.tsx
@@ -7,7 +7,7 @@ import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
 import Player from "src/components/Viewer/Player/Player";
 import React from "react";
 import { Vault } from "@iiif/helpers/vault";
-import { ViewerProvider } from "src/context/viewer-context";
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
 import manifestSimpleAudio from "src/fixtures/viewer/player/manifest-simple-audio.json";
 import manifestStreaming from "src/fixtures/viewer/player/manifest-streaming-audio.json";
 
@@ -60,18 +60,12 @@ describe("Player component", () => {
     render(
       <ViewerProvider
         initialState={{
+          ...defaultState,
           activeCanvas:
             "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d2a423b1-6b5e-45cb-9956-46a99cd62cfd?as=iiif/canvas/access/0",
           activeManifest:
             "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d2a423b1-6b5e-45cb-9956-46a99cd62cfd?as=iiif",
-          collection: {},
-          configOptions: {},
-          customDisplays: [],
-          plugins: [],
-          isInformationOpen: false,
-          isLoaded: false,
           vault,
-          openSeadragonViewer: null,
         }}
       >
         <Player {...props} />
@@ -121,18 +115,12 @@ describe("Player component", () => {
     render(
       <ViewerProvider
         initialState={{
+          ...defaultState,
           activeCanvas:
             "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d2a423b1-6b5e-45cb-9956-46a99cd62cfd?as=iiif/canvas/access/0",
           activeManifest:
             "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d2a423b1-6b5e-45cb-9956-46a99cd62cfd?as=iiif",
-          collection: {},
-          configOptions: {},
-          customDisplays: [],
-          plugins: [],
-          isInformationOpen: false,
-          isLoaded: false,
           vault,
-          openSeadragonViewer: null,
         }}
       >
         <Player {...props} />
@@ -179,18 +167,12 @@ describe("Player component", () => {
     render(
       <ViewerProvider
         initialState={{
+          ...defaultState,
           activeCanvas:
             "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas",
           activeManifest:
             "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json",
-          collection: {},
-          configOptions: {},
-          customDisplays: [],
-          plugins: [],
-          isInformationOpen: false,
-          isLoaded: false,
           vault,
-          openSeadragonViewer: null,
         }}
       >
         <Player {...props} />

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -212,6 +212,27 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
             type: "updateManifestSequence",
             sequence,
           });
+
+          /**
+           * Extract viewingDirection from manifest (defaults to left-to-right)
+           * and check if behavior includes "paged"
+           */
+          // @ts-ignore - viewingDirection exists on IIIF manifest but may not be typed
+          const viewingDirection = data.viewingDirection || "left-to-right";
+          // @ts-ignore - behavior exists on IIIF manifest but may not be typed
+          const behavior = data.behavior || [];
+          const isPaged = Array.isArray(behavior)
+            ? behavior.includes("paged")
+            : behavior === "paged";
+
+          dispatch({
+            type: "updateViewingDirection",
+            viewingDirection,
+          });
+          dispatch({
+            type: "updateIsPaged",
+            isPaged,
+          });
         })
         .catch((error: Error) => {
           console.error(`Manifest failed to load: ${error}`);

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -177,6 +177,12 @@ export type PluginConfig = {
   };
 };
 
+export type ViewingDirection =
+  | "left-to-right"
+  | "right-to-left"
+  | "top-to-bottom"
+  | "bottom-to-top";
+
 export interface ViewerContextStore {
   activeCanvas: string;
   activeManifest: string;
@@ -193,9 +199,11 @@ export interface ViewerContextStore {
   isAutoScrolling?: boolean;
   isInformationOpen: boolean;
   isLoaded: boolean;
+  isPaged: boolean;
   isUserScrolling?: number | undefined;
   sequence: [Reference<"Canvas">[], number[][]];
   vault: Vault;
+  viewingDirection: ViewingDirection;
   openSeadragonViewer: OpenSeadragon.Viewer | null;
   openSeadragonId?: string;
   viewerId?: string;
@@ -215,12 +223,14 @@ export interface ViewerAction {
   isAutoScrolling: boolean;
   isInformationOpen: boolean;
   isLoaded: boolean;
+  isPaged: boolean;
   isUserScrolling: number | undefined;
   manifestId: string;
   OSDImageLoaded?: boolean;
   player: HTMLVideoElement | HTMLAudioElement | null;
   sequence: [Reference<"Canvas">[], number[][]];
   vault: Vault;
+  viewingDirection: ViewingDirection;
   openSeadragonViewer: OpenSeadragon.Viewer;
   viewerId: string;
   visibleCanvases: Array<Reference<"Canvas">>;
@@ -304,9 +314,11 @@ export const createDefaultState = (): ViewerContextStore => ({
   // Respect explicit false; default to true only when undefined
   isInformationOpen: defaultConfigOptions?.informationPanel?.open ?? true,
   isLoaded: false,
+  isPaged: false,
   isUserScrolling: undefined,
   sequence: [[], []],
   vault: new Vault(),
+  viewingDirection: "left-to-right",
   openSeadragonViewer: null,
   viewerId: uuidv4(),
   visibleCanvases: [],
@@ -436,6 +448,18 @@ function viewerReducer(state: ViewerContextStore, action: ViewerAction) {
       return {
         ...state,
         visibleCanvases: action.visibleCanvases,
+      };
+    }
+    case "updateViewingDirection": {
+      return {
+        ...state,
+        viewingDirection: action.viewingDirection,
+      };
+    }
+    case "updateIsPaged": {
+      return {
+        ...state,
+        isPaged: action.isPaged,
       };
     }
     default: {


### PR DESCRIPTION
- Add viewingDirection and isPaged to viewer context store
- Extract viewingDirection and behavior from manifest when loading
- Reverse visible canvases order for RTL paged content in OSD display
- Swap navigation button positions for RTL paged content
- Apply RTL direction to thumbnail strip
- Add test manifest for RTL paged behavior