### PR TITLE
Fix l is not a function error in vanilla js.

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -142,12 +142,12 @@ const buildOptions = {
     resolve: {
       alias: {
         react: "preact/compat",
+        "react/jsx-runtime": "preact/jsx-runtime",
       },
     },
     esbuild: {
-      jsxFactory: "h",
-      jsxFragment: "PFrag",
-      jsxInject: `import { h, Fragment as PFrag } from 'preact'`,
+      jsx: "automatic",
+      jsxImportSource: "preact",
     },
     build: {
       sourcemap: false,


### PR DESCRIPTION
## Problem

Loading a IIIF manifest with annotations in the web component (vanilla JS) build causes the Annotations tab to say:                                                                                    

```
Something went wrong                                                                                                                                                        
Error message: l is not a function
```

The root cause seems to be a variable naming collision in the minified bundle. The web component build currently uses the classic JSX factory pattern:                                          

```
esbuild: {                                                                                                                                                                    
  jsxFactory: "h",                                                                                                                                                            
  jsxFragment: "PFrag",
  jsxInject: `import { h, Fragment as PFrag } from 'preact'`,                                                                                                                 
},   
```           

When esbuild minifies the bundle, it renames all variables to short letters. In some scopes h is correctly renamed (e.g. to `L`), but in the annotation rendering scope it is renamed to `l`.  That letter (`l`) is already used (renderFormat string variable / "text/plain"). This is the root (I think) of the `l` is not a function error.                                                                                                        

## Proposed Fix

Switch the web component build from the classic JSX factory to the automatic JSX runtime:

```
resolve: {
  alias: {                                                                                                                                                                    
    react: "preact/compat",
    "react/jsx-runtime": "preact/jsx-runtime",                                                                                                                                
  },            
},
esbuild: {
  jsx: "automatic",
  jsxImportSource: "preact",
},       
```                                                                                                                                                                     

With the automatic runtime, esbuild imports deterministically-named helper functions (_jsx, _jsxs) from preact/jsx-runtime at the module scope rather than relying on a single renamed global variable.

## What Else Does this Fix

* text/markdown annotations are silently missing from the bundle currently.  It should be included now.
* VTT annotations are missing inlineCues. This is caused by the same thing. The rebuilt bundle should correctly pass inlineCues, label, and vttUri to the `AnnotationItemVTT` component. 
