### PR TITLE
Replace Swiper with Embla Carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-tabs": "^1.1.1",
         "@stitches/react": "^1.2.8",
         "dompurify": "^3.0.2",
+        "embla-carousel-react": "^8.6.0",
         "flexsearch": "^0.7.43",
         "hls.js": "^1.5.17",
         "i18next": "^23.16.5",
@@ -36,7 +37,6 @@
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
-        "swiper": "^9.0.0",
         "unified": "^11.0.5",
         "uuid": "^9.0.1"
       },
@@ -84,8 +84,7 @@
       },
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0",
-        "swiper": "^9.0.0"
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6592,6 +6591,34 @@
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "dev": true,
       "license": "EPL-2.0"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -19148,12 +19175,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT"
-    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -19585,28 +19606,6 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/swiper": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.4.1.tgz",
-      "integrity": "sha512-1nT2T8EzUpZ0FagEqaN/YAhRj33F2x/lN6cyB0/xoYJDMf8KwTFT3hMOeoB8Tg4o3+P/CKqskP+WX0Df046fqA==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.2"
-      },
-      "engines": {
-        "node": ">= 4.7.0"
-      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@radix-ui/react-tabs": "^1.1.1",
     "@stitches/react": "^1.2.8",
     "dompurify": "^3.0.2",
+    "embla-carousel-react": "^8.6.0",
     "flexsearch": "^0.7.43",
     "hls.js": "^1.5.17",
     "i18next": "^23.16.5",
@@ -117,7 +118,6 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
-    "swiper": "^9.0.0",
     "unified": "^11.0.5",
     "uuid": "^9.0.1"
   },
