### PR TITLE
Lazy-load hls.js when an HLS source is detected

### DIFF
--- a/build/base-config.mjs
+++ b/build/base-config.mjs
@@ -18,6 +18,10 @@ const FORCED_EXTERNALS = new Set([
   "i18next-browser-languagedetector",
   "openseadragon",
   "swiper",
+  // hls.js is loaded dynamically only for HLS sources. Externalising it
+  // keeps it out of the always-bundled `dist/*/index.{mjs,cjs}` output and
+  // lets consumer bundlers (or direct ESM resolution) load it on demand.
+  "hls.js",
 ]);
 
 function getPackageName(id) {

--- a/public/manifest/hls-test.json
+++ b/public/manifest/hls-test.json
@@ -1,0 +1,42 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/hls-test.json",
+  "type": "Manifest",
+  "label": { "en": ["HLS streaming test"] },
+  "summary": {
+    "en": [
+      "Local fixture wrapping a public Apple bipbop HLS stream to exercise hls.js lazy loading."
+    ]
+  },
+  "items": [
+    {
+      "id": "http://localhost:3000/manifest/hls-test/canvas/1",
+      "type": "Canvas",
+      "height": 480,
+      "width": 640,
+      "duration": 30,
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/hls-test/canvas/1/page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/hls-test/canvas/1/anno/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8",
+                "type": "Video",
+                "format": "application/x-mpegurl",
+                "height": 480,
+                "width": 640,
+                "duration": 30
+              },
+              "target": "http://localhost:3000/manifest/hls-test/canvas/1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/manifest/streaming/hls.json
+++ b/public/manifest/streaming/hls.json
@@ -1,27 +1,27 @@
 {
   "@context": "http://iiif.io/api/presentation/3/context.json",
-  "id": "http://localhost:3000/manifest/hls-test.json",
+  "id": "http://localhost:3000/manifest/streaming/hls.json",
   "type": "Manifest",
   "label": { "en": ["HLS streaming test"] },
   "summary": {
     "en": [
-      "Local fixture wrapping a public Apple bipbop HLS stream to exercise hls.js lazy loading."
+      "Local fixture wrapping a public Mux HLS test stream to exercise hls.js lazy loading."
     ]
   },
   "items": [
     {
-      "id": "http://localhost:3000/manifest/hls-test/canvas/1",
+      "id": "http://localhost:3000/manifest/streaming/hls/canvas/1",
       "type": "Canvas",
       "height": 480,
       "width": 640,
       "duration": 30,
       "items": [
         {
-          "id": "http://localhost:3000/manifest/hls-test/canvas/1/page/1",
+          "id": "http://localhost:3000/manifest/streaming/hls/canvas/1/page/1",
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "http://localhost:3000/manifest/hls-test/canvas/1/anno/1",
+              "id": "http://localhost:3000/manifest/streaming/hls/canvas/1/anno/1",
               "type": "Annotation",
               "motivation": "painting",
               "body": {
@@ -32,7 +32,7 @@
                 "width": 640,
                 "duration": 30
               },
-              "target": "http://localhost:3000/manifest/hls-test/canvas/1"
+              "target": "http://localhost:3000/manifest/streaming/hls/canvas/1"
             }
           ]
         }

--- a/src/components/Primitives/ContentResource/ContentResource.tsx
+++ b/src/components/Primitives/ContentResource/ContentResource.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useRef } from "react";
 
-import Hls from "hls.js";
 import { PrimitivesContentResource } from "src/types/primitives";
 import { getLabelAsString } from "src/lib/label-helpers";
+import { isHls } from "src/lib/hls";
 import { sanitizeAttributes } from "src/lib/html-element";
 import { styled } from "src/styles/stitches.config";
 import { useGetImageResource } from "src/hooks/useGetImageResource";
@@ -24,62 +24,73 @@ const ContentResource: React.FC<PrimitivesContentResource> = (props) => {
 
   const { type, id, width = 200, height = 200, duration } = contentResource;
 
+  const isHlsSource = isHls(id, contentResource.format);
+
   useEffect(() => {
-    /**
-     * Check that IIIF content resource ID exists and
-     * we have a reffed <video> for attaching HLS
-     */
-    if (!id && !mediaRef.current) return;
-    if (["Image"].includes(type)) return;
+    if (!id || !mediaRef.current) return;
+    if (type === "Image") return;
+    if (!isHlsSource) return;
 
-    /**
-     * Eject HLS attachment if file extension from
-     * the IIIF content resource ID is not .m3u8
-     */
-    if (!id.includes("m3u8")) return;
+    const video = mediaRef.current as unknown as HTMLVideoElement;
 
-    // Bind hls.js package to our <video /> element and then load the media source
-    const hls = new Hls();
-
-    if (mediaRef.current) {
-      hls.attachMedia(mediaRef.current);
-      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
-        hls.loadSource(id as string);
-      });
+    // Native HLS support (Safari): point the element at the playlist directly.
+    if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = id as string;
+      return;
     }
 
-    // Handle errors
-    hls.on(Hls.Events.ERROR, function (event, data) {
-      if (data.fatal) {
+    // Otherwise dynamically import hls.js only when an HLS source is detected
+    // and the browser doesn't natively support it.
+    let cancelled = false;
+    let hls: import("hls.js").default | undefined;
+
+    (async () => {
+      const { default: Hls } = await import("hls.js");
+      if (cancelled || !mediaRef.current) return;
+
+      // Browser must support MSE for hls.js to attach. If not, fall back to
+      // setting the source directly so the browser can surface the failure.
+      if (!Hls.isSupported()) {
+        (mediaRef.current as unknown as HTMLVideoElement).src = id as string;
+        return;
+      }
+
+      hls = new Hls();
+      hls.attachMedia(mediaRef.current);
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+        hls?.loadSource(id as string);
+      });
+
+      hls.on(Hls.Events.ERROR, function (event, data) {
+        if (!data.fatal) return;
         switch (data.type) {
           case Hls.ErrorTypes.NETWORK_ERROR:
-            // try to recover network error
             console.error(
               `fatal ${event} network error encountered, try to recover`,
             );
-            hls.startLoad();
+            hls?.startLoad();
             break;
           case Hls.ErrorTypes.MEDIA_ERROR:
             console.error(
               `fatal ${event} media error encountered, try to recover`,
             );
-            hls.recoverMediaError();
+            hls?.recoverMediaError();
             break;
           default:
-            // cannot recover
-            hls.destroy();
+            hls?.destroy();
             break;
         }
-      }
-    });
+      });
+    })();
 
     return () => {
+      cancelled = true;
       if (hls) {
         hls.detachMedia();
         hls.destroy();
       }
     };
-  }, [id, type]);
+  }, [id, type, isHlsSource]);
 
   const playLoop = useCallback(() => {
     if (!mediaRef.current) return;
@@ -134,7 +145,10 @@ const ContentResource: React.FC<PrimitivesContentResource> = (props) => {
           muted
           onPause={playLoop}
           ref={mediaRef}
-          src={id}
+          // Don't set `src` for HLS sources — the useEffect above attaches
+          // the playlist via hls.js (or native HLS for Safari). Setting src
+          // here would race the attach in non-Safari browsers.
+          {...(isHlsSource ? {} : { src: id })}
         />
       );
 

--- a/src/components/Viewer/Player/Player.test.tsx
+++ b/src/components/Viewer/Player/Player.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 
 import { AnnotationResources } from "src/types/annotations";
 import Hls from "hls.js";
@@ -14,15 +14,24 @@ import manifestStreaming from "src/fixtures/viewer/player/manifest-streaming-aud
 describe("Player component", () => {
   let originalLoad: any;
 
+  let originalCanPlayType: any;
+
   beforeAll(() => {
     originalLoad = window.HTMLMediaElement.prototype.load;
     window.HTMLMediaElement.prototype.load = () => {
       /* do nothing */
     };
+    // Force the non-native HLS path (i.e. hls.js fallback) so we can assert
+    // that attachMedia is called. jsdom's canPlayType returns "" for
+    // unknown types, which would already cause the fallback, but we stub
+    // it explicitly to make the test intent clear.
+    originalCanPlayType = window.HTMLMediaElement.prototype.canPlayType;
+    window.HTMLMediaElement.prototype.canPlayType = () => "";
   });
 
   afterAll(() => {
     window.HTMLMediaElement.prototype.load = originalLoad;
+    window.HTMLMediaElement.prototype.canPlayType = originalCanPlayType;
   });
 
   it("renders the Player component for a streaming audio file", async () => {
@@ -107,6 +116,7 @@ describe("Player component", () => {
       annotationResources: annotationResources as AnnotationResources,
     };
 
+    vi.spyOn(Hls, "isSupported").mockReturnValue(true);
     const hlsSpy = vi.spyOn(Hls.prototype, "attachMedia");
 
     const vault = new Vault();
@@ -132,8 +142,9 @@ describe("Player component", () => {
     // Test for the audio visualizer
     expect(screen.getByRole("presentation")).toBeInTheDocument();
 
-    // Test for Hls Attach
-    expect(hlsSpy).toHaveBeenCalled();
+    // Hls.js is now lazy-loaded via dynamic import, so attachMedia is called
+    // asynchronously after the chunk resolves.
+    await waitFor(() => expect(hlsSpy).toHaveBeenCalled());
   });
 
   it("renders the Player component for a standard audio file", async () => {

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -1,5 +1,5 @@
 import { AnnotationNormalized, CanvasNormalized } from "@iiif/presentation-3";
-import Hls, { HlsConfig } from "hls.js";
+import type { HlsConfig } from "hls.js";
 import React, { useEffect } from "react";
 import {
   ViewerContextStore,
@@ -13,7 +13,7 @@ import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
 import { PlayerWrapper } from "src/components/Viewer/Player/Player.styled";
 import Track from "src/components/Viewer/Player/Track";
 import { getPaintingResource } from "src/hooks/use-iiif";
-import { hlsMimeTypes } from "src/lib/hls";
+import { isHls } from "src/lib/hls";
 
 interface PlayerProps {
   allSources: LabeledIIIFExternalWebResource[];
@@ -32,94 +32,106 @@ const Player: React.FC<PlayerProps> = ({
   const [poster, setPoster] = React.useState<string | undefined>();
   const playerRef = React.useRef<HTMLVideoElement>(null);
   const onEndedRef = React.useRef(onEnded);
-  React.useEffect(() => { onEndedRef.current = onEnded; }, [onEnded]);
+  React.useEffect(() => {
+    onEndedRef.current = onEnded;
+  }, [onEnded]);
 
   const viewerDispatch: any = useViewerDispatch();
   const viewerState: ViewerContextStore = useViewerState();
 
-  const { activeCanvas, configOptions, contentStateAnnotation, isMediaPlaying, vault } =
-    viewerState;
+  const {
+    activeCanvas,
+    configOptions,
+    contentStateAnnotation,
+    isMediaPlaying,
+    vault,
+  } = viewerState;
   const isAudio = painting?.type === "Sound";
 
   /**
-   * HLS.js binding for .m3u8 files
-   * STAGING and PRODUCTION environments only
+   * Source binding. Plain MP4 / WebM / etc. is set as `video.src` directly.
+   * HLS playlists (.m3u8) are handed to native HLS support where available
+   * (Safari) and fall back to dynamically importing `hls.js` only when we
+   * actually need it. This keeps `hls.js` (~150KB) out of the initial
+   * bundle for the common case.
    */
   useEffect(() => {
-    /**
-     * Check that IIIF content resource ID exists and
-     * we have a reffed <video> for attaching HLS
-     */
     if (!painting.id || !playerRef.current) return;
 
-    if (playerRef?.current) {
-      const video: HTMLVideoElement = playerRef.current;
-      viewerDispatch({
-        type: "updateActivePlayer",
-        player: video,
-      });
+    const video: HTMLVideoElement = playerRef.current;
+    viewerDispatch({ type: "updateActivePlayer", player: video });
+
+    if (!isHls(painting.id, painting.format)) {
       video.src = painting.id as string;
       video.load();
+      return;
     }
 
-    /**
-     * Eject HLS attachment if file extension from
-     * the IIIF content resource ID is not .m3u8
-     * and format is not one of many m3u8 formats.
-     */
-    if (
-      painting.id.split(".").pop() !== "m3u8" &&
-      painting.format &&
-      !hlsMimeTypes.includes(painting.format)
-    )
+    // Native HLS support (Safari): just point the element at the playlist.
+    if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = painting.id as string;
+      video.load();
       return;
+    }
 
-    // Construct HLS.js config
-    const config = {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      xhrSetup: function (xhr, url) {
-        xhr.withCredentials = !!configOptions.withCredentials;
-      },
-    } as HlsConfig;
+    // Otherwise, lazy-load hls.js only when we actually have an HLS source
+    // and the browser doesn't natively support it.
+    let cancelled = false;
+    let hls: import("hls.js").default | undefined;
 
-    // Bind hls.js package to our <video /> element and then load the media source
-    const hls = new Hls(config);
-    hls.attachMedia(playerRef.current);
-    hls.on(Hls.Events.MEDIA_ATTACHED, function () {
-      hls.loadSource(painting.id as string);
-    });
+    (async () => {
+      const { default: Hls } = await import("hls.js");
+      if (cancelled || !playerRef.current) return;
 
-    // Handle errors
-    hls.on(Hls.Events.ERROR, function (event, data) {
-      if (data.fatal) {
+      // Final guard: the browser must support MediaSource Extensions for
+      // hls.js to work. If not, fall back to setting the source directly
+      // and let the browser surface the failure naturally.
+      if (!Hls.isSupported()) {
+        playerRef.current.src = painting.id as string;
+        playerRef.current.load();
+        return;
+      }
+
+      const config: Partial<HlsConfig> = {
+        xhrSetup: function (xhr: XMLHttpRequest) {
+          xhr.withCredentials = !!configOptions.withCredentials;
+        },
+      };
+
+      hls = new Hls(config);
+      hls.attachMedia(playerRef.current);
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+        hls?.loadSource(painting.id as string);
+      });
+
+      hls.on(Hls.Events.ERROR, function (event, data) {
+        if (!data.fatal) return;
         switch (data.type) {
           case Hls.ErrorTypes.NETWORK_ERROR:
-            // try to recover network error
             console.error(
               `fatal ${event} network error encountered, try to recover`,
             );
-            hls.startLoad();
+            hls?.startLoad();
             break;
           case Hls.ErrorTypes.MEDIA_ERROR:
             console.error(
               `fatal ${event} media error encountered, try to recover`,
             );
-            hls.recoverMediaError();
+            hls?.recoverMediaError();
             break;
           default:
-            // cannot recover
-            hls.destroy();
+            hls?.destroy();
             break;
         }
-      }
-    });
+      });
+    })();
 
     return () => {
+      cancelled = true;
       if (hls && playerRef.current) {
-        const video: HTMLVideoElement = playerRef.current;
         hls.detachMedia();
         hls.destroy();
-        video.currentTime = 0;
+        playerRef.current.currentTime = 0;
       }
     };
   }, [

--- a/src/lib/hls.ts
+++ b/src/lib/hls.ts
@@ -1,3 +1,18 @@
+/**
+ * Detect whether a content resource id / format pair represents an HLS
+ * playlist. Strips any query string before checking the file extension so
+ * tokenised URLs like `…/playlist.m3u8?token=…` are matched, then falls
+ * back to a list of common HLS MIME types.
+ */
+export const isHls = (id?: string, format?: string): boolean => {
+  if (id) {
+    const path = id.split("?")[0];
+    if (path.split(".").pop()?.toLowerCase() === "m3u8") return true;
+  }
+  if (format && hlsMimeTypes.includes(format)) return true;
+  return false;
+};
+
 export const hlsMimeTypes = [
   // Apple santioned
   "application/vnd.apple.mpegurl",


### PR DESCRIPTION
## Summary

`hls.js` is currently a top-level static import in both `Viewer/Player/Player.tsx` and `Primitives/ContentResource/ContentResource.tsx`, which means every consumer of `@samvera/clover-iiif` bundles it even though it's only needed for IIIF manifests that include HLS streaming sources (a minority of providers).

This PR replaces the static `import Hls from "hls.js"` with a runtime `import("hls.js")` that fires only when:

1. The painting source looks like HLS (`.m3u8` path or an HLS MIME type like `application/x-mpegurl`), and
2. The browser doesn't natively support HLS via `video.canPlayType("application/vnd.apple.mpegurl")` (Safari / iOS / WKWebView use native playback and never load `hls.js`).

After the dynamic import resolves, `Hls.isSupported()` is also checked; if MSE is missing the source falls back to native playback so the browser surfaces the failure naturally rather than silently no-op'ing.

### Other changes pulled in alongside

- **Shared HLS detection helper.** `Player.tsx` and `ContentResource.tsx` previously used inconsistent heuristics (`split(".").pop() === "m3u8"` vs `id.includes("m3u8")`). Both now use a new `isHls(id, format)` helper in `src/lib/hls.ts`, which strips query strings before the extension check so tokenised playlist URLs like `…/playlist.m3u8?token=…` are matched.
- **`ContentResource.tsx` no longer sets `<video src={id}>` for HLS sources.** The JSX-set `src` was racing the imperative `hls.attachMedia` call in non-Safari browsers and could trigger a media decode error before hls.js took over. The src attribute is now omitted for HLS sources and set only for plain MP4/WebM.
- **`hls.js` is added to `FORCED_EXTERNALS`** in `build/base-config.mjs` so it survives the lib build's `inlineDynamicImports: true` setting and stays out of the published `dist/{viewer,scroll,primitives}` bundles. The consumer's bundler resolves the dynamic `import("hls.js")` from `node_modules` and code-splits it. (`hls.js` remains in `dependencies`, so npm and direct CDN consumers still install it automatically — only the static inline of its bytes goes away.)

### Manual test fixture

`public/manifest/hls-test.json` wraps a public Mux HLS test stream so the lazy path can be exercised against `npm run dev` without depending on a hosted IIIF manifest:

```
http://localhost:3000/docs/viewer/demo?iiif-content=http://localhost:3000/manifest/streaming/hls.json
```

## Test plan

- [x] `npm run test` — 213 tests pass. The Player HLS test is updated to await the dynamic import (via `waitFor`) and stubs `HTMLMediaElement.prototype.canPlayType` and `Hls.isSupported` to force the non-native lazy path.
- [x] `npx prettier --check` clean on touched files.
- [x] `npm run build` succeeds.
- [x] Manually verified in `npm run dev`:
  - Default image manifests render unchanged with no `hls.js` chunk loaded.
  - HLS test manifest in Firefox loads `node_modules_hls_js_dist_hls_mjs.js` on demand and plays the stream.
  - HLS test manifest in Safari plays via native HLS without loading `hls.js` at all.

Refs #328 (v4 wishlist: _"Handle hls.js better … load if we detect an m3u8"_).