### PR TITLE
Add support for compounded duration and auto-advance.

### DIFF
--- a/pages/docs/thumbnail.mdx
+++ b/pages/docs/thumbnail.mdx
@@ -76,6 +76,7 @@ Thumbnails are rendered to a relative HTML `<img>` or `<video>` element depenpde
 | ----------- | ------------------------------------------------------------ | ------- | -------- |
 | `as`        | `img`, `video`                                               | `img`   | --       |
 | `thumbnail` | [thumbnail](https://iiif.io/api/presentation/3.0/#thumbnail) | --      | **Yes**  |
+| `objectFit` | `contain`, `cover`                                           | `cover` | --       |
 | `className` | `string`, `undefined`                                        | --      | --       |
 | `style`     | `CSSProperties`, `undefined`                                 | --      | --       |
 | `lang`      | `string`, `undefined`                                        | --      | --       |

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -103,18 +103,38 @@ const OSD: React.FC<OSDProps> = ({
   useEffect(() => {
     if (!osdUri.length || !openSeadragon) return;
 
-    // For multi-image (paged) views, close immediately — bounds calculation
-    // in getBaseItemWithRetry requires a clean world. For single images, capture
-    // old items and remove them only after the new image loads, eliminating the
-    // blank flash between frames.
+    // Only defer old-image removal for a true one-for-one swap: exactly 1 image
+    // currently in the world and exactly 1 new image being loaded. This eliminates
+    // the blank flash on single-image swaps (animation frames, canvas navigation)
+    // while keeping the original close() behaviour for every other case (initial
+    // load, multi-image/paged views, count mismatches).
     const itemsToRemove = [];
-    if (osdUri.length > 1) {
+    const isSingleImageSwap =
+      openSeadragon.world.getItemCount() === 1 && osdUri.length === 1;
+    if (!isSingleImageSwap) {
       openSeadragon.close();
     } else {
-      for (let i = 0; i < openSeadragon.world.getItemCount(); i++) {
-        itemsToRemove.push(openSeadragon.world.getItemAt(i));
-      }
+      itemsToRemove.push(openSeadragon.world.getItemAt(0));
     }
+
+    const expectedCount = osdUri.length;
+    let loadedCount = 0;
+
+    const fitBoundsOnAllLoaded = () => {
+      loadedCount++;
+      if (!isFirstImageLoad.current || loadedCount < expectedCount) return;
+      isFirstImageLoad.current = false;
+      const maxRetries = 3;
+      let attempts = 0;
+      const tryFit = () => {
+        if (attempts >= maxRetries) return;
+        const bounds = openSeadragon?.world.getHomeBounds();
+        if (bounds) openSeadragon?.viewport.fitBounds(bounds, true);
+        attempts++;
+        setTimeout(tryFit, 50);
+      };
+      tryFit();
+    };
 
     const load = async () => {
       switch (imageType) {
@@ -161,6 +181,7 @@ const OSD: React.FC<OSDProps> = ({
                   itemsToRemove.forEach((item) =>
                     openSeadragon.world.removeItem(item),
                   );
+                  fitBoundsOnAllLoaded();
                   setOsdDrawn((prev) => [...prev, url]);
                   if (typeof dispatch === "function") {
                     dispatch({
@@ -210,6 +231,7 @@ const OSD: React.FC<OSDProps> = ({
                   itemsToRemove.forEach((item) =>
                     openSeadragon.world.removeItem(item),
                   );
+                  fitBoundsOnAllLoaded();
                   setOsdDrawn((prev) => [...prev, url]);
                   if (typeof dispatch === "function") {
                     dispatch({
@@ -237,23 +259,6 @@ const OSD: React.FC<OSDProps> = ({
 
   useEffect(() => {
     if (!osdDrawn.length) return;
-
-    if (isFirstImageLoad.current) {
-      isFirstImageLoad.current = false;
-      const maxRetries = 3;
-      let attempts = 0;
-      const fitBounds = () => {
-        if (attempts < maxRetries) {
-          const bounds = openSeadragon?.world.getHomeBounds();
-          if (bounds) {
-            openSeadragon?.viewport.fitBounds(bounds, true);
-          }
-          attempts++;
-          setTimeout(fitBounds, 50);
-        }
-      };
-      fitBounds();
-    }
 
     // handles zoom to annotation on click
     openSeadragon?.addHandler("canvas-click", (event) => {

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -103,7 +103,18 @@ const OSD: React.FC<OSDProps> = ({
   useEffect(() => {
     if (!osdUri.length || !openSeadragon) return;
 
-    openSeadragon.close(); // remove previous images
+    // For multi-image (paged) views, close immediately — bounds calculation
+    // in getBaseItemWithRetry requires a clean world. For single images, capture
+    // old items and remove them only after the new image loads, eliminating the
+    // blank flash between frames.
+    const itemsToRemove = [];
+    if (osdUri.length > 1) {
+      openSeadragon.close();
+    } else {
+      for (let i = 0; i < openSeadragon.world.getItemCount(); i++) {
+        itemsToRemove.push(openSeadragon.world.getItemAt(i));
+      }
+    }
 
     const load = async () => {
       switch (imageType) {
@@ -147,6 +158,9 @@ const OSD: React.FC<OSDProps> = ({
                 y: 0,
                 height,
                 success: () => {
+                  itemsToRemove.forEach((item) =>
+                    openSeadragon.world.removeItem(item),
+                  );
                   setOsdDrawn((prev) => [...prev, url]);
                   if (typeof dispatch === "function") {
                     dispatch({
@@ -193,6 +207,9 @@ const OSD: React.FC<OSDProps> = ({
                 y: 0,
                 height,
                 success: () => {
+                  itemsToRemove.forEach((item) =>
+                    openSeadragon.world.removeItem(item),
+                  );
                   setOsdDrawn((prev) => [...prev, url]);
                   if (typeof dispatch === "function") {
                     dispatch({

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -60,6 +60,7 @@ const OSD: React.FC<OSDProps> = ({
   >([]);
   const dispatch: any = useViewerDispatch();
   const initializeOSD = useRef(false);
+  const isFirstImageLoad = useRef(true);
 
   const annotationClassName = "clover-iiif-image-openseadragon-annotation";
 
@@ -218,7 +219,10 @@ const OSD: React.FC<OSDProps> = ({
   }, [osdUri, imageType, openSeadragon]);
 
   useEffect(() => {
-    if (osdDrawn) {
+    if (!osdDrawn.length) return;
+
+    if (isFirstImageLoad.current) {
+      isFirstImageLoad.current = false;
       const maxRetries = 3;
       let attempts = 0;
       const fitBounds = () => {
@@ -232,9 +236,10 @@ const OSD: React.FC<OSDProps> = ({
         }
       };
       fitBounds();
+    }
 
-      // handles zoom to annotation on click
-      openSeadragon?.addHandler("canvas-click", (event) => {
+    // handles zoom to annotation on click
+    openSeadragon?.addHandler("canvas-click", (event) => {
         const overlay: Overlay = openSeadragon?.getOverlayById(
           event.originalTarget.id,
         );
@@ -251,7 +256,6 @@ const OSD: React.FC<OSDProps> = ({
           return (event.preventDefaultAction = true);
         }
       });
-    }
   }, [osdDrawn]);
 
   useEffect(() => {

--- a/src/components/Image/OSD/defaults.ts
+++ b/src/components/Image/OSD/defaults.ts
@@ -25,6 +25,7 @@ function defaultOpenSeadragonConfiguration(
       pinchToZoom: true,
       scrollToZoom: false,
     },
+    preserveViewport: true,
   };
 }
 

--- a/src/components/Viewer/InformationPanel/About/About.tsx
+++ b/src/components/Viewer/InformationPanel/About/About.tsx
@@ -74,7 +74,11 @@ const About: React.FC = () => {
   return (
     <AboutStyled>
       <AboutContent>
-        <Thumbnail thumbnail={thumbnail} label={manifest.label} />
+        <Thumbnail
+          thumbnail={thumbnail}
+          label={manifest.label}
+          objectFit="contain"
+        />
         <Summary summary={manifest.summary} />
         <Metadata metadata={manifest.metadata} />
         <RequiredStatement requiredStatement={manifest.requiredStatement} />

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -1,19 +1,15 @@
 import { styled } from "src/styles/stitches.config";
 
 const AnimationControlsWrapper = styled("div", {
-  position: "absolute",
-  bottom: "1rem",
-  left: "50%",
-  transform: "translateX(-50%)",
   display: "flex",
+  alignSelf: "center",
+  flexShrink: "0",
   alignItems: "center",
   gap: "0.25rem",
-  backgroundColor: "$accentAlt",
   borderRadius: "2rem",
   boxShadow: "5px 5px 5px #0003",
   color: "$secondary",
   padding: "0",
-  zIndex: "$1",
 });
 
 const AnimationButton = styled("button", {
@@ -25,21 +21,21 @@ const AnimationButton = styled("button", {
   padding: "0",
   margin: "0",
   borderRadius: "2rem",
-  backgroundColor: "$accent",
   color: "$secondary",
   cursor: "pointer",
   transition: "$all",
   flexShrink: "0",
+  opacity: "0.75",
 
   svg: {
-    height: "60%",
-    width: "60%",
-    padding: "20%",
+    height: "52%",
+    width: "52%",
+    padding: "24%",
     fill: "$secondary",
     stroke: "$secondary",
     opacity: "1",
-    filter: "drop-shadow(5px 5px 5px #000D)",
-    boxSizing: "border-box",
+    boxSizing: "content-box",
+    display: "block",
     transition: "$all",
   },
 
@@ -47,6 +43,14 @@ const AnimationButton = styled("button", {
     backgroundColor: "transparent",
     boxShadow: "none",
     svg: { opacity: "0.25" },
+  },
+
+  "&:not(:disabled):hover": {
+    opacity: "1",
+
+    svg: {
+      opacity: "1",
+    },
   },
 });
 
@@ -57,6 +61,7 @@ const AnimationCounter = styled("span", {
   fontWeight: "bold",
   gap: "0.25rem",
   whiteSpace: "nowrap",
+  fontFamily: "monospace",
 
   em: {
     opacity: "0.25",

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -2,10 +2,15 @@ import { styled } from "src/styles/stitches.config";
 
 const AnimationBar = styled("div", {
   display: "flex",
+  flexDirection: "column",
+  gap: "0.3rem",
+});
+
+const AnimationControlsRow = styled("div", {
+  display: "flex",
   flexDirection: "row",
   alignItems: "center",
   gap: "0.5rem",
-  position: "relative",
 
   "@sm": {
     flexDirection: "column",
@@ -18,8 +23,7 @@ const AnimationControlsWrapper = styled("div", {
   flexShrink: "0",
   alignItems: "center",
   borderRadius: "2rem",
-  position: "absolute",
-  right: "0.5rem",
+  marginLeft: "auto",
 });
 
 const AnimationButton = styled("button", {
@@ -90,9 +94,52 @@ const AnimationCounter = styled("span", {
   },
 });
 
+const AnimationThumbnailStrip = styled("div", {
+  display: "flex",
+  flexDirection: "row",
+  paddingTop: "0.25rem",
+  gap: "0.25rem",
+  overflowX: "auto",
+  alignItems: "center",
+  scrollbarWidth: "none",
+
+  "&::-webkit-scrollbar": {
+    display: "none",
+  },
+});
+
+const AnimationThumbnailButton = styled("button", {
+  display: "flex",
+  flexShrink: "0",
+  padding: "0",
+  margin: "0",
+  background: "none",
+  cursor: "pointer",
+  border: "none",
+  outline: "2px solid transparent",
+  outlineOffset: "-3px",
+  borderRadius: "2px",
+  opacity: "0.75",
+  transition: "$all",
+
+  img: {
+    display: "block",
+    height: "61.8px",
+    borderRadius: "2px",
+  },
+
+  "&[data-active=true]": {
+    outline: "3px solid $accent",
+    opacity: "1",
+  },
+});
+
 export {
   AnimationBar,
   AnimationButton,
+  AnimationControlsRow,
   AnimationControlsWrapper,
   AnimationCounter,
+  AnimationThumbnailButton,
+  AnimationThumbnailStrip,
 };

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -1,5 +1,17 @@
 import { styled } from "src/styles/stitches.config";
 
+const AnimationBar = styled("div", {
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "0.5rem",
+
+  "@sm": {
+    flexDirection: "column",
+    alignItems: "flex-start",
+  },
+});
+
 const AnimationControlsWrapper = styled("div", {
   display: "flex",
   flexShrink: "0",
@@ -7,12 +19,8 @@ const AnimationControlsWrapper = styled("div", {
   gap: "0.25rem",
   borderRadius: "2rem",
   color: "$secondary",
-  position: "absolute",
-  zIndex: 100,
-  bottom: "1rem",
   backgroundColor: "#111C",
   padding: "0 0.5rem 0 0.25rem",
-  left: "1rem",
 });
 
 const AnimationButton = styled("button", {
@@ -80,4 +88,9 @@ const AnimationCounter = styled("span", {
   },
 });
 
-export { AnimationButton, AnimationControlsWrapper, AnimationCounter };
+export {
+  AnimationBar,
+  AnimationButton,
+  AnimationControlsWrapper,
+  AnimationCounter,
+};

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -5,6 +5,7 @@ const AnimationBar = styled("div", {
   flexDirection: "row",
   alignItems: "center",
   gap: "0.5rem",
+  position: "relative",
 
   "@sm": {
     flexDirection: "column",
@@ -16,11 +17,9 @@ const AnimationControlsWrapper = styled("div", {
   display: "flex",
   flexShrink: "0",
   alignItems: "center",
-  gap: "0.25rem",
   borderRadius: "2rem",
-  color: "$secondary",
-  backgroundColor: "#111C",
-  padding: "0 0.5rem 0 0.25rem",
+  position: "absolute",
+  right: "0.5rem",
 });
 
 const AnimationButton = styled("button", {
@@ -32,19 +31,19 @@ const AnimationButton = styled("button", {
   padding: "0",
   margin: "0",
   borderRadius: "2rem",
-  color: "$secondary",
+  color: "$accent",
   cursor: "pointer",
   transition: "$all",
   flexShrink: "0",
-  opacity: "0.5",
+  opacity: "1",
 
   svg: {
-    height: "52%",
-    width: "52%",
-    padding: "24%",
-    fill: "$secondary",
-    stroke: "$secondary",
+    height: "50%",
+    width: "50%",
+    padding: "25%",
     opacity: "1",
+    fill: "$accent",
+    stroke: "$accent",
     boxSizing: "content-box",
     display: "block",
     transition: "$all",
@@ -53,7 +52,7 @@ const AnimationButton = styled("button", {
   "&:disabled": {
     backgroundColor: "transparent",
     boxShadow: "none",
-    svg: { opacity: "0.25" },
+    svg: { opacity: "0.25", color: "$accent", stroke: "$accent" },
   },
 
   "&:not(:disabled):hover": {
@@ -61,6 +60,8 @@ const AnimationButton = styled("button", {
 
     svg: {
       opacity: "1",
+      color: "$accent",
+      stroke: "$accent",
     },
   },
 
@@ -68,6 +69,7 @@ const AnimationButton = styled("button", {
     opacity: "1",
     svg: {
       opacity: "1",
+      color: "$accent",
       path: { strokeWidth: "56" },
     },
   },
@@ -75,12 +77,12 @@ const AnimationButton = styled("button", {
 
 const AnimationCounter = styled("span", {
   display: "flex",
-  margin: "0 0.25rem",
   fontSize: "0.7222rem",
-  fontWeight: "bold",
   gap: "0.25rem",
+  fontWeight: "bold",
   whiteSpace: "nowrap",
-  fontFamily: "monospace",
+  letterSpacing: "0",
+  marginRight: "0.5rem",
 
   em: {
     opacity: "0.25",

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -2,14 +2,17 @@ import { styled } from "src/styles/stitches.config";
 
 const AnimationControlsWrapper = styled("div", {
   display: "flex",
-  alignSelf: "center",
   flexShrink: "0",
   alignItems: "center",
   gap: "0.25rem",
   borderRadius: "2rem",
-  boxShadow: "5px 5px 5px #0003",
   color: "$secondary",
-  padding: "0",
+  position: "absolute",
+  zIndex: 100,
+  bottom: "1rem",
+  backgroundColor: "#111C",
+  padding: "0 0.5rem 0 0.25rem",
+  left: "1rem",
 });
 
 const AnimationButton = styled("button", {
@@ -25,7 +28,7 @@ const AnimationButton = styled("button", {
   cursor: "pointer",
   transition: "$all",
   flexShrink: "0",
-  opacity: "0.75",
+  opacity: "0.5",
 
   svg: {
     height: "52%",
@@ -50,6 +53,14 @@ const AnimationButton = styled("button", {
 
     svg: {
       opacity: "1",
+    },
+  },
+
+  "&[data-active=true]": {
+    opacity: "1",
+    svg: {
+      opacity: "1",
+      path: { strokeWidth: "56" },
     },
   },
 });

--- a/src/components/Viewer/Painting/AnimationControls.styled.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.styled.tsx
@@ -1,0 +1,67 @@
+import { styled } from "src/styles/stitches.config";
+
+const AnimationControlsWrapper = styled("div", {
+  position: "absolute",
+  bottom: "1rem",
+  left: "50%",
+  transform: "translateX(-50%)",
+  display: "flex",
+  alignItems: "center",
+  gap: "0.25rem",
+  backgroundColor: "$accentAlt",
+  borderRadius: "2rem",
+  boxShadow: "5px 5px 5px #0003",
+  color: "$secondary",
+  padding: "0",
+  zIndex: "$1",
+});
+
+const AnimationButton = styled("button", {
+  display: "flex",
+  background: "none",
+  border: "none",
+  width: "2rem",
+  height: "2rem",
+  padding: "0",
+  margin: "0",
+  borderRadius: "2rem",
+  backgroundColor: "$accent",
+  color: "$secondary",
+  cursor: "pointer",
+  transition: "$all",
+  flexShrink: "0",
+
+  svg: {
+    height: "60%",
+    width: "60%",
+    padding: "20%",
+    fill: "$secondary",
+    stroke: "$secondary",
+    opacity: "1",
+    filter: "drop-shadow(5px 5px 5px #000D)",
+    boxSizing: "border-box",
+    transition: "$all",
+  },
+
+  "&:disabled": {
+    backgroundColor: "transparent",
+    boxShadow: "none",
+    svg: { opacity: "0.25" },
+  },
+});
+
+const AnimationCounter = styled("span", {
+  display: "flex",
+  margin: "0 0.25rem",
+  fontSize: "0.7222rem",
+  fontWeight: "bold",
+  gap: "0.25rem",
+  whiteSpace: "nowrap",
+
+  em: {
+    opacity: "0.25",
+    fontStyle: "normal",
+  },
+});
+
+export { AnimationButton, AnimationControlsWrapper, AnimationCounter };

--- a/src/components/Viewer/Painting/AnimationControls.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.tsx
@@ -1,8 +1,11 @@
 import {
+  AnimationBar,
   AnimationButton,
   AnimationControlsWrapper,
   AnimationCounter,
 } from "./AnimationControls.styled";
+
+export { AnimationBar };
 
 import React from "react";
 import { useCloverTranslation } from "src/i18n/useCloverTranslation";

--- a/src/components/Viewer/Painting/AnimationControls.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.tsx
@@ -1,0 +1,98 @@
+import {
+  AnimationButton,
+  AnimationControlsWrapper,
+  AnimationCounter,
+} from "./AnimationControls.styled";
+
+import React from "react";
+import { useCloverTranslation } from "src/i18n/useCloverTranslation";
+
+const PlayIcon = ({ title }: { title: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>{title}</title>
+    <path d="M133 440a35.37 35.37 0 01-17.5-4.67c-12-6.8-19.46-20-19.46-34.33V111c0-14.37 7.46-27.53 19.46-34.33a35.13 35.13 0 0135.77.45l247.85 148.36a36 36 0 010 61.11L151.23 435a35.5 35.5 0 01-18.23 5z" />
+  </svg>
+);
+
+const PauseIcon = ({ title }: { title: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>{title}</title>
+    <path d="M224 432h-80V80h80zm144 0h-80V80h80z" />
+  </svg>
+);
+
+const PreviousFrameIcon = ({ title }: { title: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>{title}</title>
+    <path d="M112 64a16 16 0 0116 16v136.43L360.77 77.11a35.13 35.13 0 0135.77.45c12 6.8 19.46 20 19.46 34.33v288.22c0 14.37-7.46 27.53-19.46 34.33a35.13 35.13 0 01-35.77.45L128 295.57V432a16 16 0 01-32 0V80a16 16 0 0116-16z" />
+  </svg>
+);
+
+const NextFrameIcon = ({ title }: { title: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>{title}</title>
+    <path d="M400 64a16 16 0 00-16 16v136.43L151.23 77.11a35.13 35.13 0 00-35.77.45C103.46 84.36 96 97.52 96 111.89v288.22c0 14.37 7.46 27.53 19.46 34.33a35.13 35.13 0 0035.77.45L384 295.57V432a16 16 0 0032 0V80a16 16 0 00-16-16z" />
+  </svg>
+);
+
+interface AnimationControlsProps {
+  frameIndex: number;
+  isPlaying: boolean;
+  totalFrames: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onPrevFrame: () => void;
+  onNextFrame: () => void;
+}
+
+const AnimationControls: React.FC<AnimationControlsProps> = ({
+  frameIndex,
+  isPlaying,
+  totalFrames,
+  onPlay,
+  onPause,
+  onPrevFrame,
+  onNextFrame,
+}) => {
+  const { t } = useCloverTranslation();
+
+  return (
+    <AnimationControlsWrapper className="clover-viewer-animation-controls">
+      <AnimationButton
+        onClick={onPrevFrame}
+        disabled={frameIndex === 0}
+        type="button"
+        aria-label={t("canvasAnimationPreviousFrame")}
+      >
+        <PreviousFrameIcon title={t("canvasAnimationPreviousFrame")} />
+      </AnimationButton>
+
+      <AnimationButton
+        onClick={isPlaying ? onPause : onPlay}
+        type="button"
+        aria-label={isPlaying ? t("canvasAnimationPause") : t("canvasAnimationPlay")}
+      >
+        {isPlaying ? (
+          <PauseIcon title={t("canvasAnimationPause")} />
+        ) : (
+          <PlayIcon title={t("canvasAnimationPlay")} />
+        )}
+      </AnimationButton>
+
+      <AnimationButton
+        onClick={onNextFrame}
+        disabled={frameIndex === totalFrames - 1}
+        type="button"
+        aria-label={t("canvasAnimationNextFrame")}
+      >
+        <NextFrameIcon title={t("canvasAnimationNextFrame")} />
+      </AnimationButton>
+
+      <AnimationCounter>
+        {frameIndex + 1} <em>/</em> {totalFrames}
+      </AnimationCounter>
+    </AnimationControlsWrapper>
+  );
+};
+
+export default AnimationControls;

--- a/src/components/Viewer/Painting/AnimationControls.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.tsx
@@ -1,11 +1,14 @@
 import {
   AnimationBar,
   AnimationButton,
+  AnimationControlsRow,
   AnimationControlsWrapper,
   AnimationCounter,
+  AnimationThumbnailButton,
+  AnimationThumbnailStrip,
 } from "./AnimationControls.styled";
 
-export { AnimationBar };
+export { AnimationBar, AnimationControlsRow, AnimationThumbnailButton, AnimationThumbnailStrip };
 
 import React from "react";
 import { useCloverTranslation } from "src/i18n/useCloverTranslation";

--- a/src/components/Viewer/Painting/AnimationControls.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.tsx
@@ -35,24 +35,37 @@ const NextFrameIcon = ({ title }: { title: string }) => (
   </svg>
 );
 
+const RepeatIcon = ({ title }: { title: string }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>{title}</title>
+    <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32" d="M320 120l48 48-48 48"/>
+    <path d="M352 168H144a80.24 80.24 0 00-80 80v16M192 392l-48-48 48-48" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32"/>
+    <path d="M160 344h208a80.24 80.24 0 0080-80v-16" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32"/>
+  </svg>
+);
+
 interface AnimationControlsProps {
   frameIndex: number;
   isPlaying: boolean;
+  isRepeat: boolean;
   totalFrames: number;
   onPlay: () => void;
   onPause: () => void;
   onPrevFrame: () => void;
   onNextFrame: () => void;
+  onToggleRepeat: () => void;
 }
 
 const AnimationControls: React.FC<AnimationControlsProps> = ({
   frameIndex,
   isPlaying,
+  isRepeat,
   totalFrames,
   onPlay,
   onPause,
   onPrevFrame,
   onNextFrame,
+  onToggleRepeat,
 }) => {
   const { t } = useCloverTranslation();
 
@@ -77,6 +90,16 @@ const AnimationControls: React.FC<AnimationControlsProps> = ({
         ) : (
           <PlayIcon title={t("canvasAnimationPlay")} />
         )}
+      </AnimationButton>
+
+      <AnimationButton
+        onClick={onToggleRepeat}
+        type="button"
+        aria-label={t("canvasAnimationRepeat")}
+        aria-pressed={isRepeat}
+        data-active={isRepeat}
+      >
+        <RepeatIcon title={t("canvasAnimationRepeat")} />
       </AnimationButton>
 
       <AnimationButton

--- a/src/components/Viewer/Painting/AnimationControls.tsx
+++ b/src/components/Viewer/Painting/AnimationControls.tsx
@@ -41,39 +41,90 @@ const NextFrameIcon = ({ title }: { title: string }) => (
 const RepeatIcon = ({ title }: { title: string }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>{title}</title>
-    <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32" d="M320 120l48 48-48 48"/>
-    <path d="M352 168H144a80.24 80.24 0 00-80 80v16M192 392l-48-48 48-48" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32"/>
-    <path d="M160 344h208a80.24 80.24 0 0080-80v-16" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="32"/>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M320 120l48 48-48 48"
+    />
+    <path
+      d="M352 168H144a80.24 80.24 0 00-80 80v16M192 392l-48-48 48-48"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
+    <path
+      d="M160 344h208a80.24 80.24 0 0080-80v-16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
   </svg>
 );
 
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  const tenths = Math.floor((seconds % 1) * 10);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}.${tenths}`;
+}
+
 interface AnimationControlsProps {
+  duration: number;
   frameIndex: number;
   isPlaying: boolean;
   isRepeat: boolean;
+  playbackRate: number;
   totalFrames: number;
   onPlay: () => void;
   onPause: () => void;
   onPrevFrame: () => void;
   onNextFrame: () => void;
   onToggleRepeat: () => void;
+  onSetPlaybackRate: (rate: number) => void;
 }
 
 const AnimationControls: React.FC<AnimationControlsProps> = ({
+  duration,
   frameIndex,
   isPlaying,
   isRepeat,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  playbackRate,
   totalFrames,
   onPlay,
   onPause,
   onPrevFrame,
   onNextFrame,
   onToggleRepeat,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onSetPlaybackRate,
 }) => {
   const { t } = useCloverTranslation();
 
+  const frameDuration = totalFrames > 0 ? duration / totalFrames : 0;
+  const elapsed = frameIndex * frameDuration;
+
   return (
     <AnimationControlsWrapper className="clover-viewer-animation-controls">
+      <AnimationCounter>
+        {duration > 0 ? (
+          <>
+            {formatTime(elapsed)} <em>/</em> {formatTime(duration)}
+          </>
+        ) : (
+          <>
+            {frameIndex + 1} <em>/</em> {totalFrames}
+          </>
+        )}
+      </AnimationCounter>
+
       <AnimationButton
         onClick={onPrevFrame}
         disabled={frameIndex === 0}
@@ -86,7 +137,9 @@ const AnimationControls: React.FC<AnimationControlsProps> = ({
       <AnimationButton
         onClick={isPlaying ? onPause : onPlay}
         type="button"
-        aria-label={isPlaying ? t("canvasAnimationPause") : t("canvasAnimationPlay")}
+        aria-label={
+          isPlaying ? t("canvasAnimationPause") : t("canvasAnimationPlay")
+        }
       >
         {isPlaying ? (
           <PauseIcon title={t("canvasAnimationPause")} />
@@ -113,10 +166,6 @@ const AnimationControls: React.FC<AnimationControlsProps> = ({
       >
         <NextFrameIcon title={t("canvasAnimationNextFrame")} />
       </AnimationButton>
-
-      <AnimationCounter>
-        {frameIndex + 1} <em>/</em> {totalFrames}
-      </AnimationCounter>
     </AnimationControlsWrapper>
   );
 };

--- a/src/components/Viewer/Painting/Painting.styled.tsx
+++ b/src/components/Viewer/Painting/Painting.styled.tsx
@@ -25,7 +25,8 @@ const PaintingStyled = styled("div", {
 
 const PaintingCanvas = styled("div", {
   width: "100%",
-  height: "100%",
+  flexGrow: "1",
+  minHeight: "0",
 });
 
 const AnimationFrameImage = styled("img", {

--- a/src/components/Viewer/Painting/Painting.styled.tsx
+++ b/src/components/Viewer/Painting/Painting.styled.tsx
@@ -8,7 +8,6 @@ const PaintingStyled = styled("div", {
   flexDirection: "column",
   flexGrow: "1",
   flexShrink: "1",
-  gap: "1rem",
   zIndex: "0",
   overflow: "hidden",
 

--- a/src/components/Viewer/Painting/Painting.styled.tsx
+++ b/src/components/Viewer/Painting/Painting.styled.tsx
@@ -28,4 +28,11 @@ const PaintingCanvas = styled("div", {
   height: "100%",
 });
 
-export { PaintingCanvas, PaintingStyled, ToggleStyled };
+const AnimationFrameImage = styled("img", {
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+  display: "block",
+});
+
+export { AnimationFrameImage, PaintingCanvas, PaintingStyled, ToggleStyled };

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -9,11 +9,16 @@ import {
   PaintingCanvas,
   PaintingStyled,
 } from "./Painting.styled";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Select, SelectOption } from "src/components/UI/Select";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 
-import AnimationControls, { AnimationBar } from "./AnimationControls";
+import AnimationControls, {
+  AnimationBar,
+  AnimationControlsRow,
+  AnimationThumbnailButton,
+  AnimationThumbnailStrip,
+} from "./AnimationControls";
 import { AnnotationResources } from "src/types/annotations";
 import ImageViewer from "src/components/Image";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
@@ -189,6 +194,14 @@ const Painting: React.FC<PaintingProps> = ({
     setIsPlaying(false);
     setAnnotationIndex(parseInt(value, 10));
   };
+
+  const activeThumbnailRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node)
+        node.scrollIntoView({ inline: "nearest", block: "nearest", behavior: "smooth" });
+    },
+    [annotationIndex],
+  );
 
   const customDisplay = customDisplays.find((customDisplay) => {
     let match = false;
@@ -447,39 +460,58 @@ const Painting: React.FC<PaintingProps> = ({
 
       {isAnimationMode && !showPlaceholder && (
         <AnimationBar>
-          <Select
-            value={String(annotationIndex)}
-            onValueChange={handleFrameChange}
-            maxHeight={"200px"}
-          >
+          <AnimationThumbnailStrip>
             {animationFrames.map((frame, index) => (
-              <SelectOption
-                value={String(index)}
+              <AnimationThumbnailButton
                 key={index}
-                label={frame.label ?? { none: [String(index + 1)] }}
-              />
+                ref={index === annotationIndex ? activeThumbnailRef : undefined}
+                data-active={index === annotationIndex}
+                type="button"
+                aria-label={`Frame ${index + 1}`}
+                onClick={() => {
+                  setIsPlaying(false);
+                  setAnnotationIndex(index);
+                }}
+              >
+                <img src={frame.body.id} alt="" />
+              </AnimationThumbnailButton>
             ))}
-          </Select>
-          <AnimationControls
-            duration={canvasDuration}
-            frameIndex={annotationIndex}
-            isPlaying={isPlaying}
-            isRepeat={isRepeat}
-            playbackRate={playbackRate}
-            totalFrames={totalFrames}
-            onPlay={() => setIsPlaying(true)}
-            onPause={() => setIsPlaying(false)}
-            onPrevFrame={() => {
-              setIsPlaying(false);
-              setAnnotationIndex((prev) => Math.max(0, prev - 1));
-            }}
-            onNextFrame={() => {
-              setIsPlaying(false);
-              setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
-            }}
-            onToggleRepeat={() => setIsRepeat((prev) => !prev)}
-            onSetPlaybackRate={setPlaybackRate}
-          />
+          </AnimationThumbnailStrip>
+          <AnimationControlsRow>
+            <Select
+              value={String(annotationIndex)}
+              onValueChange={handleFrameChange}
+              maxHeight={"200px"}
+            >
+              {animationFrames.map((frame, index) => (
+                <SelectOption
+                  value={String(index)}
+                  key={index}
+                  label={frame.label ?? { none: [String(index + 1)] }}
+                />
+              ))}
+            </Select>
+            <AnimationControls
+              duration={canvasDuration}
+              frameIndex={annotationIndex}
+              isPlaying={isPlaying}
+              isRepeat={isRepeat}
+              playbackRate={playbackRate}
+              totalFrames={totalFrames}
+              onPlay={() => setIsPlaying(true)}
+              onPause={() => setIsPlaying(false)}
+              onPrevFrame={() => {
+                setIsPlaying(false);
+                setAnnotationIndex((prev) => Math.max(0, prev - 1));
+              }}
+              onNextFrame={() => {
+                setIsPlaying(false);
+                setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
+              }}
+              onToggleRepeat={() => setIsRepeat((prev) => !prev)}
+              onSetPlaybackRate={setPlaybackRate}
+            />
+          </AnimationControlsRow>
         </AnimationBar>
       )}
 

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -51,8 +51,10 @@ const Painting: React.FC<PaintingProps> = ({
   const [toggleCount, setToggleCount] = useState(0);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isRepeat, setIsRepeat] = useState(false);
 
   const {
+    activeManifest,
     configOptions,
     customDisplays,
     contentStateAnnotation,
@@ -82,7 +84,15 @@ const Painting: React.FC<PaintingProps> = ({
   const dispatch: any = useViewerDispatch();
   const normalizedCanvas: CanvasNormalized = vault.get(activeCanvas);
 
-  const { isAutoAdvance, isRepeat } = getCanvasBehavior(vault, activeCanvas);
+  const {
+    isAutoAdvance,
+    isManifestAutoAdvance,
+    isRepeat: behaviorIsRepeat,
+  } = getCanvasBehavior(vault, activeCanvas, activeManifest);
+
+  useEffect(() => {
+    setIsRepeat(behaviorIsRepeat);
+  }, [activeCanvas, behaviorIsRepeat]);
   const canvasDuration = normalizedCanvas?.duration ?? 0;
   const totalFrames = painting?.length ?? 0;
 
@@ -93,7 +103,7 @@ const Painting: React.FC<PaintingProps> = ({
     () => getAnimationFrames(vault, activeCanvas).length > 0,
     [vault, activeCanvas],
   );
-  const isAnimationMode = isAutoAdvance && hasTemporalAnnotations;
+  const isAnimationMode = hasTemporalAnnotations;
   const hasChoice = Boolean(painting?.length > 1) && !isAnimationMode;
 
   const frameInterval =
@@ -101,10 +111,10 @@ const Painting: React.FC<PaintingProps> = ({
       ? (canvasDuration / totalFrames / playbackRate) * 1000
       : 0;
 
-  // Start playing automatically when entering animation mode
+  // Auto-play only when auto-advance is set; otherwise show controls paused
   useEffect(() => {
-    if (isAnimationMode) setIsPlaying(true);
-  }, [isAnimationMode]);
+    if (isAnimationMode && isAutoAdvance) setIsPlaying(true);
+  }, [isAnimationMode, isAutoAdvance]);
 
   // Preload all frames so subsequent loops are smooth
   useEffect(() => {
@@ -125,15 +135,17 @@ const Painting: React.FC<PaintingProps> = ({
         if (next >= totalFrames) {
           if (isRepeat) return 0;
           setIsPlaying(false);
-          const allCanvases = sequence[0];
-          const currentIdx = allCanvases.findIndex(
-            (c) => c.id === activeCanvas,
-          );
-          if (currentIdx >= 0 && currentIdx < allCanvases.length - 1) {
-            dispatch({
-              type: "updateActiveCanvas",
-              canvasId: allCanvases[currentIdx + 1].id,
-            });
+          if (isManifestAutoAdvance) {
+            const allCanvases = sequence[0];
+            const currentIdx = allCanvases.findIndex(
+              (c) => c.id === activeCanvas,
+            );
+            if (currentIdx >= 0 && currentIdx < allCanvases.length - 1) {
+              dispatch({
+                type: "updateActiveCanvas",
+                canvasId: allCanvases[currentIdx + 1].id,
+              });
+            }
           }
           return prev;
         }
@@ -149,6 +161,7 @@ const Painting: React.FC<PaintingProps> = ({
     frameInterval,
     totalFrames,
     isRepeat,
+    isManifestAutoAdvance,
     sequence,
     activeCanvas,
     dispatch,
@@ -410,6 +423,7 @@ const Painting: React.FC<PaintingProps> = ({
         <AnimationControls
           frameIndex={annotationIndex}
           isPlaying={isPlaying}
+          isRepeat={isRepeat}
           playbackRate={playbackRate}
           totalFrames={totalFrames}
           onPlay={() => setIsPlaying(true)}
@@ -422,6 +436,7 @@ const Painting: React.FC<PaintingProps> = ({
             setIsPlaying(false);
             setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
           }}
+          onToggleRepeat={() => setIsRepeat((prev) => !prev)}
           onSetPlaybackRate={setPlaybackRate}
         />
       )}

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -121,6 +121,7 @@ const Painting: React.FC<PaintingProps> = ({
   useEffect(() => {
     if (!isAnimationMode) return;
     painting.forEach((resource) => {
+      if (!resource.id) return;
       const img = new window.Image();
       img.src = resource.id;
     });
@@ -401,6 +402,25 @@ const Painting: React.FC<PaintingProps> = ({
               allSources={painting}
               painting={painting[annotationIndex]}
               annotationResources={annotationResources}
+              onEnded={
+                isManifestAutoAdvance
+                  ? () => {
+                      const allCanvases = sequence[0];
+                      const currentIdx = allCanvases.findIndex(
+                        (c) => c.id === activeCanvas,
+                      );
+                      if (
+                        currentIdx >= 0 &&
+                        currentIdx < allCanvases.length - 1
+                      ) {
+                        dispatch({
+                          type: "updateActiveCanvas",
+                          canvasId: allCanvases[currentIdx + 1].id,
+                        });
+                      }
+                    }
+                  : undefined
+              }
             />
           ) : (
             painting && (
@@ -427,7 +447,21 @@ const Painting: React.FC<PaintingProps> = ({
 
       {isAnimationMode && !showPlaceholder && (
         <AnimationBar>
+          <Select
+            value={String(annotationIndex)}
+            onValueChange={handleFrameChange}
+            maxHeight={"200px"}
+          >
+            {animationFrames.map((frame, index) => (
+              <SelectOption
+                value={String(index)}
+                key={index}
+                label={frame.label ?? { none: [String(index + 1)] }}
+              />
+            ))}
+          </Select>
           <AnimationControls
+            duration={canvasDuration}
             frameIndex={annotationIndex}
             isPlaying={isPlaying}
             isRepeat={isRepeat}
@@ -446,19 +480,6 @@ const Painting: React.FC<PaintingProps> = ({
             onToggleRepeat={() => setIsRepeat((prev) => !prev)}
             onSetPlaybackRate={setPlaybackRate}
           />
-          {/* <Select
-            value={String(annotationIndex)}
-            onValueChange={handleFrameChange}
-            maxHeight={"200px"}
-          >
-            {animationFrames.map((frame, index) => (
-              <SelectOption
-                value={String(index)}
-                key={index}
-                label={frame.label ?? { none: [String(index + 1)] }}
-              />
-            ))}
-          </Select> */}
         </AnimationBar>
       )}
 

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -4,17 +4,24 @@ import {
   CanvasNormalized,
   InternationalString,
 } from "@iiif/presentation-3";
-import { PaintingCanvas, PaintingStyled } from "./Painting.styled";
-import React, { useEffect } from "react";
+import {
+  AnimationFrameImage,
+  PaintingCanvas,
+  PaintingStyled,
+} from "./Painting.styled";
+import React, { useEffect, useMemo, useState } from "react";
 import { Select, SelectOption } from "src/components/UI/Select";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 
+import AnimationControls from "./AnimationControls";
 import { AnnotationResources } from "src/types/annotations";
 import ImageViewer from "src/components/Image";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
 import PaintingPlaceholder from "./Placeholder";
 import Player from "src/components/Viewer/Player/Player";
 import Toggle from "./Toggle";
+import { getAnimationFrames } from "src/hooks/use-iiif/getAnimationFrames";
+import { getCanvasBehavior } from "src/hooks/use-iiif/getCanvasBehavior";
 import { getPaintingResource } from "src/hooks/use-iiif";
 import { hashCode } from "src/lib/utils";
 
@@ -33,15 +40,18 @@ const Painting: React.FC<PaintingProps> = ({
   isMedia,
   painting,
 }) => {
-  const [annotationIndex, setAnnotationIndex] = React.useState<number>(0);
-  const [isInteractive, setIsInteractive] = React.useState(false);
-  const [imageBody, setImageBody] = React.useState<
-    LabeledIIIFExternalWebResource[]
-  >([]);
-  const [placeholderItems, setPlaceholderItems] = React.useState<
+  const [annotationIndex, setAnnotationIndex] = useState<number>(0);
+  const [isInteractive, setIsInteractive] = useState(false);
+  const [imageBody, setImageBody] = useState<LabeledIIIFExternalWebResource[]>(
+    [],
+  );
+  const [placeholderItems, setPlaceholderItems] = useState<
     Array<{ id: string; label: InternationalString | null }>
   >([]);
-  const [toggleCount, setToggleCount] = React.useState(0);
+  const [toggleCount, setToggleCount] = useState(0);
+  const [playbackRate, setPlaybackRate] = useState(1);
+  const [isPlaying, setIsPlaying] = useState(false);
+
   const {
     configOptions,
     customDisplays,
@@ -49,18 +59,15 @@ const Painting: React.FC<PaintingProps> = ({
     informationPanelResource,
     isPaged,
     openSeadragonViewer,
+    sequence,
     vault,
     viewerId,
     viewingDirection,
     visibleCanvases,
   } = useViewerState();
 
-  /**
-   * Determine if canvases should be displayed in reverse order
-   * for right-to-left viewing direction when behavior is paged
-   */
   const isRtlPaged = isPaged && viewingDirection === "right-to-left";
-  const [annotations, setAnnotations] = React.useState<
+  const [annotations, setAnnotations] = useState<
     Array<{
       annotation: Annotation;
       targetIndex: number;
@@ -74,9 +81,84 @@ const Painting: React.FC<PaintingProps> = ({
 
   const dispatch: any = useViewerDispatch();
   const normalizedCanvas: CanvasNormalized = vault.get(activeCanvas);
+
+  const { isAutoAdvance, isRepeat } = getCanvasBehavior(vault, activeCanvas);
+  const canvasDuration = normalizedCanvas?.duration ?? 0;
+  const totalFrames = painting?.length ?? 0;
+
+  // Animation mode requires auto-advance AND temporal annotation targets (#t=).
+  // A canvas with auto-advance + choice annotations is not animation mode —
+  // it just auto-advances after its duration with the choice select still visible.
+  const hasTemporalAnnotations = useMemo(
+    () => getAnimationFrames(vault, activeCanvas).length > 0,
+    [vault, activeCanvas],
+  );
+  const isAnimationMode = isAutoAdvance && hasTemporalAnnotations;
+  const hasChoice = Boolean(painting?.length > 1) && !isAnimationMode;
+
+  const frameInterval =
+    isAnimationMode && canvasDuration > 0 && totalFrames > 0
+      ? (canvasDuration / totalFrames / playbackRate) * 1000
+      : 0;
+
+  // Start playing automatically when entering animation mode
+  useEffect(() => {
+    if (isAnimationMode) setIsPlaying(true);
+  }, [isAnimationMode]);
+
+  // Preload all frames so subsequent loops are smooth
+  useEffect(() => {
+    if (!isAnimationMode) return;
+    painting.forEach((resource) => {
+      const img = new window.Image();
+      img.src = resource.id;
+    });
+  }, [isAnimationMode, painting]);
+
+  // Advance annotationIndex on each frame interval
+  useEffect(() => {
+    if (!isAnimationMode || !isPlaying || frameInterval <= 0) return;
+
+    const timer = setTimeout(() => {
+      setAnnotationIndex((prev) => {
+        const next = prev + 1;
+        if (next >= totalFrames) {
+          if (isRepeat) return 0;
+          setIsPlaying(false);
+          const allCanvases = sequence[0];
+          const currentIdx = allCanvases.findIndex(
+            (c) => c.id === activeCanvas,
+          );
+          if (currentIdx >= 0 && currentIdx < allCanvases.length - 1) {
+            dispatch({
+              type: "updateActiveCanvas",
+              canvasId: allCanvases[currentIdx + 1].id,
+            });
+          }
+          return prev;
+        }
+        return next;
+      });
+    }, frameInterval);
+
+    return () => clearTimeout(timer);
+  }, [
+    isAnimationMode,
+    isPlaying,
+    annotationIndex,
+    frameInterval,
+    totalFrames,
+    isRepeat,
+    sequence,
+    activeCanvas,
+    dispatch,
+  ]);
+
   const showPlaceholder = placeholderItems.length && !isInteractive && !isMedia;
-  const hasChoice = Boolean(painting?.length > 1);
-  const instanceId = `${viewerId}-${hashCode(activeCanvas + annotationIndex + JSON.stringify(visibleCanvases) + toggleCount)}`;
+  // Exclude annotationIndex from instanceId so OSD stays mounted when the
+  // user changes a choice or the animation advances frames. OSD swaps images
+  // via its uri-change effect rather than remounting, preserving zoom state.
+  const instanceId = `${viewerId}-${hashCode(activeCanvas + JSON.stringify(visibleCanvases) + toggleCount)}`;
 
   const handleToggle = () => {
     setIsInteractive(!isInteractive);
@@ -88,9 +170,6 @@ const Painting: React.FC<PaintingProps> = ({
     setAnnotationIndex(index);
   };
 
-  /**
-   * Determine whether a custom display should be used for the current canvas.
-   */
   const customDisplay = customDisplays.find((customDisplay) => {
     let match = false;
     const { canvasId, paintingFormat } = customDisplay.target;
@@ -112,10 +191,6 @@ const Painting: React.FC<PaintingProps> = ({
     }
   }, [hasContentStateAnnotation, showPlaceholder]);
 
-  /**
-   * If placeholder is toggled, this resets active
-   * selector and openSeadragon instance in context
-   */
   useEffect(() => {
     if (showPlaceholder) {
       dispatch({
@@ -129,7 +204,6 @@ const Painting: React.FC<PaintingProps> = ({
     }
   }, [showPlaceholder]);
 
-  /** Retrieve annotations for visible canvases from Vault */
   useEffect(() => {
     const resources: Array<{
       annotation: Annotation;
@@ -213,45 +287,39 @@ const Painting: React.FC<PaintingProps> = ({
   ]);
 
   useEffect(() => {
-    if (isMedia) {
-      return;
-    } else {
-      /**
-       * For RTL paged content, we reverse the order of visible canvases
-       * so that the rightmost canvas appears on the left side of the display
-       */
-      const orderedCanvases = isRtlPaged
-        ? [...visibleCanvases].reverse()
-        : visibleCanvases;
+    if (isMedia) return;
 
-      const body = orderedCanvases
-        .map((canvas) => {
-          const canvasId = canvas.id;
-          const painting = getPaintingResource(vault, canvasId);
-          return painting ? painting[annotationIndex] : undefined;
-        })
-        .filter(Boolean) as LabeledIIIFExternalWebResource[];
+    const orderedCanvases = isRtlPaged
+      ? [...visibleCanvases].reverse()
+      : visibleCanvases;
 
-      const placeholders = orderedCanvases
-        .map((entry) => {
-          const canvasId = entry.id;
+    const body = orderedCanvases
+      .map((canvas) => {
+        const canvasId = canvas.id;
+        const painting = getPaintingResource(vault, canvasId);
+        return painting ? painting[annotationIndex] : undefined;
+      })
+      .filter(Boolean) as LabeledIIIFExternalWebResource[];
 
-          const canvas: CanvasNormalized = vault.get(canvasId);
-          const placeholderCanvas = canvas?.placeholderCanvas?.id;
-          const hasPlaceholder = Boolean(placeholderCanvas);
+    const placeholders = orderedCanvases
+      .map((entry) => {
+        const canvasId = entry.id;
 
-          if (!hasPlaceholder || !placeholderCanvas) return null;
+        const canvas: CanvasNormalized = vault.get(canvasId);
+        const placeholderCanvas = canvas?.placeholderCanvas?.id;
+        const hasPlaceholder = Boolean(placeholderCanvas);
 
-          return {
-            id: placeholderCanvas,
-            label: canvas?.label,
-          };
-        })
-        .filter((item) => item !== null);
+        if (!hasPlaceholder || !placeholderCanvas) return null;
 
-      setImageBody(body);
-      setPlaceholderItems(placeholders);
-    }
+        return {
+          id: placeholderCanvas,
+          label: canvas?.label,
+        };
+      })
+      .filter((item) => item !== null);
+
+    setImageBody(body);
+    setPlaceholderItems(placeholders);
   }, [
     annotationIndex,
     activeCanvas,
@@ -261,12 +329,10 @@ const Painting: React.FC<PaintingProps> = ({
     normalizedCanvas,
   ]);
 
-  // resets the annotation index if the visible canvases change
   useEffect(() => {
     setAnnotationIndex(0);
   }, [visibleCanvases]);
 
-  /** Update OpenSeadragon Viewer in viewer context */
   const handleOpenSeadragonCallback = (viewer) => {
     if (
       viewer &&
@@ -310,7 +376,6 @@ const Painting: React.FC<PaintingProps> = ({
             setIsInteractive={setIsInteractive}
           />
         )}
-        {/* Standard Viewer displays */}
         {!showPlaceholder &&
           !customDisplay &&
           (isMedia ? (
@@ -332,13 +397,33 @@ const Painting: React.FC<PaintingProps> = ({
               />
             )
           ))}
-        {/* Custom display */}
         {!showPlaceholder && CustomComponent && (
           <CustomComponent
             id={activeCanvas}
             annotationBody={painting[annotationIndex]}
             hooks={{ useViewerDispatch, useViewerState }}
             {...customDisplay?.display.componentProps}
+          />
+        )}
+        {isAnimationMode && !isMedia && !showPlaceholder && (
+          <AnimationControls
+            frameIndex={annotationIndex}
+            isPlaying={isPlaying}
+            playbackRate={playbackRate}
+            totalFrames={totalFrames}
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onPrevFrame={() => {
+              setIsPlaying(false);
+              setAnnotationIndex((prev) => Math.max(0, prev - 1));
+            }}
+            onNextFrame={() => {
+              setIsPlaying(false);
+              setAnnotationIndex((prev) =>
+                Math.min(totalFrames - 1, prev + 1),
+              );
+            }}
+            onSetPlaybackRate={setPlaybackRate}
           />
         )}
       </PaintingCanvas>

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Select, SelectOption } from "src/components/UI/Select";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 
-import AnimationControls from "./AnimationControls";
+import AnimationControls, { AnimationBar } from "./AnimationControls";
 import { AnnotationResources } from "src/types/annotations";
 import ImageViewer from "src/components/Image";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
@@ -99,10 +99,11 @@ const Painting: React.FC<PaintingProps> = ({
   // Animation mode requires auto-advance AND temporal annotation targets (#t=).
   // A canvas with auto-advance + choice annotations is not animation mode —
   // it just auto-advances after its duration with the choice select still visible.
-  const hasTemporalAnnotations = useMemo(
-    () => getAnimationFrames(vault, activeCanvas).length > 0,
+  const animationFrames = useMemo(
+    () => getAnimationFrames(vault, activeCanvas),
     [vault, activeCanvas],
   );
+  const hasTemporalAnnotations = animationFrames.length > 0;
   const isAnimationMode = hasTemporalAnnotations;
   const hasChoice = Boolean(painting?.length > 1) && !isAnimationMode;
 
@@ -181,6 +182,11 @@ const Painting: React.FC<PaintingProps> = ({
   const handleChoiceChange = (value) => {
     const index = painting.findIndex((resource) => resource.id === value);
     setAnnotationIndex(index);
+  };
+
+  const handleFrameChange = (value: string) => {
+    setIsPlaying(false);
+    setAnnotationIndex(parseInt(value, 10));
   };
 
   const customDisplay = customDisplays.find((customDisplay) => {
@@ -419,26 +425,41 @@ const Painting: React.FC<PaintingProps> = ({
         )}
       </PaintingCanvas>
 
-      {isAnimationMode && !isMedia && !showPlaceholder && (
-        <AnimationControls
-          frameIndex={annotationIndex}
-          isPlaying={isPlaying}
-          isRepeat={isRepeat}
-          playbackRate={playbackRate}
-          totalFrames={totalFrames}
-          onPlay={() => setIsPlaying(true)}
-          onPause={() => setIsPlaying(false)}
-          onPrevFrame={() => {
-            setIsPlaying(false);
-            setAnnotationIndex((prev) => Math.max(0, prev - 1));
-          }}
-          onNextFrame={() => {
-            setIsPlaying(false);
-            setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
-          }}
-          onToggleRepeat={() => setIsRepeat((prev) => !prev)}
-          onSetPlaybackRate={setPlaybackRate}
-        />
+      {isAnimationMode && !showPlaceholder && (
+        <AnimationBar>
+          <AnimationControls
+            frameIndex={annotationIndex}
+            isPlaying={isPlaying}
+            isRepeat={isRepeat}
+            playbackRate={playbackRate}
+            totalFrames={totalFrames}
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onPrevFrame={() => {
+              setIsPlaying(false);
+              setAnnotationIndex((prev) => Math.max(0, prev - 1));
+            }}
+            onNextFrame={() => {
+              setIsPlaying(false);
+              setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
+            }}
+            onToggleRepeat={() => setIsRepeat((prev) => !prev)}
+            onSetPlaybackRate={setPlaybackRate}
+          />
+          {/* <Select
+            value={String(annotationIndex)}
+            onValueChange={handleFrameChange}
+            maxHeight={"200px"}
+          >
+            {animationFrames.map((frame, index) => (
+              <SelectOption
+                value={String(index)}
+                key={index}
+                label={frame.label ?? { none: [String(index + 1)] }}
+              />
+            ))}
+          </Select> */}
+        </AnimationBar>
       )}
 
       {hasChoice && (

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -355,10 +355,9 @@ const Painting: React.FC<PaintingProps> = ({
       <PaintingCanvas
         style={{
           backgroundColor: configOptions.canvasBackgroundColor,
-          height:
-            configOptions.canvasHeight === "auto"
-              ? "100%"
-              : configOptions.canvasHeight,
+          ...(configOptions.canvasHeight !== "auto" && {
+            height: configOptions.canvasHeight,
+          }),
         }}
       >
         {Boolean(placeholderItems.length) && !isMedia && (
@@ -405,28 +404,27 @@ const Painting: React.FC<PaintingProps> = ({
             {...customDisplay?.display.componentProps}
           />
         )}
-        {isAnimationMode && !isMedia && !showPlaceholder && (
-          <AnimationControls
-            frameIndex={annotationIndex}
-            isPlaying={isPlaying}
-            playbackRate={playbackRate}
-            totalFrames={totalFrames}
-            onPlay={() => setIsPlaying(true)}
-            onPause={() => setIsPlaying(false)}
-            onPrevFrame={() => {
-              setIsPlaying(false);
-              setAnnotationIndex((prev) => Math.max(0, prev - 1));
-            }}
-            onNextFrame={() => {
-              setIsPlaying(false);
-              setAnnotationIndex((prev) =>
-                Math.min(totalFrames - 1, prev + 1),
-              );
-            }}
-            onSetPlaybackRate={setPlaybackRate}
-          />
-        )}
       </PaintingCanvas>
+
+      {isAnimationMode && !isMedia && !showPlaceholder && (
+        <AnimationControls
+          frameIndex={annotationIndex}
+          isPlaying={isPlaying}
+          playbackRate={playbackRate}
+          totalFrames={totalFrames}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onPrevFrame={() => {
+            setIsPlaying(false);
+            setAnnotationIndex((prev) => Math.max(0, prev - 1));
+          }}
+          onNextFrame={() => {
+            setIsPlaying(false);
+            setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
+          }}
+          onSetPlaybackRate={setPlaybackRate}
+        />
+      )}
 
       {hasChoice && (
         <Select

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -18,23 +18,28 @@ import { hlsMimeTypes } from "src/lib/hls";
 interface PlayerProps {
   allSources: LabeledIIIFExternalWebResource[];
   annotationResources: AnnotationResources;
+  onEnded?: () => void;
   painting: LabeledIIIFExternalWebResource;
 }
 
 const Player: React.FC<PlayerProps> = ({
   allSources,
   annotationResources,
+  onEnded,
   painting,
 }) => {
   const [currentTime, setCurrentTime] = React.useState<number>(0);
   const [poster, setPoster] = React.useState<string | undefined>();
   const playerRef = React.useRef<HTMLVideoElement>(null);
-  const isAudio = painting?.type === "Sound";
+  const onEndedRef = React.useRef(onEnded);
+  React.useEffect(() => { onEndedRef.current = onEnded; }, [onEnded]);
 
   const viewerDispatch: any = useViewerDispatch();
   const viewerState: ViewerContextStore = useViewerState();
-  const { activeCanvas, configOptions, contentStateAnnotation, vault } =
+
+  const { activeCanvas, configOptions, contentStateAnnotation, isMediaPlaying, vault } =
     viewerState;
+  const isAudio = painting?.type === "Sound";
 
   /**
    * HLS.js binding for .m3u8 files
@@ -182,13 +187,47 @@ const Player: React.FC<PlayerProps> = ({
       }
     };
 
+    const onEndedHandler = () => onEndedRef.current?.();
+
     video.addEventListener("timeupdate", onTimeUpdate);
+    video.addEventListener("ended", onEndedHandler);
 
     return () => {
       video?.removeEventListener("timeupdate", onTimeUpdate);
+      video?.removeEventListener("ended", onEndedHandler);
       if (intervalId) clearInterval(intervalId);
     };
   }, [painting.id, activeCanvas]);
+
+  // Auto-play when mounting a new source if media was already playing
+  useEffect(() => {
+    const video = playerRef.current;
+    if (!video || !isMediaPlaying) return;
+
+    const onCanPlay = () => video.play().catch(() => {});
+    video.addEventListener("canplay", onCanPlay, { once: true });
+    return () => video.removeEventListener("canplay", onCanPlay);
+  }, [painting.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Keep isMediaPlaying context in sync with actual playback state
+  useEffect(() => {
+    const video = playerRef.current;
+    if (!video) return;
+
+    const onPlay = () =>
+      viewerDispatch({ type: "updateIsMediaPlaying", isMediaPlaying: true });
+    const onPause = () => {
+      if (!video.ended)
+        viewerDispatch({ type: "updateIsMediaPlaying", isMediaPlaying: false });
+    };
+
+    video.addEventListener("play", onPlay);
+    video.addEventListener("pause", onPause);
+    return () => {
+      video.removeEventListener("play", onPlay);
+      video.removeEventListener("pause", onPause);
+    };
+  }, [painting.id, viewerDispatch]);
 
   /**
    * Update to video to content state annotation selector

--- a/src/components/Viewer/Properties/Thumbnail.tsx
+++ b/src/components/Viewer/Properties/Thumbnail.tsx
@@ -9,11 +9,13 @@ import { Thumbnail } from "src/components/Primitives";
 interface PropertiesThumbnailProps {
   label: InternationalString | null;
   thumbnail: IIIFExternalWebResource[];
+  objectFit?: "cover" | "contain";
 }
 
 const PropertiesThumbnail: React.FC<PropertiesThumbnailProps> = ({
   label,
   thumbnail,
+  objectFit = "cover",
 }) => {
   if (thumbnail?.length === 0) return <></>;
 
@@ -22,7 +24,7 @@ const PropertiesThumbnail: React.FC<PropertiesThumbnailProps> = ({
       <Thumbnail
         altAsLabel={label ? label : { none: ["resource"] }}
         thumbnail={thumbnail}
-        style={{ backgroundColor: "#6663", objectFit: "cover" }}
+        style={{ backgroundColor: "#6663", objectFit: objectFit }}
       />
     </>
   );

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -188,61 +188,72 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
   ]);
 
   useEffect(() => {
-    if (activeManifest)
-      vault
-        .load(activeManifest)
-        .then((data: ManifestNormalized) => {
-          if (!data) return;
+    if (!activeManifest) return;
 
-          setManifest(data);
+    // When a manifest's internal `id` differs from the URL it was fetched from,
+    // vault stores the entity under the internal id but tracks the *request* under
+    // the fetch URL. A subsequent vault.load(internalId) finds no request entry
+    // and tries to fetch from the internal id as a URL, which may not resolve.
+    // Check vault.get first — it looks directly in entities and handles this case.
+    const existingManifest = vault.get(activeManifest) as ManifestNormalized | null;
+    const manifestLoader: Promise<ManifestNormalized> =
+      existingManifest && Array.isArray((existingManifest as any).items)
+        ? Promise.resolve(existingManifest)
+        : (vault.load(activeManifest) as Promise<ManifestNormalized>);
 
-          /**
-           * ignoring as ManifestNormalized mismatches across helper libraries
-           */
+    manifestLoader
+      .then((data: ManifestNormalized) => {
+        if (!data) return;
 
-          // @ts-ignore
-          const sequence = getManifestSequence(vault, data);
-          const canvasId = activeCanvas || getActiveCanvas(data);
+        setManifest(data);
 
-          dispatch({
-            type: "updateActiveCanvas",
-            canvasId: canvasId,
-          });
-          dispatch({
-            type: "updateManifestSequence",
-            sequence,
-          });
+        /**
+         * ignoring as ManifestNormalized mismatches across helper libraries
+         */
 
-          /**
-           * Extract viewingDirection from manifest (defaults to left-to-right)
-           * and check if behavior includes "paged"
-           */
-          // @ts-ignore - viewingDirection exists on IIIF manifest but may not be typed
-          const viewingDirection = data.viewingDirection || "left-to-right";
-          // @ts-ignore - behavior exists on IIIF manifest but may not be typed
-          const behavior = data.behavior || [];
-          const isPaged = Array.isArray(behavior)
-            ? behavior.includes("paged")
-            : behavior === "paged";
+        // @ts-ignore
+        const sequence = getManifestSequence(vault, data);
+        const canvasId = activeCanvas || getActiveCanvas(data);
 
-          dispatch({
-            type: "updateViewingDirection",
-            viewingDirection,
-          });
-          dispatch({
-            type: "updateIsPaged",
-            isPaged,
-          });
-        })
-        .catch((error: Error) => {
-          console.error(`Manifest failed to load: ${error}`);
-        })
-        .finally(() => {
-          dispatch({
-            type: "updateIsLoaded",
-            isLoaded: true,
-          });
+        dispatch({
+          type: "updateActiveCanvas",
+          canvasId: canvasId,
         });
+        dispatch({
+          type: "updateManifestSequence",
+          sequence,
+        });
+
+        /**
+         * Extract viewingDirection from manifest (defaults to left-to-right)
+         * and check if behavior includes "paged"
+         */
+        // @ts-ignore - viewingDirection exists on IIIF manifest but may not be typed
+        const viewingDirection = data.viewingDirection || "left-to-right";
+        // @ts-ignore - behavior exists on IIIF manifest but may not be typed
+        const behavior = data.behavior || [];
+        const isPaged = Array.isArray(behavior)
+          ? behavior.includes("paged")
+          : behavior === "paged";
+
+        dispatch({
+          type: "updateViewingDirection",
+          viewingDirection,
+        });
+        dispatch({
+          type: "updateIsPaged",
+          isPaged,
+        });
+      })
+      .catch((error: Error) => {
+        console.error(`Manifest failed to load: ${error}`);
+      })
+      .finally(() => {
+        dispatch({
+          type: "updateIsLoaded",
+          isLoaded: true,
+        });
+      });
   }, [iiifContent, activeManifest, dispatch, vault]);
 
   useEffect(() => {

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -205,6 +205,7 @@ export interface ViewerContextStore {
   isAutoScrolling?: boolean;
   isInformationOpen: boolean;
   isLoaded: boolean;
+  isMediaPlaying: boolean;
   isPaged: boolean;
   isUserScrolling?: number | undefined;
   sequence: [Reference<"Canvas">[], number[][]];
@@ -229,6 +230,7 @@ export interface ViewerAction {
   isAutoScrolling: boolean;
   isInformationOpen: boolean;
   isLoaded: boolean;
+  isMediaPlaying?: boolean;
   isPaged: boolean;
   isUserScrolling: number | undefined;
   manifestId: string;
@@ -320,6 +322,7 @@ export const createDefaultState = (): ViewerContextStore => ({
   // Respect explicit false; default to true only when undefined
   isInformationOpen: defaultConfigOptions?.informationPanel?.open ?? true,
   isLoaded: false,
+  isMediaPlaying: false,
   isPaged: false,
   isUserScrolling: undefined,
   sequence: [[], []],
@@ -418,6 +421,12 @@ function viewerReducer(state: ViewerContextStore, action: ViewerAction) {
       return {
         ...state,
         isLoaded: action.isLoaded,
+      };
+    }
+    case "updateIsMediaPlaying": {
+      return {
+        ...state,
+        isMediaPlaying: action.isMediaPlaying ?? false,
       };
     }
     case "updateManifestSequence": {

--- a/src/hooks/use-iiif/getAnimationFrames.ts
+++ b/src/hooks/use-iiif/getAnimationFrames.ts
@@ -1,0 +1,57 @@
+import { AnnotationPageNormalized, CanvasNormalized } from "@iiif/presentation-3";
+
+import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
+import { parseAnnotationTarget } from "src/lib/annotation-helpers";
+
+export interface AnimationFrame {
+  body: LabeledIIIFExternalWebResource;
+  startTime: number;
+  endTime: number;
+  duration: number;
+}
+
+export const getAnimationFrames = (
+  vault: any,
+  canvasId: string,
+): AnimationFrame[] => {
+  const canvas: CanvasNormalized = vault.get(canvasId);
+  if (!canvas?.items?.length) return [];
+
+  const annotationPage: AnnotationPageNormalized = vault.get(canvas.items[0]);
+  if (!annotationPage?.items?.length) return [];
+
+  const annotations = vault.get(annotationPage.items);
+  const frames: AnimationFrame[] = [];
+
+  for (const annotation of annotations) {
+    if (!annotation?.target) continue;
+
+    const parsed = parseAnnotationTarget(annotation.target);
+    if (!parsed.t) continue;
+
+    const parts = parsed.t.split(",").map(Number);
+    if (parts.length !== 2 || isNaN(parts[0]) || isNaN(parts[1])) continue;
+
+    const [startTime, endTime] = parts;
+
+    const bodyRef = Array.isArray(annotation.body)
+      ? annotation.body[0]
+      : annotation.body;
+    if (!bodyRef) continue;
+
+    const bodyId = typeof bodyRef === "string" ? bodyRef : bodyRef.id;
+    if (!bodyId) continue;
+
+    const body = vault.get(bodyId);
+    if (!body) continue;
+
+    frames.push({
+      body: body as LabeledIIIFExternalWebResource,
+      startTime,
+      endTime,
+      duration: endTime - startTime,
+    });
+  }
+
+  return frames.sort((a, b) => a.startTime - b.startTime);
+};

--- a/src/hooks/use-iiif/getAnimationFrames.ts
+++ b/src/hooks/use-iiif/getAnimationFrames.ts
@@ -1,10 +1,15 @@
-import { AnnotationPageNormalized, CanvasNormalized } from "@iiif/presentation-3";
+import {
+  AnnotationPageNormalized,
+  CanvasNormalized,
+  InternationalString,
+} from "@iiif/presentation-3";
 
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
 import { parseAnnotationTarget } from "src/lib/annotation-helpers";
 
 export interface AnimationFrame {
   body: LabeledIIIFExternalWebResource;
+  label: InternationalString | null;
   startTime: number;
   endTime: number;
   duration: number;
@@ -47,6 +52,7 @@ export const getAnimationFrames = (
 
     frames.push({
       body: body as LabeledIIIFExternalWebResource,
+      label: annotation.label ?? null,
       startTime,
       endTime,
       duration: endTime - startTime,

--- a/src/hooks/use-iiif/getCanvasBehavior.ts
+++ b/src/hooks/use-iiif/getCanvasBehavior.ts
@@ -1,7 +1,8 @@
-import { CanvasNormalized } from "@iiif/presentation-3";
+import { CanvasNormalized, ManifestNormalized } from "@iiif/presentation-3";
 
 export interface CanvasBehavior {
   isAutoAdvance: boolean;
+  isManifestAutoAdvance: boolean;
   isRepeat: boolean;
   duration: number;
 }
@@ -9,19 +10,43 @@ export interface CanvasBehavior {
 export const getCanvasBehavior = (
   vault: any,
   canvasId: string,
+  manifestId?: string,
 ): CanvasBehavior => {
   const canvas: CanvasNormalized = vault.get(canvasId);
 
   if (!canvas) {
-    return { isAutoAdvance: false, isRepeat: false, duration: 0 };
+    return {
+      isAutoAdvance: false,
+      isManifestAutoAdvance: false,
+      isRepeat: false,
+      duration: 0,
+    };
   }
 
-  const behavior = canvas.behavior || [];
-  const behaviorArray = Array.isArray(behavior) ? behavior : [behavior];
+  const canvasBehavior = canvas.behavior || [];
+  const canvasBehaviorArray = Array.isArray(canvasBehavior)
+    ? canvasBehavior
+    : [canvasBehavior];
+
+  let manifestBehaviorArray: string[] = [];
+  if (manifestId) {
+    const manifest: ManifestNormalized = vault.get(manifestId);
+    if (manifest) {
+      const manifestBehavior = manifest.behavior || [];
+      manifestBehaviorArray = Array.isArray(manifestBehavior)
+        ? manifestBehavior
+        : [manifestBehavior];
+    }
+  }
+
+  // Canvas inherits from manifest when it has no behavior of its own
+  const effectiveBehavior =
+    canvasBehaviorArray.length > 0 ? canvasBehaviorArray : manifestBehaviorArray;
 
   return {
-    isAutoAdvance: behaviorArray.includes("auto-advance"),
-    isRepeat: behaviorArray.includes("repeat"),
+    isAutoAdvance: effectiveBehavior.includes("auto-advance"),
+    isManifestAutoAdvance: manifestBehaviorArray.includes("auto-advance"),
+    isRepeat: effectiveBehavior.includes("repeat"),
     duration: canvas.duration || 0,
   };
 };

--- a/src/hooks/use-iiif/getCanvasBehavior.ts
+++ b/src/hooks/use-iiif/getCanvasBehavior.ts
@@ -1,0 +1,27 @@
+import { CanvasNormalized } from "@iiif/presentation-3";
+
+export interface CanvasBehavior {
+  isAutoAdvance: boolean;
+  isRepeat: boolean;
+  duration: number;
+}
+
+export const getCanvasBehavior = (
+  vault: any,
+  canvasId: string,
+): CanvasBehavior => {
+  const canvas: CanvasNormalized = vault.get(canvasId);
+
+  if (!canvas) {
+    return { isAutoAdvance: false, isRepeat: false, duration: 0 };
+  }
+
+  const behavior = canvas.behavior || [];
+  const behaviorArray = Array.isArray(behavior) ? behavior : [behavior];
+
+  return {
+    isAutoAdvance: behaviorArray.includes("auto-advance"),
+    isRepeat: behaviorArray.includes("repeat"),
+    duration: canvas.duration || 0,
+  };
+};

--- a/src/hooks/useCanvasAnimation.ts
+++ b/src/hooks/useCanvasAnimation.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { AnimationFrame } from "src/hooks/use-iiif/getAnimationFrames";
+
+export interface UseCanvasAnimationOptions {
+  frames: AnimationFrame[];
+  duration: number;
+  isAutoAdvance: boolean;
+  isRepeat: boolean;
+  playbackRate: number;
+  onComplete?: () => void;
+}
+
+export interface UseCanvasAnimationResult {
+  frameIndex: number;
+  isPlaying: boolean;
+  totalFrames: number;
+  play: () => void;
+  pause: () => void;
+  prevFrame: () => void;
+  nextFrame: () => void;
+}
+
+export const useCanvasAnimation = ({
+  frames,
+  duration,
+  isAutoAdvance,
+  isRepeat,
+  playbackRate,
+  onComplete,
+}: UseCanvasAnimationOptions): UseCanvasAnimationResult => {
+  const [frameIndex, setFrameIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(isAutoAdvance);
+  const totalFrames = frames.length;
+
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  });
+
+  useEffect(() => {
+    setFrameIndex(0);
+    setIsPlaying(isAutoAdvance);
+  }, [frames]);
+
+  const frameInterval =
+    totalFrames > 0 ? (duration / totalFrames / playbackRate) * 1000 : 0;
+
+  useEffect(() => {
+    if (!isPlaying || totalFrames === 0 || frameInterval <= 0) return;
+
+    const timer = setTimeout(() => {
+      setFrameIndex((prev) => {
+        const next = prev + 1;
+        if (next >= totalFrames) {
+          if (isRepeat) return 0;
+          setIsPlaying(false);
+          onCompleteRef.current?.();
+          return prev;
+        }
+        return next;
+      });
+    }, frameInterval);
+
+    return () => clearTimeout(timer);
+  }, [isPlaying, frameIndex, frameInterval, isRepeat, totalFrames]);
+
+  const play = useCallback(() => setIsPlaying(true), []);
+  const pause = useCallback(() => setIsPlaying(false), []);
+
+  const prevFrame = useCallback(() => {
+    setIsPlaying(false);
+    setFrameIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const nextFrame = useCallback(() => {
+    setIsPlaying(false);
+    setFrameIndex((prev) => Math.min(totalFrames - 1, prev + 1));
+  }, [totalFrames]);
+
+  return { frameIndex, isPlaying, totalFrames, play, pause, prevFrame, nextFrame };
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,5 +28,10 @@
   "shareCollectionJson": "View Collection",
   "shareCollectionCopy": "Copy Collection URL",
   "shareManifestJson": "View Manifest",
-  "shareManifestCopy": "Copy Manifest URL"
+  "shareManifestCopy": "Copy Manifest URL",
+  "canvasAnimationPlay": "Play",
+  "canvasAnimationPause": "Pause",
+  "canvasAnimationPreviousFrame": "Previous frame",
+  "canvasAnimationNextFrame": "Next frame",
+  "canvasAnimationSpeed": "Speed"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -33,5 +33,6 @@
   "canvasAnimationPause": "Pause",
   "canvasAnimationPreviousFrame": "Previous frame",
   "canvasAnimationNextFrame": "Next frame",
+  "canvasAnimationRepeat": "Repeat",
   "canvasAnimationSpeed": "Speed"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -28,5 +28,10 @@
   "shareCollectionJson": "Ver colección",
   "shareCollectionCopy": "Copiar URL de la colección",
   "shareManifestJson": "Ver manifiesto",
-  "shareManifestCopy": "Copiar URL del manifiesto"
+  "shareManifestCopy": "Copiar URL del manifiesto",
+  "canvasAnimationPlay": "Reproducir",
+  "canvasAnimationPause": "Pausar",
+  "canvasAnimationPreviousFrame": "Fotograma anterior",
+  "canvasAnimationNextFrame": "Fotograma siguiente",
+  "canvasAnimationSpeed": "Velocidad"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -33,5 +33,6 @@
   "canvasAnimationPause": "Pausar",
   "canvasAnimationPreviousFrame": "Fotograma anterior",
   "canvasAnimationNextFrame": "Fotograma siguiente",
+  "canvasAnimationRepeat": "Repetir",
   "canvasAnimationSpeed": "Velocidad"
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -21,5 +21,10 @@
   "shareCollectionJson": "Näytä kokoelma",
   "shareCollectionCopy": "Kopioi kokoelman osoite",
   "shareManifestJson": "Näytä manifesti",
-  "shareManifestCopy": "Kopioi manifestin osoite"
+  "shareManifestCopy": "Kopioi manifestin osoite",
+  "canvasAnimationPlay": "Toista",
+  "canvasAnimationPause": "Keskeytä",
+  "canvasAnimationPreviousFrame": "Edellinen ruutu",
+  "canvasAnimationNextFrame": "Seuraava ruutu",
+  "canvasAnimationSpeed": "Nopeus"
 }

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -26,5 +26,6 @@
   "canvasAnimationPause": "Keskeytä",
   "canvasAnimationPreviousFrame": "Edellinen ruutu",
   "canvasAnimationNextFrame": "Seuraava ruutu",
+  "canvasAnimationRepeat": "Toista uudelleen",
   "canvasAnimationSpeed": "Nopeus"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -33,5 +33,6 @@
   "canvasAnimationPause": "Pause",
   "canvasAnimationPreviousFrame": "Image précédente",
   "canvasAnimationNextFrame": "Image suivante",
+  "canvasAnimationRepeat": "Répéter",
   "canvasAnimationSpeed": "Vitesse"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -28,5 +28,10 @@
   "shareCollectionJson": "Afficher la collection",
   "shareCollectionCopy": "Copier l’URL de la collection",
   "shareManifestJson": "Afficher le manifeste",
-  "shareManifestCopy": "Copier l’URL du manifeste"
+  "shareManifestCopy": "Copier l’URL du manifeste",
+  "canvasAnimationPlay": "Lire",
+  "canvasAnimationPause": "Pause",
+  "canvasAnimationPreviousFrame": "Image précédente",
+  "canvasAnimationNextFrame": "Image suivante",
+  "canvasAnimationSpeed": "Vitesse"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -26,5 +26,6 @@
   "canvasAnimationPause": "Pause",
   "canvasAnimationPreviousFrame": "Forrige bilde",
   "canvasAnimationNextFrame": "Neste bilde",
+  "canvasAnimationRepeat": "Gjenta",
   "canvasAnimationSpeed": "Hastighet"
 }

--- a/src/i18n/locales/nb.json
+++ b/src/i18n/locales/nb.json
@@ -21,5 +21,10 @@
   "shareCollectionJson": "Se samlingen",
   "shareCollectionCopy": "Kopiér samlingens URL",
   "shareManifestJson": "Se manifestet",
-  "shareManifestCopy": "Kopiér manifestets URL"
+  "shareManifestCopy": "Kopiér manifestets URL",
+  "canvasAnimationPlay": "Spill av",
+  "canvasAnimationPause": "Pause",
+  "canvasAnimationPreviousFrame": "Forrige bilde",
+  "canvasAnimationNextFrame": "Neste bilde",
+  "canvasAnimationSpeed": "Hastighet"
 }

--- a/src/i18n/locales/nn.json
+++ b/src/i18n/locales/nn.json
@@ -21,5 +21,10 @@
   "shareCollectionJson": "Sjå samlinga",
   "shareCollectionCopy": "Kopiér samlingas URL",
   "shareManifestJson": "Sjå manifestet",
-  "shareManifestCopy": "Kopiér manifestets URL"
+  "shareManifestCopy": "Kopiér manifestets URL",
+  "canvasAnimationPlay": "Spel av",
+  "canvasAnimationPause": "Pause",
+  "canvasAnimationPreviousFrame": "Førre bilete",
+  "canvasAnimationNextFrame": "Neste bilete",
+  "canvasAnimationSpeed": "Hastigheit"
 }

--- a/src/i18n/locales/nn.json
+++ b/src/i18n/locales/nn.json
@@ -26,5 +26,6 @@
   "canvasAnimationPause": "Pause",
   "canvasAnimationPreviousFrame": "Førre bilete",
   "canvasAnimationNextFrame": "Neste bilete",
+  "canvasAnimationRepeat": "Gjenta",
   "canvasAnimationSpeed": "Hastigheit"
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -26,5 +26,6 @@
   "canvasAnimationPause": "Pause",
   "canvasAnimationPreviousFrame": "Forrige bilde",
   "canvasAnimationNextFrame": "Neste bilde",
+  "canvasAnimationRepeat": "Gjenta",
   "canvasAnimationSpeed": "Hastighet"
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -21,5 +21,10 @@
   "shareCollectionJson": "Se samlingen",
   "shareCollectionCopy": "Kopiér samlingens URL",
   "shareManifestJson": "Se manifestet",
-  "shareManifestCopy": "Kopiér manifestets URL"
+  "shareManifestCopy": "Kopiér manifestets URL",
+  "canvasAnimationPlay": "Spill av",
+  "canvasAnimationPause": "Pause",
+  "canvasAnimationPreviousFrame": "Forrige bilde",
+  "canvasAnimationNextFrame": "Neste bilde",
+  "canvasAnimationSpeed": "Hastighet"
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1,1 +1,7 @@
-{}
+{
+  "canvasAnimationPlay": "Reproduzir",
+  "canvasAnimationPause": "Pausar",
+  "canvasAnimationPreviousFrame": "Fotograma anterior",
+  "canvasAnimationNextFrame": "Próximo fotograma",
+  "canvasAnimationSpeed": "Velocidade"
+}

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -3,5 +3,6 @@
   "canvasAnimationPause": "Pausar",
   "canvasAnimationPreviousFrame": "Fotograma anterior",
   "canvasAnimationNextFrame": "Próximo fotograma",
+  "canvasAnimationRepeat": "Repetir",
   "canvasAnimationSpeed": "Velocidade"
 }

--- a/src/lib/annotation-helpers.test.ts
+++ b/src/lib/annotation-helpers.test.ts
@@ -84,6 +84,34 @@ describe("parseAnnotationTarget", () => {
     expect(result).toEqual(expected);
   });
 
+  it("handles target strings with t using query param style (&t=)", () => {
+    const target = "http://example.com/canvas/1&t=0,2";
+
+    const result = parseAnnotationTarget(target);
+
+    const expected = {
+      id: "http://example.com/canvas/1",
+      t: "0,2",
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it("handles vault-normalized SpecificResource with &t= in source id (no selector)", () => {
+    const target = {
+      type: "SpecificResource" as const,
+      source: { id: "http://example.com/canvas/1&t=0,2", type: "Canvas" as const },
+    };
+
+    // @ts-ignore - testing non-standard vault normalization shape
+    const result = parseAnnotationTarget(target);
+
+    const expected = {
+      id: "http://example.com/canvas/1",
+      t: "0,2",
+    };
+    expect(result).toEqual(expected);
+  });
+
   it("handles target objects with PointSelector", () => {
     const target: AnnotationTargetExtended = {
       type: "SpecificResource",

--- a/src/lib/annotation-helpers.ts
+++ b/src/lib/annotation-helpers.ts
@@ -86,11 +86,12 @@ const parseAnnotationTarget = (target: AnnotationTargetExtended | string) => {
         svg: target.selector.value,
       };
     } else if (target.selector?.type === "FragmentSelector") {
-      if (
-        target.selector?.value.includes("xywh=") &&
-        target.source.type == "Canvas" &&
-        target.source.id
-      ) {
+      const sourceId =
+        typeof target.source === "string"
+          ? target.source
+          : target.source?.id;
+
+      if (target.selector?.value.includes("xywh=") && sourceId) {
         const parts = target.selector?.value.split("xywh=");
         if (parts && parts[1]) {
           const [x, y, w, h] = parts[1]
@@ -98,13 +99,16 @@ const parseAnnotationTarget = (target: AnnotationTargetExtended | string) => {
             .map((value) => Number(value));
 
           parsedTarget = {
-            id: target.source.id,
-            rect: {
-              x,
-              y,
-              w,
-              h,
-            },
+            id: sourceId,
+            rect: { x, y, w, h },
+          };
+        }
+      } else if (target.selector?.value.includes("t=") && sourceId) {
+        const parts = target.selector.value.split("t=");
+        if (parts && parts[1]) {
+          parsedTarget = {
+            id: sourceId,
+            t: parts[1],
           };
         }
       }

--- a/src/lib/annotation-helpers.ts
+++ b/src/lib/annotation-helpers.ts
@@ -62,8 +62,9 @@ const parseAnnotationTarget = (target: AnnotationTargetExtended | string) => {
           },
         };
       }
-    } else if (target.includes("#t=")) {
-      const parts = target.split("#t=");
+    } else if (target.includes("#t=") || target.includes("&t=")) {
+      const separator = target.includes("#t=") ? "#t=" : "&t=";
+      const parts = target.split(separator);
       if (parts && parts[1]) {
         parsedTarget = {
           id: parts[0],
@@ -110,6 +111,19 @@ const parseAnnotationTarget = (target: AnnotationTargetExtended | string) => {
             id: sourceId,
             t: parts[1],
           };
+        }
+      }
+    } else {
+      // Vault normalizes "&t=" query-param style targets to SpecificResource
+      // without a selector (it only splits on "#"). Extract time from source.id.
+      const sourceId =
+        typeof target.source === "string"
+          ? target.source
+          : target.source?.id;
+      if (sourceId?.includes("&t=")) {
+        const parts = sourceId.split("&t=");
+        if (parts[1]) {
+          parsedTarget = { id: parts[0], t: parts[1] };
         }
       }
     }


### PR DESCRIPTION
## What does this do?

This adds support for the Cookbook recipe https://iiif.io/api/cookbook/recipe/0560-resources-on-a-timeline/manifest.json where items are rendered on "timeline" based on a combination of a set `Canvas` `duration` value and `behavior` of `repeat` and/or `auto-advance`.

<img width="1303" height="985" alt="image" src="https://github.com/user-attachments/assets/47aba448-0907-40e3-9b24-cff769f31928" />

If these combination of properties are set, controls will appear that allow a user to navigate the Annotation _frames_ assigned to this canvas. They may auto-advance or repeat depending on their setting.