### PR TITLE
Add `options.thumbnails.style` with `icons` mode

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -270,6 +270,7 @@ const MyCustomViewer = () => {
 | `options.showDownload`           | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.showIIIFBadge`          | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.showTitle`              | `boolean`                                                                                                                                        | No       | true                                     |
+| `options.thumbnails`             | [See Thumbnails](#thumbnails)                                                                                                                    | No       |                                          |
 | `options.customLoadingComponent` | `React.ComponentType`                                                                                                                            | No       |                                          |
 | `options.withCredentials`        | `boolean`                                                                                                                                        | No       | false                                    |
 | `options.contentSearch`          | [See Content Search](#content-search)                                                                                                            | No       |                                          |
@@ -502,6 +503,29 @@ By default, Clover's content search will draw light red boxes in the image viewe
 
 When you click on the list of search results, Clover will pan and zoom to the location of that search result. You can set the zoom level using `options.contentSearch.overlays.zoomLevel`. A small zoom level will zoom in real close; a large zoom level will zoom in less.
 
+### Thumbnails
+
+Control how the thumbnail strip below the viewer is rendered for multi-canvas Manifests.
+
+| Prop                       | Type                           | Required | Default |
+| -------------------------- | ------------------------------ | -------- | ------- |
+| `options.thumbnails.style` | `"auto" \| "icons"`            | No       | `auto`  |
+| `options.thumbnails.icon`  | `string` (URL to SVG or image) | No       |         |
+
+- `auto` (default) — render image thumbnails for each canvas.
+- `icons` — render a small icon (Image / Sound / Video) per canvas. Useful when canvas thumbnails look identical at small sizes or to save vertical space.
+
+When `style` is `icons`, pass `options.thumbnails.icon` as a URL (typically to an SVG) to override the default icon. The same icon is used for every canvas.
+
+```jsx
+const options = {
+  thumbnails: {
+    style: "icons",
+    icon: "/icons/triangle.svg",
+  },
+};
+```
+
 ### Deprecated Options
 
 | Prop                            | In Favor Of                             | Deprecated |
@@ -655,14 +679,12 @@ Additional CSS classes are made available on structural HTML elements in the Vie
 - Each WebVTT Cue is rendered inside a `<div class="webvtt-cue"/>` element.
 
 - The following inline formatting tags are passed through without alteration:
-
   - Bold (`<b/>`)
   - Italic (`<i/>`)
   - Underline (`<u/>`)
   - [Ruby](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ruby) (`<ruby/>`) and [Ruby Text](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rt) (`<rt/>`)
 
 - Several WebVTT-specific tags are processed in special ways:
-
   - Voice Tags (e.g., `<v speaker>Caption</v>`) are wrapped in `<span title="speaker"/>` and can be styled using the CSS selector `.webvtt-cue span[title="speaker"]`
   - Class Tags (e.g., `<c.classToAdd>Caption</c>`) are wrapped in `<span class="classtoAdd"/>` and can be styled using the CSS selector `.webvtt-cue span.classToAdd`
   - Language Tags (e.g., `<lang.en-US>English Caption</lang>`) are handled the same as Class Tags - wrapped in `<span class="en-US"/>` and can be styled using the CSS selector `.webvtt-cue span.en-US`

--- a/src/components/Viewer/Media/Controls.tsx
+++ b/src/components/Viewer/Media/Controls.tsx
@@ -115,10 +115,7 @@ const Controls: React.FC<ControlsProps> = ({
     handleFilter(event.target.value);
 
   return (
-    <Wrapper 
-      isToggle={toggleFilter} 
-      className="clover-viewer-media-controls"
-    >
+    <Wrapper isToggle={toggleFilter} className="clover-viewer-media-controls">
       <Form>
         {toggleFilter && (
           <Input
@@ -128,7 +125,10 @@ const Controls: React.FC<ControlsProps> = ({
           />
         )}
         {!toggleFilter && (
-          <Direction className="clover-viewer-media-navigation" data-rtl-paged={isRtlPaged}>
+          <Direction
+            className="clover-viewer-media-navigation"
+            data-rtl-paged={isRtlPaged}
+          >
             {isRtlPaged ? (
               <>
                 <Button

--- a/src/components/Viewer/Media/Thumbnail.styled.tsx
+++ b/src/components/Viewer/Media/Thumbnail.styled.tsx
@@ -90,6 +90,44 @@ const Item = styled(RadioGroup.Item, {
   fontSize: "1rem",
   textAlign: "left",
 
+  "figure[data-thumbnail-style='icons']": {
+    width: "80px",
+
+    [`& ${FigureImage}`]: {
+      height: "80px",
+      borderRadius: "6px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+
+    ".media-thumbnail-icon": {
+      display: "flex",
+      width: "55%",
+      height: "55%",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "$secondary",
+
+      svg: {
+        width: "100%",
+        height: "100%",
+        fill: "currentColor",
+      },
+
+      img: {
+        width: "100%",
+        height: "100%",
+        objectFit: "contain",
+      },
+    },
+
+    figcaption: {
+      textAlign: "center",
+      WebkitLineClamp: "1",
+    },
+  },
+
   figure: {
     margin: "0",
     width: "161.8px",

--- a/src/components/Viewer/Media/Thumbnail.test.tsx
+++ b/src/components/Viewer/Media/Thumbnail.test.tsx
@@ -28,6 +28,7 @@ import { StyledSequence } from "src/components/Viewer/Media/Media.styled";
 import Thumbnail from "src/components/Viewer/Media/Thumbnail";
 import { ThumbnailProps } from "src/components/Viewer/Media/Thumbnail";
 import { getThumbnail } from "@iiif/helpers/thumbnail";
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
 
 const props: ThumbnailProps = {
   canvas: {
@@ -165,6 +166,50 @@ describe("Thumbnail component", () => {
       );
       const fig = await screen.findByTestId("fig-caption");
       expect(fig).toHaveTextContent("2");
+    });
+  });
+
+  describe("icons style", () => {
+    it("renders icon instead of image when thumbnails.style is 'icons'", () => {
+      const initialState = {
+        ...defaultState,
+        configOptions: {
+          ...defaultState.configOptions,
+          thumbnails: { style: "icons" as const },
+        },
+      };
+      render(
+        <ViewerProvider initialState={initialState}>
+          <StyledSequence>
+            <Thumbnail {...props} />
+          </StyledSequence>
+        </ViewerProvider>,
+      );
+      expect(screen.getByTestId("media-thumbnail-icon")).toBeInTheDocument();
+      expect(screen.queryByTestId("media-thumbnail-lazyload")).toBeNull();
+      expect(screen.queryByTestId("media-thumbnail-image")).toBeNull();
+    });
+
+    it("renders the custom icon when thumbnails.icon is provided", () => {
+      const initialState = {
+        ...defaultState,
+        configOptions: {
+          ...defaultState.configOptions,
+          thumbnails: {
+            style: "icons" as const,
+            icon: "https://example.org/icon.svg",
+          },
+        },
+      };
+      render(
+        <ViewerProvider initialState={initialState}>
+          <StyledSequence>
+            <Thumbnail {...props} />
+          </StyledSequence>
+        </ViewerProvider>,
+      );
+      const img = screen.getByTestId("media-thumbnail-icon-custom");
+      expect(img).toHaveAttribute("src", "https://example.org/icon.svg");
     });
   });
 

--- a/src/components/Viewer/Media/Thumbnail.tsx
+++ b/src/components/Viewer/Media/Thumbnail.tsx
@@ -58,16 +58,18 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
   const [load, setLoad] = useState(false);
   const [thumbnail, setThumbnail] = useState<string>();
   const state: ViewerContextStore = useViewerState();
-  const { vault } = state;
+  const { vault, configOptions } = state;
 
   const size = 200;
+  const isIconStyle = configOptions?.thumbnails?.style === "icons";
+  const customIcon = configOptions?.thumbnails?.icon;
 
   const label = canvas?.label
     ? (getLabelAsString(canvas?.label) as string)
     : String(canvasIndex + 1);
 
   useEffect(() => {
-    if (!load) return;
+    if (!load || isIconStyle) return;
 
     (async () => {
       try {
@@ -88,7 +90,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         console.error("Error fetching thumbnail", err);
       }
     })();
-  }, [canvas, load]);
+  }, [canvas, load, isIconStyle]);
 
   const handleIsVisibleCallback = (isVisible: boolean) => {
     setLoad(isVisible);
@@ -102,24 +104,42 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
       onClick={() => handleChange(canvas.id)}
       value={canvas.id}
     >
-      <figure>
+      <figure data-thumbnail-style={isIconStyle ? "icons" : "auto"}>
         <FigureImage>
-          <LazyLoad
-            isVisibleCallback={handleIsVisibleCallback}
-            attributes={{
-              className: "media-thumbnail-lazyload",
-              "data-lazyload": String(load),
-              "data-testid": "media-thumbnail-lazyload",
-            }}
-          >
-            {thumbnail && (
-              <img
-                alt={label}
-                data-testid="media-thumbnail-image"
-                src={thumbnail}
-              />
-            )}
-          </LazyLoad>
+          {isIconStyle ? (
+            <span
+              aria-label={label}
+              data-testid="media-thumbnail-icon"
+              className="media-thumbnail-icon"
+            >
+              {customIcon ? (
+                <img
+                  src={customIcon}
+                  alt=""
+                  data-testid="media-thumbnail-icon-custom"
+                />
+              ) : (
+                <IconPath type={type} />
+              )}
+            </span>
+          ) : (
+            <LazyLoad
+              isVisibleCallback={handleIsVisibleCallback}
+              attributes={{
+                className: "media-thumbnail-lazyload",
+                "data-lazyload": String(load),
+                "data-testid": "media-thumbnail-lazyload",
+              }}
+            >
+              {thumbnail && (
+                <img
+                  alt={label}
+                  data-testid="media-thumbnail-image"
+                  src={thumbnail}
+                />
+              )}
+            </LazyLoad>
+          )}
           <Outline />
           <Type>
             <Tag isIcon data-testid="thumbnail-tag">

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -12,6 +12,8 @@ import { Vault } from "@iiif/helpers/vault";
 import { deepMerge } from "src/lib/utils";
 import { v4 as uuidv4 } from "uuid";
 
+export type ThumbnailsStyle = "auto" | "icons";
+
 export type AutoScrollSettings = {
   behavior: string; // ScrollBehavior ("auto" | "instant" | "smooth")
   block: string; // ScrollLogicalPosition ("center" | "end" | "nearest" | "start")
@@ -54,6 +56,10 @@ export type ViewerConfigOptions = {
   showDownload?: boolean;
   showIIIFBadge?: boolean;
   showTitle?: boolean;
+  thumbnails?: {
+    style?: ThumbnailsStyle;
+    icon?: string;
+  };
   customLoadingComponent?: React.ComponentType;
   withCredentials?: boolean;
   localeText?: {
@@ -131,6 +137,9 @@ const defaultConfigOptions: ViewerConfigOptions = {
   showDownload: true,
   showIIIFBadge: true,
   showTitle: true,
+  thumbnails: {
+    style: "auto",
+  },
   withCredentials: false,
 };
 
@@ -249,11 +258,14 @@ export function expandAutoScrollOptions(
 ): AutoScrollOptions {
   // Get safe defaults, avoiding potential undefined values
   const getDefaults = (): AutoScrollOptions => {
-    const configDefaults = defaultConfigOptions?.informationPanel?.vtt?.autoScroll as AutoScrollOptions;
-    return configDefaults || {
-      enabled: true,
-      settings: defaultAutoScrollSettings,
-    };
+    const configDefaults = defaultConfigOptions?.informationPanel?.vtt
+      ?.autoScroll as AutoScrollOptions;
+    return (
+      configDefaults || {
+        enabled: true,
+        settings: defaultAutoScrollSettings,
+      }
+    );
   };
 
   const defaults = getDefaults();
@@ -495,23 +507,19 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
   const [state, dispatch] = useReducer<
     React.Reducer<ViewerContextStore, ViewerAction>,
     ViewerContextStore | undefined
-  >(
-    viewerReducer,
-    initialState,
-    (initArg?: ViewerContextStore) => {
-      if (initArg) {
-        return {
-          ...initArg,
-          configOptions: cloneViewerConfigOptions(
-            initArg.configOptions ?? defaultConfigOptions,
-          ),
-          viewerId: initArg.viewerId ?? uuidv4(),
-        };
-      }
+  >(viewerReducer, initialState, (initArg?: ViewerContextStore) => {
+    if (initArg) {
+      return {
+        ...initArg,
+        configOptions: cloneViewerConfigOptions(
+          initArg.configOptions ?? defaultConfigOptions,
+        ),
+        viewerId: initArg.viewerId ?? uuidv4(),
+      };
+    }
 
-      return createDefaultState();
-    },
-  );
+    return createDefaultState();
+  });
 
   const { openSeadragonViewer } = state;
 


### PR DESCRIPTION
## Summary

- Add `options.thumbnails.style` (`auto` | `icons`) to control how the thumbnail strip below the Viewer is rendered for multi-canvas Manifests.
- Add `options.thumbnails.icon` (URL string) to optionally override the icon used in `icons` mode (e.g. inline SVG hosted at a URL).
- Default is `auto`, so existing behaviour is unchanged.

`icons` mode renders a small (80px) icon per canvas — based on the canvas resource type (Image / Sound / Video) — instead of generated image thumbnails. Useful when canvas thumbnails look identical at small sizes or to save vertical space.

This addresses the first sub-feature of #223. The `hide` mode (and the related layout work to overlay nav controls on the canvas) is intentionally deferred to a follow-up PR after some additional design discussion.

API shape follows the suggestion from @mathewjordan in #223:

```ts
options: {
  thumbnails: {
    style: "auto" | "icons"; // default: "auto"
    icon?: string;           // URL to SVG/image, optional
  }
}
```

## Test plan

- [ ] `npm run test` — all 215 tests pass (2 new tests added for `icons` mode + custom `icon` URL)
- [ ] `npx prettier --check` clean on touched files
- [ ] `npm run build` succeeds
- [ ] Manually verified in `npm run dev`:
  - default (`auto`) renders unchanged
  - `style: "icons"` renders type-based default icons
  - `style: "icons"` + `icon: "<url>"` renders the custom icon

Refs #223