### PR TITLE
Add contentSearchCallback prop on viewer and pre-populate search input with initial query

### DIFF
--- a/pages/docs/viewer/contentsearch.mdx
+++ b/pages/docs/viewer/contentsearch.mdx
@@ -14,6 +14,7 @@ Due to the fact that the Clover documentation site is a statically generated, se
 
 <Viewer
   iiifContent="http://localhost:3000/manifest/content-search/newspaper.json"
+  iiifContentSearchQuery={{ q: "Berliner" }}
   options={{
     informationPanel: {
       open: true,

--- a/src/components/Viewer/InformationPanel/ContentSearch/ContentSearch.tsx
+++ b/src/components/Viewer/InformationPanel/ContentSearch/ContentSearch.tsx
@@ -20,6 +20,8 @@ type ContentSearchProps = {
   >;
   activeCanvas: string;
   annotationPage: AnnotationResource;
+  contentSearchCallback?: (query: string) => void;
+  initialSearchQuery?: string;
 };
 
 const ContentSearch: React.FC<ContentSearchProps> = ({
@@ -27,6 +29,8 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
   setContentSearchResource,
   activeCanvas,
   annotationPage,
+  contentSearchCallback,
+  initialSearchQuery,
 }) => {
   const viewerState: ViewerContextStore = useViewerState();
   const { vault } = viewerState;
@@ -65,6 +69,8 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
         setContentSearchResource={setContentSearchResource}
         activeCanvas={activeCanvas}
         setLoading={setLoading}
+        contentSearchCallback={contentSearchCallback}
+        initialSearchQuery={initialSearchQuery}
       />
       {loading ? (
         <span>{t("contentSearchLoading")}</span>

--- a/src/components/Viewer/InformationPanel/ContentSearch/ContentSearchForm.tsx
+++ b/src/components/Viewer/InformationPanel/ContentSearch/ContentSearchForm.tsx
@@ -16,15 +16,19 @@ type Props = {
   >;
   activeCanvas: string;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  contentSearchCallback?: (query: string) => void;
+  initialSearchQuery?: string;
 };
 
 const SearchContent: React.FC<Props> = ({
   searchServiceUrl,
   setContentSearchResource,
   setLoading,
+  contentSearchCallback,
+  initialSearchQuery,
 }) => {
   const { t } = useCloverTranslation();
-  const [searchTerms, setSearchTerms] = useState<string | undefined>();
+  const [searchTerms, setSearchTerms] = useState<string | undefined>(initialSearchQuery);
 
   const viewerState: ViewerContextStore = useViewerState();
   const { vault } = viewerState;
@@ -50,7 +54,9 @@ const SearchContent: React.FC<Props> = ({
 
   const handleChange = (e: any) => {
     e.preventDefault();
-    setSearchTerms(e.target.value);
+    const query = e.target.value;
+    setSearchTerms(query);
+    contentSearchCallback?.(query);
   };
 
   const placeholder = t("contentSearchPlaceholder");
@@ -59,7 +65,11 @@ const SearchContent: React.FC<Props> = ({
     <FormStyled>
       <Form.Root onSubmit={searchSubmitHandler} className="content-search-form">
         <Form.Field className="content-search-input" name="searchTerms">
-          <Form.Control placeholder={placeholder} onChange={handleChange} />
+          <Form.Control
+            placeholder={placeholder}
+            defaultValue={initialSearchQuery}
+            onChange={handleChange}
+          />
         </Form.Field>
 
         <Form.Submit asChild>

--- a/src/components/Viewer/InformationPanel/InformationPanel.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.tsx
@@ -42,6 +42,8 @@ interface NavigatorProps {
     React.SetStateAction<AnnotationPageNormalized | undefined>
   >;
   contentSearchResource?: AnnotationResource;
+  contentSearchCallback?: (query: string) => void;
+  initialSearchQuery?: string;
 }
 
 export const InformationPanel: React.FC<NavigatorProps> = ({
@@ -50,6 +52,8 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
   searchServiceUrl,
   setContentSearchResource,
   contentSearchResource,
+  contentSearchCallback,
+  initialSearchQuery,
 }) => {
   const { t } = useCloverTranslation();
   const dispatch: any = useViewerDispatch();
@@ -270,6 +274,8 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
               setContentSearchResource={setContentSearchResource}
               activeCanvas={activeCanvas}
               annotationPage={contentSearchResource}
+              contentSearchCallback={contentSearchCallback}
+              initialSearchQuery={initialSearchQuery}
             />
           </Content>
         )}

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -25,6 +25,8 @@ export interface ViewerContentProps {
     React.SetStateAction<AnnotationPageNormalized | undefined>
   >;
   contentSearchResource?: AnnotationResource;
+  contentSearchCallback?: (query: string) => void;
+  initialSearchQuery?: string;
   painting: IIIFExternalWebResource[];
   items: Canvas[];
   isAudioVideo: boolean;
@@ -36,6 +38,8 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
   searchServiceUrl,
   setContentSearchResource,
   contentSearchResource,
+  contentSearchCallback,
+  initialSearchQuery,
   isAudioVideo,
   items,
   painting,
@@ -101,6 +105,8 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
             searchServiceUrl={searchServiceUrl}
             setContentSearchResource={setContentSearchResource}
             contentSearchResource={contentSearchResource}
+            contentSearchCallback={contentSearchCallback}
+            initialSearchQuery={initialSearchQuery}
           />
         </Aside>
       )}

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -33,12 +33,14 @@ interface ViewerProps {
   manifest: ManifestNormalized;
   theme?: unknown;
   iiifContentSearchQuery?: ContentSearchQuery;
+  contentSearchCallback?: (query: string) => void;
 }
 
 const Viewer: React.FC<ViewerProps> = ({
   manifest,
   theme,
   iiifContentSearchQuery,
+  contentSearchCallback,
 }) => {
   /**
    * Viewer State
@@ -186,6 +188,8 @@ const Viewer: React.FC<ViewerProps> = ({
             searchServiceUrl={searchServiceUrl}
             setContentSearchResource={setContentSearchResource}
             contentSearchResource={contentSearchResource}
+            contentSearchCallback={contentSearchCallback}
+            initialSearchQuery={iiifContentSearchQuery?.q}
             items={manifest.items}
             isAudioVideo={isAudioVideo}
           />

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -33,6 +33,7 @@ import { hashCode } from "src/lib/utils";
 export interface CloverViewerProps {
   canvasIdCallback?: (arg0: string) => void;
   contentStateCallback?: (iiifContentState: object) => void;
+  contentSearchCallback?: (query: string) => void;
   customDisplays?: Array<CustomDisplay>;
   plugins?: Array<PluginConfig>;
   customTheme?: any;
@@ -46,6 +47,7 @@ export interface CloverViewerProps {
 const CloverViewer: React.FC<CloverViewerProps> = ({
   canvasIdCallback,
   contentStateCallback,
+  contentSearchCallback,
   customDisplays = [],
   plugins = [],
   customTheme,
@@ -90,6 +92,7 @@ const CloverViewer: React.FC<CloverViewerProps> = ({
         iiifContent={iiifResource}
         canvasIdCallback={canvasIdCallback}
         contentStateCallback={contentStateCallback}
+        contentSearchCallback={contentSearchCallback}
         customTheme={customTheme}
         options={options}
         iiifContentSearchQuery={iiifContentSearchQuery}
@@ -101,6 +104,7 @@ const CloverViewer: React.FC<CloverViewerProps> = ({
 const RenderViewer: React.FC<CloverViewerProps> = ({
   canvasIdCallback,
   contentStateCallback,
+  contentSearchCallback,
   customTheme,
   iiifContent,
   options,
@@ -417,6 +421,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
       theme={theme}
       key={manifest.id}
       iiifContentSearchQuery={iiifContentSearchQuery}
+      contentSearchCallback={contentSearchCallback}
     />
   );
 };


### PR DESCRIPTION
### Summary

Provide a callback so implementing apps can take action when content search query changes. Also fix bug where initial search query is not populating content search field.

### Specific changes

- Pre-populate the search input with `iiifContentSearchQuery.q` on mount. The query was already used to fire the initial search, but the input field showed blank, leaving users with no indication of what had been searched.     
- Added optional `contentSearchCallback?: (query: string) => void` prop to the top-level Viewer. Fires on every keystroke in the search input,  allowing consuming applications to react to query changes. Backwards compatible - no-op when not provided.

