### PR TITLE
Fix bug in content search firing

### DIFF
--- a/src/components/Viewer/InformationPanel/ContentSearch/ContentSearchForm.tsx
+++ b/src/components/Viewer/InformationPanel/ContentSearch/ContentSearchForm.tsx
@@ -27,12 +27,11 @@ const SearchContent: React.FC<Props> = ({
   const [searchTerms, setSearchTerms] = useState<string | undefined>();
 
   const viewerState: ViewerContextStore = useViewerState();
-  const { openSeadragonViewer, vault } = viewerState;
+  const { vault } = viewerState;
 
   async function searchSubmitHandler(e) {
     e.preventDefault();
 
-    if (!openSeadragonViewer) return;
     if (!searchServiceUrl) return;
     if (!searchTerms || searchTerms.trim() === "") {
       setContentSearchResource({} as unknown as AnnotationPageNormalized);
@@ -59,12 +58,8 @@ const SearchContent: React.FC<Props> = ({
   return (
     <FormStyled>
       <Form.Root onSubmit={searchSubmitHandler} className="content-search-form">
-        <Form.Field
-          className="content-search-input"
-          name="searchTerms"
-          onChange={handleChange}
-        >
-          <Form.Control placeholder={placeholder} />
+        <Form.Field className="content-search-input" name="searchTerms">
+          <Form.Control placeholder={placeholder} onChange={handleChange} />
         </Form.Field>
 
         <Form.Submit asChild>


### PR DESCRIPTION
### Summary

Fixes bug where queries entered in content search box were not correctly firing.

### Changes

Two fixes were made in `ContentSearchForm.tsx`:                           
                                                                     
  1. `onChange` moved to `Form.Control` (line 62) — React maps `onChange` on a   `<div>` to the native change event, which only fires on blur. On a `<input>` it correctly fires on every keystroke via the native input event. This  was why searchTerms was never being set before submit.                
  2. Removed `openSeadragonViewer` guard (was line 35) — Content search fetches from a IIIF search service URL; it has no dependency on the OSD viewer being initialized. That guard was silently swallowing all searches if OSD hadn't loaded yet.  