@@ -162,8 +162,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",
-    "react-dom": "^18.2.0 || ^19.0.0",
-    "swiper": "^9.0.0"
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "typesVersions": {
     "*": {

--- a/pages/docs/composing.mdx
+++ b/pages/docs/composing.mdx
@@ -132,7 +132,7 @@ export default Work;
 
 ### Add Slider
 
-Finally, we add the `Slider` component to render the IIIF Collection that this Manifest is part of. We also need to import the `swiper` CSS files for baseline styling.
+Finally, we add the `Slider` component to render the IIIF Collection that this Manifest is part of.
 
 <br />
 <CallToAction href="/docs/slider" text="Slider Docs" size="small" />
@@ -150,10 +150,6 @@ import {
   Thumbnail,
 } from "@samvera/clover-iiif/primitives";
 import Slider from "@samvera/clover-iiif/slider";
-
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
 
 const Work = () => {
   const [manifest, setManifest] = useState();

--- a/pages/docs/slider.mdx
+++ b/pages/docs/slider.mdx
@@ -20,6 +20,8 @@ A UI component that renders an item carousel for the contents of a IIIF Collecti
 
 <Slider iiifContent="https://api.dc.library.northwestern.edu/api/v2/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd?as=iiif" />
 
+> **Note:** Clover IIIF has discontinued use of [Swiper](https://swiperjs.com/) due to dependency security vulnerabilities and its impact on bundle size. We recommend upgrading to Clover IIIF `3.7.x` or later, which now uses the lighter [Embla Carousel](https://www.embla-carousel.com/) as a precaution.
+
 ## Features
 
 Provide a [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) Collection and the component:

--- a/pages/docs/slider.mdx
+++ b/pages/docs/slider.mdx
@@ -7,13 +7,9 @@ import IIIFBadge from "docs/components/IIIFBadge";
 import { Tabs, Tab } from "nextra/components";
 import { Steps } from "nextra/components";
 
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-
 # Slider
 
-A UI component that renders an item carousel for the contents of a IIIF Collection using [swiper.js](https://swiperjs.com/).
+A UI component that renders an item carousel for the contents of a IIIF Collection using [Embla Carousel](https://www.embla-carousel.com/).
 
 <IIIFBadge
   href="https://iiif.io/api/presentation/3.0/#21-defined-types"
@@ -64,14 +60,10 @@ Provide a [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) Collect
 
 ### React
 
-Add the `Slider` component to your `jsx` or `tsx` code. Slider does require you to load [swiper.js](https://swiperjs.com/) styling to the side. These stylesheets are not compiled with the @samvera/clover-iiif package, however are bundled as a dependency when installing Clover IIIF.
+Add the `Slider` component to your `jsx` or `tsx` code. The Slider uses [Embla Carousel](https://www.embla-carousel.com/) and ships with the styles it needs, so no additional stylesheet imports are required.
 
 ```jsx
 import Slider from "@samvera/clover-iiif/slider";
-
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
 ```
 
 Render the slider with IIIF Collection URI. The only required prop is the `iiifContent`, which is the URI of the IIIF Collection.
@@ -96,13 +88,13 @@ Render the slider with IIIF Collection URI. The only required prop is the `iiifC
 | `iiifContent`                 | `string`                         | Yes      |         |
 | `collectionId` _(deprecated)_ | `string`                         | No       |         |
 | `onItemInteraction`           | `function`                       | No       |         |
-| `options.breakpoints`         | `SwiperProps["breakpoints"]`     | No       |         |
+| `options.breakpoints`         | `SliderBreakpoints`              | No       |         |
 | `options.credentials`         | `omit`, `same-origin`, `include` | No       | `omit`  |
 | `options.customViewAll`       | `string`                         | No       |         |
 
 ### Custom Breakpoints
 
-`Slider` uses default values per <a href="https://swiperjs.com/swiper-api#param-breakpoints" target="_blank">Swiper's `breakpoints` API </a>. You may customize your own by passing in a `breakpoints` object, ie:
+`Slider` ships with sensible default breakpoints. You may customize your own by passing in a `breakpoints` object, where each key is a min-width pixel value and each value sets `slidesPerView`, `slidesPerGroup`, and/or `spaceBetween` for widths at or above that breakpoint:
 
 ```tsx
 const MyCustomSlider = () => {
@@ -112,14 +104,17 @@ const MyCustomSlider = () => {
   const customBreakpoints = {
     320: {
       slidesPerView: 2,
+      slidesPerGroup: 2,
       spaceBetween: 20,
     },
     480: {
       slidesPerView: 3,
+      slidesPerGroup: 3,
       spaceBetween: 30,
     },
     640: {
       slidesPerView: 4,
+      slidesPerGroup: 4,
       spaceBetween: 40,
     },
   };

--- a/pages/docs/slider/demo.mdx
+++ b/pages/docs/slider/demo.mdx
@@ -4,16 +4,12 @@ import { Bleed } from "nextra-theme-docs";
 import { Tabs, Tab } from "nextra/components";
 import CallToAction from "docs/components/CallToAction";
 
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-
 ## Slider
 
 <br />
 <CallToAction href="/docs/slider" text="Docs" size="small" />
 
-A UI component that renders an item carousel for the contents of a IIIF Collection using [swiper.js](https://swiperjs.com/).
+A UI component that renders an item carousel for the contents of a IIIF Collection using [Embla Carousel](https://www.embla-carousel.com/).
 
 ---
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -18,10 +18,6 @@ import {
 } from "src/components/Primitives";
 import Redirect from "docs/components/Redirect";
 
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-
 <Redirect />
 
 <HomepageHeader />

--- a/src/components/Slider/Items/Items.styled.ts
+++ b/src/components/Slider/Items/Items.styled.ts
@@ -1,7 +1,16 @@
 import { styled } from "src/styles/stitches.config";
 
 const ItemsStyled = styled("div", {
-  "& .swiper-slide": {},
+  overflow: "hidden",
+  width: "100%",
+
+  "& .clover-slider-track": {
+    touchAction: "pan-y pinch-zoom",
+  },
+
+  "& .clover-slider-slide": {
+    transform: "translate3d(0, 0, 0)",
+  },
 });
 
 export { ItemsStyled };

--- a/src/components/Slider/Items/Items.test.tsx
+++ b/src/components/Slider/Items/Items.test.tsx
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import Items from "src/components/Slider/Items/Items";
+import React from "react";
+import { sliderItem } from "src/fixtures/slider/slider-item";
+
+// jsdom lacks matchMedia, which Embla calls during init. Stub before the
+// component (and embla-carousel-react inside it) is loaded.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+// Mock LazyLoad so children are visible in tests without intersection-observer.
+vi.mock("src/components/UI/LazyLoad/LazyLoad", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const items = [
+  { ...sliderItem, id: "https://example.org/m/1" },
+  { ...sliderItem, id: "https://example.org/m/2" },
+  { ...sliderItem, id: "https://example.org/m/3" },
+];
+
+describe("Slider Items (Embla carousel)", () => {
+  it("renders the carousel root with the carousel role", () => {
+    render(<Items items={items} instance={1} />);
+    const root = screen.getByTestId("slider-items");
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveAttribute("aria-roledescription", "carousel");
+  });
+
+  it("renders one slide per item with slide labels", () => {
+    render(<Items items={items} instance={2} />);
+    const slides = screen.getAllByRole("group");
+    expect(slides).toHaveLength(items.length);
+    expect(slides[0]).toHaveAttribute("aria-label", `1 of ${items.length}`);
+    expect(slides[2]).toHaveAttribute(
+      "aria-label",
+      `${items.length} of ${items.length}`,
+    );
+  });
+
+  it("attaches click handlers to externally-rendered prev/next buttons by instance", () => {
+    const prev = document.createElement("button");
+    prev.className = "clover-slider-previous-99";
+    const next = document.createElement("button");
+    next.className = "clover-slider-next-99";
+    document.body.append(prev, next);
+
+    render(<Items items={items} instance={99} />);
+
+    // Clicks shouldn't throw even before Embla has measured (jsdom).
+    expect(() => fireEvent.click(prev)).not.toThrow();
+    expect(() => fireEvent.click(next)).not.toThrow();
+
+    prev.remove();
+    next.remove();
+  });
+});

--- a/src/components/Slider/Items/Items.tsx
+++ b/src/components/Slider/Items/Items.tsx
@@ -1,46 +1,44 @@
-import { A11y, Navigation } from "swiper";
-import React, { useRef } from "react";
-import { SliderItem, SwiperBreakpoints } from "src/types/slider";
-import { Swiper, SwiperSlide } from "swiper/react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { CollectionItems } from "@iiif/presentation-3";
 import Item from "./Item";
 import { ItemsStyled } from "src/components/Slider/Items/Items.styled";
 import LazyLoad from "src/components/UI/LazyLoad/LazyLoad";
+import { SliderItem, SliderBreakpoints } from "src/types/slider";
+import useEmblaCarousel from "embla-carousel-react";
 
 interface ItemsProps {
-  breakpoints?: SwiperBreakpoints;
+  breakpoints?: SliderBreakpoints;
   handleItemInteraction?: (item: SliderItem) => void;
   instance: number;
   items: CollectionItems[];
 }
 
-const defaultBreakpoints = {
-  640: {
-    slidesPerView: 2,
-    slidesPerGroup: 2,
-    spaceBetween: 20,
-  },
-  768: {
-    slidesPerView: 3,
-    slidesPerGroup: 3,
-    spaceBetween: 30,
-  },
-  1024: {
-    slidesPerView: 4,
-    slidesPerGroup: 4,
-    spaceBetween: 40,
-  },
-  1366: {
-    slidesPerView: 5,
-    slidesPerGroup: 5,
-    spaceBetween: 50,
-  },
-  1920: {
-    slidesPerView: 6,
-    slidesPerGroup: 6,
-    spaceBetween: 60,
-  },
+const defaultBreakpoints: SliderBreakpoints = {
+  640: { slidesPerView: 2, slidesPerGroup: 2, spaceBetween: 20 },
+  768: { slidesPerView: 3, slidesPerGroup: 3, spaceBetween: 30 },
+  1024: { slidesPerView: 4, slidesPerGroup: 4, spaceBetween: 40 },
+  1366: { slidesPerView: 5, slidesPerGroup: 5, spaceBetween: 50 },
+  1920: { slidesPerView: 6, slidesPerGroup: 6, spaceBetween: 60 },
+};
+
+/**
+ * Pick the breakpoint config that applies to the current window width by
+ * matching the largest min-width breakpoint that is <= window.innerWidth.
+ */
+const resolveBreakpoint = (breakpoints: SliderBreakpoints) => {
+  if (typeof window === "undefined") {
+    return { slidesPerView: 2, slidesPerGroup: 2, spaceBetween: 31 };
+  }
+  const width = window.innerWidth;
+  const sorted = Object.entries(breakpoints)
+    .map(([k, v]) => [Number(k), v] as const)
+    .sort((a, b) => a[0] - b[0]);
+  let active = { slidesPerView: 2, slidesPerGroup: 2, spaceBetween: 31 };
+  for (const [min, config] of sorted) {
+    if (width >= min) active = { ...active, ...config };
+  }
+  return active;
 };
 
 const Items: React.FC<ItemsProps> = ({
@@ -49,31 +47,89 @@ const Items: React.FC<ItemsProps> = ({
   instance,
   items,
 }) => {
-  const itemsRef = useRef<HTMLDivElement>(null);
+  const [config, setConfig] = useState(() => resolveBreakpoint(breakpoints));
+
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    align: "start",
+    slidesToScroll: config.slidesPerGroup,
+    containScroll: "trimSnaps",
+  });
+
+  // Update slidesToScroll on window resize so the active breakpoint stays in
+  // sync with the column count rendered by CSS below.
+  useEffect(() => {
+    const onResize = () => setConfig(resolveBreakpoint(breakpoints));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [breakpoints]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+    emblaApi.reInit({ slidesToScroll: config.slidesPerGroup });
+  }, [emblaApi, config.slidesPerGroup]);
+
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+
+  // Wire up the externally-rendered prev/next buttons in <Header /> and keep
+  // their disabled state in sync with Embla's scroll bounds.
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    const prev = document.querySelector<HTMLButtonElement>(
+      `.clover-slider-previous-${instance}`,
+    );
+    const next = document.querySelector<HTMLButtonElement>(
+      `.clover-slider-next-${instance}`,
+    );
+
+    const updateDisabled = () => {
+      if (prev) prev.disabled = !emblaApi.canScrollPrev();
+      if (next) next.disabled = !emblaApi.canScrollNext();
+    };
+
+    prev?.addEventListener("click", scrollPrev);
+    next?.addEventListener("click", scrollNext);
+    emblaApi.on("select", updateDisabled);
+    emblaApi.on("reInit", updateDisabled);
+    updateDisabled();
+
+    return () => {
+      prev?.removeEventListener("click", scrollPrev);
+      next?.removeEventListener("click", scrollNext);
+      emblaApi.off("select", updateDisabled);
+      emblaApi.off("reInit", updateDisabled);
+    };
+  }, [emblaApi, instance, scrollPrev, scrollNext]);
 
   return (
-    <ItemsStyled ref={itemsRef}>
-      <Swiper
-        // @ts-ignore
-        a11y={{
-          prevSlideMessage: "previous item",
-          nextSlideMessage: "next item",
+    <ItemsStyled
+      ref={emblaRef}
+      aria-roledescription="carousel"
+      data-testid="slider-items"
+    >
+      <div
+        className="clover-slider-track"
+        style={{
+          display: "flex",
+          width: "100%",
+          gap: `${config.spaceBetween}px`,
         }}
-        spaceBetween={31}
-        modules={[Navigation, A11y]}
-        navigation={{
-          nextEl: `.clover-slider-next-${instance}`,
-          prevEl: `.clover-slider-previous-${instance}`,
-        }}
-        slidesPerView={2}
-        slidesPerGroup={2}
-        breakpoints={breakpoints}
       >
         {items.map((item, index) => (
-          <SwiperSlide
+          <div
             key={`${item.id}-${index}`}
+            className="clover-slider-slide"
             data-index={index}
             data-type={item?.type.toLowerCase()}
+            role="group"
+            aria-roledescription="slide"
+            aria-label={`${index + 1} of ${items.length}`}
+            style={{
+              flex: `0 0 calc((100% - ${config.spaceBetween * (config.slidesPerView - 1)}px) / ${config.slidesPerView})`,
+              minWidth: 0,
+              width: `calc((100% - ${config.spaceBetween * (config.slidesPerView - 1)}px) / ${config.slidesPerView})`,
+            }}
           >
             <LazyLoad>
               <Item
@@ -82,9 +138,9 @@ const Items: React.FC<ItemsProps> = ({
                 item={item as SliderItem}
               />
             </LazyLoad>
-          </SwiperSlide>
+          </div>
         ))}
-      </Swiper>
+      </div>
     </ItemsStyled>
   );
 };

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,7 +1,3 @@
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-
 import {
   Homepage,
   Label,

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -1,9 +1,26 @@
 import { Collection, Manifest } from "@iiif/presentation-3";
 
-import { SwiperProps } from "swiper/react";
+export interface SliderBreakpointConfig {
+  slidesPerView?: number;
+  slidesPerGroup?: number;
+  spaceBetween?: number;
+}
+
+export type SliderBreakpoints = Record<number, SliderBreakpointConfig>;
+
+/**
+ * @deprecated Use {@link SliderBreakpoints} instead.
+ *
+ * Backwards-compatible alias for the old Swiper-derived type. The Slider was
+ * migrated to Embla Carousel (see #327), but external consumers of
+ * `@samvera/clover-iiif/slider` may have imported `SwiperBreakpoints` to type
+ * their own `breakpoints` prop. Removing it would be a breaking change in the
+ * public type surface. Kept until the next major release.
+ */
+export type SwiperBreakpoints = SliderBreakpoints;
 
 export interface ConfigOptions {
-  breakpoints?: SwiperBreakpoints;
+  breakpoints?: SliderBreakpoints;
   credentials?: FetchCredentials;
   customViewAll?: string;
 }
@@ -19,8 +36,6 @@ export type CustomHomepage = Array<
 export type SliderItem = Omit<Collection | Manifest, "items"> & {
   homepage: CustomHomepage;
 };
-
-export type SwiperBreakpoints = SwiperProps["breakpoints"];
 
 // https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials
 export type FetchCredentials = "omit" | "same-origin" | "include";


### PR DESCRIPTION
## Summary

Replaces the Swiper carousel used by `<Slider />` with [Embla Carousel](https://www.embla-carousel.com/), addressing #327. Swiper v9 has open security advisories and the project has indicated an intent to move off it in a future release; Embla is lighter, framework-agnostic, currently has no advisories, and has a v9 with first-party accessibility support due soon.

The public Slider prop surface is preserved:

| Prop | Behaviour |
| --- | --- |
| `iiifContent` | unchanged |
| `collectionId` (deprecated) | unchanged |
| `onItemInteraction` | unchanged |
| `options.breakpoints` | unchanged shape (`{ [minWidthPx]: { slidesPerView?, slidesPerGroup?, spaceBetween? } }`) |
| `options.credentials` | unchanged |
| `options.customViewAll` | unchanged |

### Notable behavioural changes

- Consumers no longer need to import `swiper/css` / `swiper/css/navigation` / `swiper/css/pagination`. The relevant docs (`pages/docs/slider.mdx`, `pages/docs/composing.mdx`, `pages/index.mdx`, `pages/docs/slider/demo.mdx`) and the `dev.tsx` harness are updated.
- Prev/next buttons in the Slider header are now toggled `disabled` when the carousel cannot scroll further in either direction (Swiper handled this via class names; this is a small functional improvement).
- Carousel ARIA: the root carries `aria-roledescription="carousel"`, each slide is a `role="group"` with `aria-roledescription="slide"` and an `aria-label="N of M"`.

### Public type change (semver-relevant)

`SwiperBreakpoints` is retained as a `@deprecated` alias for a new, narrower `SliderBreakpoints` type:

```ts
type SliderBreakpoints = Record<number, {
  slidesPerView?: number;
  slidesPerGroup?: number;
  spaceBetween?: number;
}>;
```

The previous type was `SwiperProps["breakpoints"]`, which structurally allowed every Swiper-specific slide option. Consumers who extended the old type with Swiper-only fields (e.g. `loop`, `effect`) will get a TS excess-property error. Runtime behaviour is unaffected. Worth flagging in release notes.

### Out of scope (potential follow-ups)

- Embla's official accessibility plugin (`embla-carousel-accessibility`) is currently v9-rc only. Once v9 lands stable, swap the manual ARIA for the plugin (which adds a live region for slide-change announcements).
- A pre-existing visual regression where slider images briefly render at intrinsic size before the layout settles is also present on `main`; not introduced by this PR.

## Test plan

- [ ] `npm run test` — 216 tests pass, including 3 new tests for `Items` covering the carousel ARIA root, slide labelling, and prev/next button wiring (with a `matchMedia` stub for jsdom).
- [ ] `npx prettier --check` clean on touched files.
- [ ] `npm run build` succeeds.
- [ ] Manually verified in `npm run dev`:
  - `/docs/slider` and `/docs/slider/demo` render the Embla-backed carousel.
  - Prev/next nav works and disables at the bounds.
  - Resizing the window switches between breakpoints (column count + scroll step).
  - Item click / `onItemInteraction` callback unchanged.

Refs #327