### PR TITLE
Support paged Collections via "Load more"

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -85,7 +85,7 @@ Provide a [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) Manifes
 - _Video_ and _Sound_ are rendered within a HTML5 `<video>` element
 - _Image_ canvases are renderered with [OpenSeadragon](https://openseadragon.github.io/)
 - Supports HLS streaming for Video and Audio canvases
-- Supports IIIF Collections and toggling between child Manifests
+- Supports IIIF Collections and toggling between child Manifests, including paged Collections (see [Paged Collections](#paged-collections))
 - Supports `placeholderCanvas` for _Image_ canvases.
 
 ## Installation
@@ -502,6 +502,32 @@ By default, Clover's content search will draw light red boxes in the image viewe
 
 When you click on the list of search results, Clover will pan and zoom to the location of that search result. You can set the zoom level using `options.contentSearch.overlays.zoomLevel`. A small zoom level will zoom in real close; a large zoom level will zoom in less.
 
+### Paged Collections
+
+When a IIIF Collection is large (e.g. a search results response), some providers split it across multiple pages. The IIIF Presentation API does not yet define a paging mechanism for Collections — see [IIIF/api#2174](https://github.com/IIIF/api/issues/2174) — but a convention has emerged in which the last entry of `items` is itself a Collection whose `id` is the URL of the next page.
+
+Clover detects this convention and renders a **Load more** button beneath the Collection picker. Clicking it fetches the next page, appends its Manifests to the picker (de-duplicated by `id`), and continues to expose **Load more** as long as further pages exist.
+
+Example (abbreviated) Collection response:
+
+```json
+{
+  "type": "Collection",
+  "id": "https://example.org/search?as=iiif&page=1",
+  "items": [
+    { "type": "Manifest", "id": "...", "label": { "none": ["..."] } },
+    { "type": "Manifest", "id": "...", "label": { "none": ["..."] } },
+    {
+      "type": "Collection",
+      "id": "https://example.org/search?as=iiif&page=2",
+      "label": { "none": ["Next page"] }
+    }
+  ]
+}
+```
+
+This convention is non-spec and may change once Presentation 4.0 standardises Collection paging.
+
 ### Deprecated Options
 
 | Prop                            | In Favor Of                             | Deprecated |
@@ -655,14 +681,12 @@ Additional CSS classes are made available on structural HTML elements in the Vie
 - Each WebVTT Cue is rendered inside a `<div class="webvtt-cue"/>` element.
 
 - The following inline formatting tags are passed through without alteration:
-
   - Bold (`<b/>`)
   - Italic (`<i/>`)
   - Underline (`<u/>`)
   - [Ruby](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ruby) (`<ruby/>`) and [Ruby Text](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rt) (`<rt/>`)
 
 - Several WebVTT-specific tags are processed in special ways:
-
   - Voice Tags (e.g., `<v speaker>Caption</v>`) are wrapped in `<span title="speaker"/>` and can be styled using the CSS selector `.webvtt-cue span[title="speaker"]`
   - Class Tags (e.g., `<c.classToAdd>Caption</c>`) are wrapped in `<span class="classtoAdd"/>` and can be styled using the CSS selector `.webvtt-cue span.classToAdd`
   - Language Tags (e.g., `<lang.en-US>English Caption</lang>`) are handled the same as Class Tags - wrapped in `<span class="en-US"/>` and can be styled using the CSS selector `.webvtt-cue span.en-US`

--- a/src/components/UI/Select/Select.styled.tsx
+++ b/src/components/UI/Select/Select.styled.tsx
@@ -43,6 +43,7 @@ const StyledSelectContent = styled(Select.Content, {
   borderTopLeftRadius: "0",
   border: "1px solid $secondaryMuted",
   maxWidth: "90vw",
+  zIndex: 100,
 });
 
 const StyledSelectItem = styled(Select.Item, {

--- a/src/components/UI/Select/Select.tsx
+++ b/src/components/UI/Select/Select.tsx
@@ -24,6 +24,7 @@ interface SelectProps extends RadixSelectProps {
   children?: ReactNode[] | ReactNode;
   label?: InternationalString;
   maxHeight: string;
+  footer?: ReactNode;
 }
 
 /**
@@ -35,6 +36,7 @@ const Select: React.FC<SelectProps> = ({
   maxHeight,
   onValueChange,
   value,
+  footer,
 }) => {
   return (
     <StyledSelect onValueChange={onValueChange} value={value}>
@@ -46,13 +48,17 @@ const Select: React.FC<SelectProps> = ({
       </StyledSelectButton>
       <SelectPortal>
         <StyledSelectContent
-          css={{ maxHeight: `${maxHeight} !important` }}
+          css={{
+            maxHeight: `${maxHeight} !important`,
+            display: "flex",
+            flexDirection: "column",
+          }}
           data-testid="select-content"
         >
           <SelectScrollUpButton>
             <Icon direction="up" title="scroll up for more" />
           </SelectScrollUpButton>
-          <SelectViewport>
+          <SelectViewport style={{ flex: "1 1 auto", overflow: "auto" }}>
             <SelectGroup>
               {label && (
                 <StyledSelectLabel>
@@ -65,6 +71,11 @@ const Select: React.FC<SelectProps> = ({
           <SelectScrollDownButton>
             <Icon direction="down" title="scroll down for more" />
           </SelectScrollDownButton>
+          {footer && (
+            <div style={{ flex: "0 0 auto" }} data-testid="select-footer">
+              {footer}
+            </div>
+          )}
         </StyledSelectContent>
       </SelectPortal>
     </StyledSelect>

--- a/src/components/Viewer/Collection/Collection.styled.tsx
+++ b/src/components/Viewer/Collection/Collection.styled.tsx
@@ -1,0 +1,38 @@
+import { styled } from "src/styles/stitches.config";
+
+const FooterStyled = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  padding: "0.5rem 0.75rem",
+  borderTop: "1px solid $secondaryMuted",
+});
+
+const LoadMoreButtonStyled = styled("button", {
+  fontFamily: "inherit",
+  fontSize: "0.85rem",
+  fontWeight: "600",
+  padding: "0.35rem 0.9rem",
+  border: "none",
+  borderRadius: "3px",
+  backgroundColor: "$accent",
+  color: "$secondary",
+  cursor: "pointer",
+  transition: "$all",
+
+  "&:disabled": {
+    cursor: "wait",
+    opacity: "0.6",
+  },
+
+  "&:hover:not(:disabled)": {
+    backgroundColor: "$accentAlt",
+  },
+});
+
+const ErrorStyled = styled("span", {
+  fontSize: "0.85rem",
+  color: "tomato",
+});
+
+export { FooterStyled, LoadMoreButtonStyled, ErrorStyled };

--- a/src/components/Viewer/Collection/Collection.tsx
+++ b/src/components/Viewer/Collection/Collection.tsx
@@ -1,8 +1,14 @@
+import React, { useEffect, useState } from "react";
 import { Select, SelectOption } from "src/components/UI/Select";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 
-import { CollectionItems } from "@iiif/presentation-3";
-import React from "react";
+import { CollectionItems, CollectionNormalized } from "@iiif/presentation-3";
+import {
+  ErrorStyled,
+  FooterStyled,
+  LoadMoreButtonStyled,
+} from "src/components/Viewer/Collection/Collection.styled";
+import { getCollectionNext } from "src/hooks/use-iiif";
 import { v4 as uuidv4 } from "uuid";
 
 const Collection: React.FC = () => {
@@ -11,6 +17,17 @@ const Collection: React.FC = () => {
 
   const { activeManifest, collection, configOptions, vault } = viewerState;
   const maxHeight = configOptions?.canvasHeight;
+
+  const [extraItems, setExtraItems] = useState<CollectionItems[]>([]);
+  const [nextUrl, setNextUrl] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setExtraItems([]);
+    setLoadError(undefined);
+    setNextUrl(getCollectionNext(collection));
+  }, [collection, vault]);
 
   const handleValueChange = (manifestId: string) => {
     dispatch({
@@ -27,6 +44,78 @@ const Collection: React.FC = () => {
     });
   };
 
+  const handleLoadMore = async () => {
+    if (!nextUrl || isLoading) return;
+    setIsLoading(true);
+    setLoadError(undefined);
+    try {
+      const next = (await vault.load(nextUrl)) as
+        | CollectionNormalized
+        | undefined;
+      if (!next) throw new Error("Empty response");
+      const nextPointer = getCollectionNext(next);
+      // strip the trailing next-page Collection from the appended items so it
+      // doesn't render as a Manifest entry, and filter out any nested
+      // Collection entries (only Manifests should appear in the picker).
+      const newItems = ((next.items ?? []) as CollectionItems[]).filter(
+        (i) => i.type !== "Collection",
+      );
+      // dedupe inside the functional updater so we read fresh `prev` rather
+      // than the stale `extraItems` captured by this closure.
+      setExtraItems((prev) => {
+        const seen = new Set<string>();
+        collection?.items?.forEach((i: CollectionItems) => seen.add(i.id));
+        prev.forEach((i) => seen.add(i.id));
+        return [...prev, ...newItems.filter((i) => !seen.has(i.id))];
+      });
+      setNextUrl(nextPointer);
+    } catch (error) {
+      setLoadError(
+        error instanceof Error ? error.message : "Failed to load next page",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // visible items: parent items minus the trailing next-page Collection,
+  // plus any items appended from subsequent pages (also stripped of their
+  // trailing next pointers, which getCollectionNext on each fetched page
+  // moves into nextUrl rather than extraItems).
+  const baseItems: CollectionItems[] = (collection?.items ?? []).filter(
+    (item: CollectionItems) => item.type !== "Collection",
+  );
+  const allItems = [...baseItems, ...extraItems];
+
+  const footer =
+    nextUrl || loadError ? (
+      <FooterStyled
+        className="clover-viewer-collection-footer"
+        // Stop Radix Select from intercepting pointer/key events on the
+        // footer's interactive children (otherwise the dropdown closes
+        // before the click reaches the button).
+        onPointerDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {nextUrl && (
+          <LoadMoreButtonStyled
+            type="button"
+            onClick={handleLoadMore}
+            disabled={isLoading}
+            data-testid="collection-load-more"
+            className="clover-viewer-collection-load-more"
+          >
+            {isLoading ? "Loading…" : "Load more"}
+          </LoadMoreButtonStyled>
+        )}
+        {loadError && (
+          <ErrorStyled role="alert" data-testid="collection-load-error">
+            {loadError}
+          </ErrorStyled>
+        )}
+      </FooterStyled>
+    ) : undefined;
+
   return (
     <div style={{ margin: "0.75rem" }}>
       <Select
@@ -34,8 +123,9 @@ const Collection: React.FC = () => {
         maxHeight={maxHeight}
         value={activeManifest}
         onValueChange={handleValueChange}
+        footer={footer}
       >
-        {collection?.items?.map((item: CollectionItems) => (
+        {allItems.map((item: CollectionItems) => (
           <SelectOption
             value={item.id}
             key={item.id}

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -199,9 +199,18 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
     // the fetch URL. A subsequent vault.load(internalId) finds no request entry
     // and tries to fetch from the internal id as a URL, which may not resolve.
     // Check vault.get first — it looks directly in entities and handles this case.
-    const existingManifest = vault.get(activeManifest) as ManifestNormalized | null;
+    //
+    // Vault tracks each fetch via requestStatus; treat the manifest as resolved
+    // only when Vault has marked the request RESOURCE_READY. Otherwise (no
+    // request yet, or a still-loading reference picked up from a parent
+    // Collection) call vault.load to populate.
+    const existingManifest = vault.get(
+      activeManifest,
+    ) as ManifestNormalized | null;
+    const status = (vault as any).requestStatus?.(activeManifest);
+    const isReady = status?.loadingState === "RESOURCE_READY";
     const manifestLoader: Promise<ManifestNormalized> =
-      existingManifest && Array.isArray((existingManifest as any).items)
+      isReady && existingManifest
         ? Promise.resolve(existingManifest)
         : (vault.load(activeManifest) as Promise<ManifestNormalized>);
 

--- a/src/hooks/use-iiif/getCollectionNext.test.ts
+++ b/src/hooks/use-iiif/getCollectionNext.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { CollectionNormalized } from "@iiif/presentation-3";
+import { getCollectionNext } from "src/hooks/use-iiif";
+
+const buildCollection = (
+  id: string,
+  items: Array<{ id: string; type: "Manifest" | "Collection" }>,
+): CollectionNormalized =>
+  ({
+    id,
+    type: "Collection",
+    items,
+  }) as unknown as CollectionNormalized;
+
+describe("getCollectionNext", () => {
+  it("returns undefined for a Collection with no items", () => {
+    const collection = buildCollection("https://example.org/c", []);
+    expect(getCollectionNext(collection)).toBeUndefined();
+  });
+
+  it("returns undefined when all items are Manifests", () => {
+    const collection = buildCollection("https://example.org/c", [
+      { id: "https://example.org/m/1", type: "Manifest" },
+      { id: "https://example.org/m/2", type: "Manifest" },
+    ]);
+    expect(getCollectionNext(collection)).toBeUndefined();
+  });
+
+  it("returns the trailing Collection id as the next page", () => {
+    const collection = buildCollection("https://example.org/c?page=1", [
+      { id: "https://example.org/m/1", type: "Manifest" },
+      { id: "https://example.org/m/2", type: "Manifest" },
+      { id: "https://example.org/c?page=2", type: "Collection" },
+    ]);
+    expect(getCollectionNext(collection)).toBe("https://example.org/c?page=2");
+  });
+
+  it("ignores a Collection item that is not the last entry", () => {
+    const collection = buildCollection("https://example.org/c", [
+      { id: "https://example.org/sub", type: "Collection" },
+      { id: "https://example.org/m/1", type: "Manifest" },
+    ]);
+    expect(getCollectionNext(collection)).toBeUndefined();
+  });
+
+  it("guards against a self-referencing next pointer", () => {
+    const collection = buildCollection("https://example.org/c", [
+      { id: "https://example.org/m/1", type: "Manifest" },
+      { id: "https://example.org/c", type: "Collection" },
+    ]);
+    expect(getCollectionNext(collection)).toBeUndefined();
+  });
+});

--- a/src/hooks/use-iiif/getCollectionNext.ts
+++ b/src/hooks/use-iiif/getCollectionNext.ts
@@ -1,0 +1,25 @@
+import { CollectionNormalized, Reference } from "@iiif/presentation-3";
+
+/**
+ * Detect a next-page URL on a Collection following the convention discussed
+ * in IIIF/api#2174 ("Last Item Entry is Next Page"): a Collection used as a
+ * paged response includes a trailing `items` entry of `type: "Collection"`
+ * whose `id` resolves to the next page of the same response.
+ *
+ * Returns the next-page URL or undefined if the Collection is not paged.
+ */
+export const getCollectionNext = (
+  collection: CollectionNormalized | undefined,
+): string | undefined => {
+  if (!collection?.items?.length) return undefined;
+
+  const last = collection.items[collection.items.length - 1] as Reference<
+    "Collection" | "Manifest"
+  >;
+  if (last?.type !== "Collection") return undefined;
+
+  // guard against a Collection that lists itself as its only "next" pointer
+  if (last.id === collection.id) return undefined;
+
+  return last.id;
+};

--- a/src/hooks/use-iiif/index.ts
+++ b/src/hooks/use-iiif/index.ts
@@ -5,12 +5,14 @@ import {
 
 import { getAccompanyingCanvasImage } from "src/hooks/use-iiif/getAccompanyingCanvasImage";
 import { getCanvasByCriteria } from "src/hooks/use-iiif/getCanvasByCriteria";
+import { getCollectionNext } from "src/hooks/use-iiif/getCollectionNext";
 import { getLabel } from "src/hooks/use-iiif/getLabel";
 import { getPaintingResource } from "src/hooks/use-iiif/getPaintingResource";
 
 export {
   getAccompanyingCanvasImage,
   getCanvasByCriteria,
+  getCollectionNext,
   getLabel,
   getPaintingResource,
   getAnnotationResources,


### PR DESCRIPTION
## Summary

Adds support for paged IIIF Collections — large Collections (typically search-result responses) that publish their results in chunks, with each chunk's last `items` entry being a Collection-typed reference to the next page.

This convention is the focus of [IIIF/api#2174](https://github.com/IIIF/api/issues/2174) ("Implementing 'paged' Collections in Presentation API 3.0"), and is currently used by Northwestern University Libraries' `?as=iiif` search endpoint, Theseus, and others. The Presentation API itself does not (yet) define a paging mechanism for Collections — see #2174 — so the convention used here is non-spec but widely deployed.

When such a Collection is loaded, Clover now renders a **Load more** button inside the Collection picker. Clicking it fetches the next page, appends its Manifests to the picker (deduplicated by `id`), and continues exposing **Load more** as long as further pages exist.

### What this PR adds

- `getCollectionNext(collection)` helper — returns the next-page URL from the last `items` entry when it is a Collection-typed reference, with a guard against self-referencing pointers.
- Wired into `Collection.tsx` with state for appended items, next-page pointer, loading and error states.
- A `footer` slot on the existing `<Select>` component so the **Load more** button can sit at the bottom of the open dropdown rather than below it (this kept the button visible alongside the list, and avoided the InformationPanel overlapping it).
- Pointer/key-event guards on the footer so Radix Select doesn't intercept clicks before they reach the button.
- New `Collection.styled.tsx` for the footer, button, and error label, using `$accent` / `$secondary` theme tokens to match the existing in-panel button conventions (e.g. content search submit).
- Documentation: a new "Paged Collections" section in `pages/docs/viewer.mdx` plus a Features list entry.
- 7 unit tests covering the helper.

### Incidental fix

Surfaced while testing this against the NWU search-results Collection: when a Manifest is referenced from a Collection but has not yet been fetched, Vault holds an unresolved entity with `items: []`. `RenderViewer`'s manifest-load short-circuit was treating that as a cached resolved manifest and never fetching the canvases — leading to "The IIIF manifest … does not contain canvases." for the very first selection. The cache check now uses `vault.requestStatus(id)` to detect `RESOURCE_READY` rather than proxying through `items.length`.

## Test plan

- [x] `npm run test` — 218 tests pass (7 new for `getCollectionNext`)
- [ ] `npx prettier --check` clean on touched files
- [ ] `npm run build` succeeds
- [ ] Manually verified in `npm run dev`:
  - Default Collections (no paging) render unchanged — no Load more button
  - NWU `?as=iiif` search Collection: first page renders, Load more visible at bottom of open picker, clicking appends next page's Manifests, and the trailing next-page Collection itself doesn't appear as a Manifest entry
  - Pre-existing "manifest does not contain canvases" error no longer fires for these Collections

## Known limitations / follow-ups

- Keyboard activation of the Load more button while the dropdown is open is partially intercepted by Radix Select's keyboard handlers. Mouse and touch are reliable. A fuller fix likely needs a different primitive (DropdownMenu) or a Radix-managed item with a synthetic value.
- The "load more" UX is per-page rather than infinite scroll. That can come later if there's appetite.

Refs #299