### PR TITLE
Add Map component for IIIF navPlace and Georeference Annotations

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -9,6 +9,16 @@ jobs:
   examples:
     name: React 18 and 19 Compatibility
     runs-on: ubuntu-latest
+    # Browsers + system deps are preinstalled in this image, so we skip the
+    # Chromium download that hangs on GitHub-hosted runners. setup-node below
+    # upgrades the image's Node 22 to 24 (browsers stay at /ms-playwright).
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
+    # In a container the runner falls back to `sh`; force bash so bash-isms
+    # like `{1..60}` brace expansion in the readiness loops work.
+    defaults:
+      run:
+        shell: bash
     env:
       NPM_CONFIG_OPTIONAL: true
     steps:
@@ -46,9 +56,6 @@ jobs:
           # Capture only the tarball filename (last line), stripping any CRs
           PKG_TGZ=$(npm pack --silent | tail -n 1 | tr -d '\r')
           echo "PKG_TGZ=$PKG_TGZ" >> "$GITHUB_ENV"
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
 
       - name: React 19 - install deps
         working-directory: playwright/next-react19

--- a/.github/workflows/wc-e2e.yml
+++ b/.github/workflows/wc-e2e.yml
@@ -9,6 +9,16 @@ jobs:
   wc-e2e:
     name: WC HTML + Playwright
     runs-on: ubuntu-latest
+    # Browsers + system deps are preinstalled in this image, so we skip the
+    # Chromium download that hangs on GitHub-hosted runners. setup-node below
+    # upgrades the image's Node 22 to 24 (browsers stay at /ms-playwright).
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.0-noble
+    # In a container the runner falls back to `sh`; force bash for parity
+    # with the host-runner default and so any bash-isms work.
+    defaults:
+      run:
+        shell: bash
     env:
       NPM_CONFIG_OPTIONAL: true
     steps:
@@ -43,9 +53,6 @@ jobs:
         run: |
           mkdir -p playwright/html
           cp dist/web-components/index.umd.js playwright/html/wc.js
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
 
       - name: Run WC smoke test (webServer managed)
         working-directory: playwright

--- a/build/base-config.mjs
+++ b/build/base-config.mjs
@@ -22,6 +22,10 @@ const FORCED_EXTERNALS = new Set([
   // keeps it out of the always-bundled `dist/*/index.{mjs,cjs}` output and
   // lets consumer bundlers (or direct ESM resolution) load it on demand.
   "hls.js",
+  // @allmaps/leaflet is loaded dynamically only when showImageOverlay is true.
+  // Externalising it avoids bundling ~800 kB of georeferencing code for
+  // consumers who never use the warped image overlay feature.
+  "@allmaps/leaflet",
 ]);
 
 function getPackageName(id) {

--- a/build/build.mjs
+++ b/build/build.mjs
@@ -12,6 +12,13 @@ const buildOptions = {
       fileName: "index",
     },
   },
+  map: {
+    lib: {
+      name: "CloverIIIFMap",
+      entry: "./src/components/Map/index.tsx",
+      fileName: "index",
+    },
+  },
   primitives: {
     lib: {
       name: "CloverIIIFPrimitives",

--- a/build/root.mjs
+++ b/build/root.mjs
@@ -1,5 +1,6 @@
 "use client";
 import Image from "./image";
+import Map from "./map";
 import Primitives from "./primitives";
 import Scroll from "./scroll";
 import Slider from "./slider";
@@ -8,6 +9,7 @@ import Helpers from "./helpers";
 
 export {
   Image,
+  Map,
   Primitives,
   Scroll,
   Slider,

--- a/build/root.umd.js
+++ b/build/root.umd.js
@@ -2,6 +2,7 @@
 // @ts-nocheck
 
 const Image = require("./image");
+const Map = require("./map");
 const Primitives = require("./primitives");
 const Scroll = require("./scroll");
 const Slider = require("./slider");
@@ -11,6 +12,7 @@ const Helpers = require("./helpers");
 module.exports = {
   default: Viewer,
   Image,
+  Map,
   Primitives,
   Scroll,
   Slider,

--- a/decs.d.ts
+++ b/decs.d.ts
@@ -4,3 +4,4 @@
 // declare module "@iiif/parser/upgrader";
 
 declare module "node-webvtt";
+declare module "leaflet/dist/leaflet.css";

--- a/docs/components/DynamicImports/Map.tsx
+++ b/docs/components/DynamicImports/Map.tsx
@@ -1,0 +1,11 @@
+import dynamic from "next/dynamic";
+
+const Map = dynamic(() => import("src/components/Map"), {
+  ssr: false,
+});
+
+const CloverMap = (props) => {
+  return <Map {...props} />;
+};
+
+export default CloverMap;

--- a/docs/components/Map/CoordinatePickingDemo.tsx
+++ b/docs/components/Map/CoordinatePickingDemo.tsx
@@ -1,0 +1,46 @@
+import CloverMap from "docs/components/DynamicImports/Map";
+import { useState } from "react";
+
+const CoordinatePickingDemo = () => {
+  const [coordinates, setCoordinates] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(null);
+
+  return (
+    <div style={{ display: "grid", gap: "0.75rem" }}>
+      <div style={{ position: "relative", height: "400px" }}>
+        <CloverMap
+          center={{ latitude: 42.045, longitude: -87.688, zoom: 11 }}
+          markers={
+            coordinates
+              ? [
+                  {
+                    latitude: coordinates.lat,
+                    longitude: coordinates.lng,
+                    label: "Selected coordinate",
+                  },
+                ]
+              : []
+          }
+          onMapClick={([lng, lat]) => setCoordinates({ lng, lat })}
+          useCrosshairCursor
+        />
+      </div>
+      <output
+        style={{
+          display: "block",
+          minHeight: "1.5rem",
+          fontFamily: "monospace",
+          fontSize: "0.875rem",
+        }}
+      >
+        {coordinates
+          ? `longitude: ${coordinates.lng}, latitude: ${coordinates.lat}`
+          : "Click the map to pick coordinates."}
+      </output>
+    </div>
+  );
+};
+
+export default CoordinatePickingDemo;

--- a/docs/components/TitleComponent.tsx
+++ b/docs/components/TitleComponent.tsx
@@ -20,7 +20,7 @@ const betaBadgeStyling: CSSProperties = {
   marginLeft: "10px",
 };
 
-const isBeta = ["Scroll"];
+const isBeta = ["Scroll", "Map"];
 
 const TitleComponent: React.FC<TitleComponentProps> = ({ title }) => {
   if (isBeta.includes(title))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.9.2",
       "license": "ISC",
       "dependencies": {
+        "@allmaps/leaflet": "^1.0.0-beta.53",
         "@iiif/helpers": "^1.2.19",
         "@iiif/parser": "^2.1.4",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -27,6 +28,7 @@
         "hls.js": "^1.5.17",
         "i18next": "^23.16.5",
         "i18next-browser-languagedetector": "^8.0.0",
+        "leaflet": "^1.9.4",
         "marked": "^18.0.2",
         "marked-footnote": "^1.4.0",
         "node-webvtt": "^1.9.4",
@@ -45,6 +47,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/dompurify": "^3.2.0",
         "@types/flexsearch": "^0.7.6",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "20.11.16",
         "@types/openseadragon": "^3.0.10",
         "@types/react": "^18.3.12",
@@ -89,6 +92,142 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@allmaps/annotation": {
+      "version": "1.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@allmaps/annotation/-/annotation-1.0.0-beta.36.tgz",
+      "integrity": "sha512-8f79ItFD4TxFfyVJ4Wo96Qayxz2Gizy8XZ0u/10YRFWgDV2ZnQAGfSlZh3ITW1759npYQzruRzyeU68D1RXOPA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@allmaps/id": {
+      "version": "1.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/@allmaps/id/-/id-1.0.0-beta.37.tgz",
+      "integrity": "sha512-6hODPDzFPgCUX26JJABRMqlOHCZB+sN5nrzvN//z7ukfDqaXDM6L95LODc9vAzs85TVHIUYPIYvpiDQbpkL1Qg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=v19.0.0"
+      }
+    },
+    "node_modules/@allmaps/iiif-parser": {
+      "version": "1.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@allmaps/iiif-parser/-/iiif-parser-1.0.0-beta.47.tgz",
+      "integrity": "sha512-GG9Oz2MIzdB4B8x/t2UuNx1Lc0Im7oHnGZoFLjNUeSuzq53m1/wLTEgvxQKabH4JVUMSXlPVZHc7BzO+eE7r0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/@allmaps/leaflet": {
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@allmaps/leaflet/-/leaflet-1.0.0-beta.53.tgz",
+      "integrity": "sha512-kUywcFiD5MWBDrQ121iPsfSBK7LH6RUwGtsXLQckO8C25SNCYd7yVMgkv5GRCQ80Su1Vta/7SQFsp+GezSjghQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/render": "^1.0.0-beta.82",
+        "@allmaps/stdlib": "^1.0.0-beta.40",
+        "@allmaps/warpedmaplayer": "^1.0.0-beta.42",
+        "leaflet": "^1.9.4"
+      }
+    },
+    "node_modules/@allmaps/project": {
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@allmaps/project/-/project-1.0.0-beta.8.tgz",
+      "integrity": "sha512-NFz4C69HwFUPEitan2I0hm5lvKlk9xRDNdvnwbo7I/J06+vLMJWGFqKEkReBwC583BxroByeUTa732cG/UaadQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/stdlib": "^1.0.0-beta.40",
+        "@allmaps/transform": "^1.0.0-beta.51",
+        "proj4": "^2.20.0"
+      }
+    },
+    "node_modules/@allmaps/render": {
+      "version": "1.0.0-beta.82",
+      "resolved": "https://registry.npmjs.org/@allmaps/render/-/render-1.0.0-beta.82.tgz",
+      "integrity": "sha512-M/zg0xeeeRXlTYozKo6Uw0OMZ+uLLH7S5plNWF4THxSSRBjXjCrzaiAVI/xklqtBW6CCe2QF4pxIkJWgUN3HWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/annotation": "^1.0.0-beta.36",
+        "@allmaps/id": "^1.0.0-beta.37",
+        "@allmaps/iiif-parser": "^1.0.0-beta.47",
+        "@allmaps/project": "^1.0.0-beta.8",
+        "@allmaps/stdlib": "^1.0.0-beta.40",
+        "@allmaps/tailwind": "^1.0.0-beta.20",
+        "@allmaps/transform": "^1.0.0-beta.51",
+        "@allmaps/triangulate": "^1.0.0-beta.32",
+        "@allmaps/types": "^1.0.0-beta.22",
+        "comlink": "^4.4.1",
+        "lodash-es": "^4.17.21",
+        "point-in-polygon-hao": "^1.2.4",
+        "rbush": "^4.0.0"
+      }
+    },
+    "node_modules/@allmaps/stdlib": {
+      "version": "1.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@allmaps/stdlib/-/stdlib-1.0.0-beta.40.tgz",
+      "integrity": "sha512-KanrEDClErcu6bSd+4kDsRW8rO6P9hHO6n2WJxmZYpbUzUQ1gPBWv1+AB0sxAMoK1hwV3NPkqtvNEJ12M3NETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/annotation": "^1.0.0-beta.36",
+        "@allmaps/iiif-parser": "^1.0.0-beta.47",
+        "@turf/rewind": "^7.2.0",
+        "@types/lodash-es": "^4.17.12",
+        "hex-rgb": "^5.0.0",
+        "lodash-es": "^4.17.21",
+        "monotone-chain-convex-hull": "^1.1.0",
+        "rgb-hex": "^4.1.0",
+        "svg-parser": "^2.0.4"
+      }
+    },
+    "node_modules/@allmaps/tailwind": {
+      "version": "1.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@allmaps/tailwind/-/tailwind-1.0.0-beta.20.tgz",
+      "integrity": "sha512-kUM2qH4EurYmKbk4yW2ni7J/pZqCnOK/XdaSXeVqREfkWNynrH5di/j3byxtqD1+xYBeI/Fft4JTShKWrZZedA==",
+      "license": "MIT"
+    },
+    "node_modules/@allmaps/transform": {
+      "version": "1.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@allmaps/transform/-/transform-1.0.0-beta.51.tgz",
+      "integrity": "sha512-tX241cGwMrSFse7vAUO7GRDinHzMy3Pv9Ik/S8ZZQGdjxQHPsKvK7X56NXLUGfsrk7Ls/TjqN9R5Pzo1NnpUng==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/stdlib": "^1.0.0-beta.40",
+        "@turf/distance": "^7.2.0",
+        "@turf/midpoint": "^7.2.0",
+        "ml-matrix": "^6.12.0"
+      }
+    },
+    "node_modules/@allmaps/triangulate": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@allmaps/triangulate/-/triangulate-1.0.0-beta.32.tgz",
+      "integrity": "sha512-I8BOLOhPNW4H3+OvgTvBBie0tT3QdjqJbw4SgoFvlVYbPZQPwMWUU6sRGB9kpuww8vGICTkODBZsC6E+jtmx0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/stdlib": "^1.0.0-beta.40",
+        "@allmaps/types": "^1.0.0-beta.22",
+        "@kninnug/constrainautor": "^4.0.1",
+        "delaunator": "^5.0.1",
+        "point-in-polygon-hao": "^1.2.4"
+      }
+    },
+    "node_modules/@allmaps/types": {
+      "version": "1.0.0-beta.22",
+      "resolved": "https://registry.npmjs.org/@allmaps/types/-/types-1.0.0-beta.22.tgz",
+      "integrity": "sha512-93XNs2YoKoxzlx9eGsu4+h67pZ39QE5/N2OWdWjsrqcfOLJw3vWb9x2LjoMrWEl7hkB2raY71gbyqtkoGIfKiw==",
+      "license": "MIT"
+    },
+    "node_modules/@allmaps/warpedmaplayer": {
+      "version": "1.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@allmaps/warpedmaplayer/-/warpedmaplayer-1.0.0-beta.42.tgz",
+      "integrity": "sha512-OnJ/A4AWg/0BeCz5Hf1MrAxwddr4mWsAYKr358FjRGCT+SBXtv75o5se0Hbjl8fuRt8Z32fM8p/nJL8IOexGug==",
+      "license": "MIT",
+      "dependencies": {
+        "@allmaps/project": "^1.0.0-beta.8",
+        "@allmaps/render": "^1.0.0-beta.82",
+        "@allmaps/stdlib": "^1.0.0-beta.40"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1429,6 +1568,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kninnug/constrainautor": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@kninnug/constrainautor/-/constrainautor-4.1.0.tgz",
+      "integrity": "sha512-YEkGtzMewRxPRZuK1QmFDmELwaSL4LSLmc0WXTmpT8AqdcR/Ueu77fiJZ2lwOwXUX8aBJpHuy/e/06/Ve2dPNQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.1"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -3642,6 +3790,156 @@
         "unist-util-visit": "^5.0.0"
       }
     },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.5.tgz",
+      "integrity": "sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.5.tgz",
+      "integrity": "sha512-VpDIpTKBjH4oPbzx1ns18TWcosi+qCRtgU1HIJHLj4NWyLNr7TX86DvomCvZRPfsFxkYYgkFlqHBG1a29dcyqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.5.tgz",
+      "integrity": "sha512-x6ylChhOlIbucRSw7wF6z2gSEqqQl+dE0nSH5AL/ojZkqqGYahiw+2P4A8ZMuDM6rzH+FIqRYDes0o4nSArZCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.5.tgz",
+      "integrity": "sha512-y92O2YDDBkZp7jAUuUPgof/HiXHjJSkKjEtQRjWXZcjTlzHd/Fqg6/twarY2wNkENK2EuaaiV9MDy74FeRG2Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.5",
+        "@turf/destination": "7.3.5",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.5.tgz",
+      "integrity": "sha512-4AZdDh55JeCoKWLS5AC6MuXqAvoqSpj2WigtowtA3JIJ/1J4SclRrV6BGq/Xemwm5yKtRePHazBVUmG5uU75og==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.5",
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3826,6 +4124,31 @@
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
@@ -5641,6 +5964,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6453,7 +6782,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -8857,6 +9185,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/hex-rgb": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-5.0.0.tgz",
+      "integrity": "sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hls.js": {
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
@@ -9136,6 +9476,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -10014,6 +10360,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -10207,7 +10559,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11054,6 +11405,12 @@
         "web-worker": "^1.2.0"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
     "node_modules/micromark": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
@@ -11866,6 +12223,51 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ml-array-max": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-2.0.0.tgz",
+      "integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-2.0.0.tgz",
+      "integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
+      "integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-max": "^2.0.0",
+        "ml-array-min": "^2.0.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.2.tgz",
+      "integrity": "sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-rescale": "^2.0.0"
+      }
+    },
+    "node_modules/monotone-chain-convex-hull": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/monotone-chain-convex-hull/-/monotone-chain-convex-hull-1.1.0.tgz",
+      "integrity": "sha512-iZGaoO2qtqIWaAfscTtsH2LolE06U4JzTw8AgtjT/yzYIA0aoAHDdwBtsesnQXfVRvS375Wu0Y1+FqdI5Y22GA==",
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -13066,6 +13468,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -13171,6 +13582,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/proj4": {
+      "version": "2.20.8",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
+      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -13265,6 +13689,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -13827,6 +14266,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rgb-hex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-4.1.0.tgz",
+      "integrity": "sha512-UZLM57BW09Yi9J1R3OP8B1yCbbDK3NT8BDtihGZkGkGEs2b6EaV85rsfJ6yK4F+8UbxFFmfA+9xHT5ZWhN1gDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rimraf": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
@@ -13934,7 +14385,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -14894,6 +15344,12 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -16461,6 +16917,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/wkt-parser": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
+      "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -16738,7 +17203,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
       "import": "./dist/image/index.mjs",
       "require": "./dist/image/index.cjs"
     },
+    "./map": {
+      "types": "./dist/map/index.d.ts",
+      "import": "./dist/map/index.mjs",
+      "require": "./dist/map/index.cjs"
+    },
     "./primitives": {
       "types": "./dist/primitives/index.d.ts",
       "import": "./dist/primitives/index.mjs",
@@ -90,6 +95,7 @@
     "node": ">=20.10.0"
   },
   "dependencies": {
+    "@allmaps/leaflet": "^1.0.0-beta.53",
     "@iiif/helpers": "^1.2.19",
     "@iiif/parser": "^2.1.4",
     "@radix-ui/react-aspect-ratio": "^1.1.0",
@@ -108,6 +114,7 @@
     "hls.js": "^1.5.17",
     "i18next": "^23.16.5",
     "i18next-browser-languagedetector": "^8.0.0",
+    "leaflet": "^1.9.4",
     "marked": "^18.0.2",
     "marked-footnote": "^1.4.0",
     "node-webvtt": "^1.9.4",
@@ -126,6 +133,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/dompurify": "^3.2.0",
     "@types/flexsearch": "^0.7.6",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "20.11.16",
     "@types/openseadragon": "^3.0.10",
     "@types/react": "^18.3.12",
@@ -167,6 +175,9 @@
       ],
       "image": [
         "dist/image/index.d.ts"
+      ],
+      "map": [
+        "dist/map/index.d.ts"
       ],
       "primitives": [
         "dist/primitives/index.d.ts"

--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -6,6 +6,7 @@
     "title": "IIIF Components"
   },
   "image": "Image",
+  "map": "Map",
   "scroll": {
     "title": "Scroll",
     "type": "doc"

--- a/pages/docs/map.mdx
+++ b/pages/docs/map.mdx
@@ -1,0 +1,734 @@
+---
+title: Map
+---
+
+import CloverMap from "docs/components/DynamicImports/Map";
+import IIIFBadge from "docs/components/IIIFBadge";
+import { useState } from "react";
+import { Tabs, Tab } from "nextra/components";
+import {
+  DC_GEOREF_ANNOTATION_CANVAS as georefAnnotation,
+  DC_GEOREF_ANNOTATION_OVERLAY as georefAnnotationOverlay,
+} from "src/fixtures/georef";
+
+export const navPlace = {
+  type: "FeatureCollection",
+  features: [
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/feature/1",
+      type: "Feature",
+      properties: {
+        label: {
+          en: ["Current Location of the Laocoön Bronze"],
+          it: ["Ubicazione attuale del Bronzo Laocoonte e i suoi figli"],
+        },
+      },
+      geometry: { type: "Point", coordinates: [-118.4745559, 34.0776376] },
+    },
+    {
+      id: "https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/feature/2",
+      type: "Feature",
+      properties: {
+        label: { en: ["Current Location of Painting"] },
+      },
+      geometry: { type: "Point", coordinates: [-77.0199025, 38.8920717] },
+    },
+  ],
+};
+
+export const navPlacePolygon = {
+  type: "Feature",
+  properties: { label: { en: ["Lake Michigan"] } },
+  geometry: {
+    type: "Polygon",
+    coordinates: [
+      [
+        [-87.91178, 41.61793],
+        [-84.72398, 41.61793],
+        [-84.72398, 46.1023],
+        [-87.91178, 46.1023],
+        [-87.91178, 41.61793],
+      ],
+    ],
+  },
+};
+
+export const navPlaceRoute66 = {
+  type: "Feature",
+  properties: { label: { en: ["Historic Route 66"] } },
+  geometry: {
+    type: "LineString",
+    coordinates: [
+      [-87.65005, 41.85003],
+      [-89.64371, 39.80172],
+      [-90.19789, 38.62727],
+      [-94.51328, 37.08423],
+      [-97.51643, 35.46756],
+      [-101.8313, 35.222],
+      [-106.65114, 35.08449],
+      [-111.65127, 35.19807],
+      [-118.49138, 34.01949],
+    ],
+  },
+};
+
+export const navPlaceLakeMichigan = {
+  type: "Feature",
+  properties: { label: { en: ["Lake Michigan Shoreline"] } },
+  geometry: {
+    type: "GeometryCollection",
+    geometries: [
+      {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-87.91178, 41.61793],
+            [-84.72398, 41.61793],
+            [-84.72398, 46.1023],
+            [-87.91178, 46.1023],
+            [-87.91178, 41.61793],
+          ],
+        ],
+      },
+      {
+        type: "LineString",
+        coordinates: [
+          [-87.34643, 41.59337],
+          [-87.65005, 41.85003],
+          [-87.90647, 43.0389],
+          [-88.01983, 44.51916],
+        ],
+      },
+      {
+        type: "MultiPoint",
+        coordinates: [
+          [-87.34643, 41.59337],
+          [-87.65005, 41.85003],
+          [-87.90647, 43.0389],
+          [-88.01983, 44.51916],
+          [-85.62063, 44.76306],
+        ],
+      },
+    ],
+  },
+};
+
+export const CoordinatePickingDemo = () => {
+  const [coordinates, setCoordinates] = useState(null);
+
+  return (
+    <div style={{ display: "grid", gap: "0.75rem" }}>
+      <div style={{ position: "relative", height: "400px" }}>
+        <CloverMap
+          center={{ latitude: 42.045, longitude: -87.688, zoom: 11 }}
+          markers={
+            coordinates
+              ? [
+                  {
+                    latitude: coordinates.lat,
+                    longitude: coordinates.lng,
+                    label: "Selected coordinate",
+                  },
+                ]
+              : []
+          }
+          onMapClick={([lng, lat]) => setCoordinates({ lng, lat })}
+          useCrosshairCursor
+        />
+      </div>
+      <output
+        style={{
+          display: "block",
+          minHeight: "1.5rem",
+          fontFamily: "monospace",
+          fontSize: "0.875rem",
+        }}
+      >
+        {coordinates
+          ? `longitude: ${coordinates.lng}, latitude: ${coordinates.lat}`
+          : "Click the map to pick coordinates."}
+      </output>
+    </div>
+  );
+};
+
+# Map
+
+A UI component that renders a geographic map using [Leaflet](https://leafletjs.com/), with native support for IIIF [navPlace](https://iiif.io/api/extension/navplace/) geographic annotations and [Georeference Extension](https://iiif.io/api/extension/georef/) control points. Optionally renders warped IIIF image overlays via [@allmaps/leaflet](https://allmaps.org/).
+
+<IIIFBadge
+  href="https://iiif.io/api/extension/navplace/"
+  text={["navPlace Extension"]}
+/>
+
+<IIIFBadge
+  href="https://iiif.io/api/extension/georef/"
+  text={["Georeference Extension"]}
+/>
+
+---
+
+<div style={{ position: "relative", height: "400px" }}>
+  <CloverMap navPlace={navPlace} fitToData />
+</div>
+
+## Features
+
+Provide a IIIF `navPlace` GeoJSON value, a Georeference Extension annotation, or both, and the component:
+
+- Renders GeoJSON features from IIIF `navPlace` values (FeatureCollection, Feature, or bare geometry)
+- Resolves `label` properties as IIIF [InternationalString](https://iiif.io/api/presentation/3.0/#44-language-of-property-values) or plain strings for tooltips
+- Displays Ground Control Points (GCPs) from a Georeference Extension annotation as numbered markers
+- Optionally renders a warped IIIF image overlay via [@allmaps/leaflet](https://allmaps.org/) when `showImageOverlay` is enabled
+- Auto-fits the viewport to all displayed data with `fitToData`
+- Accepts a click callback for coordinate picking (`onMapClick`)
+- Configurable tile layer (defaults to [OpenStreetMap](https://www.openstreetmap.org/))
+
+## Installation
+
+<Tabs items={["npm", "yarn", "pnpm"]}>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      npm install @samvera/clover-iiif
+    ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      yarn add @samvera/clover-iiif
+    ```
+  </Tab>
+  {/* prettier-ignore */}
+  <Tab>
+    ```shell
+      pnpm install @samvera/clover-iiif
+    ```
+  </Tab>
+</Tabs>
+
+## Usage
+
+### React
+
+Add the `Map` component to your `jsx` or `tsx` code.
+
+```jsx
+import Map from "@samvera/clover-iiif/map";
+```
+
+### Next.js
+
+Implementation with Next.js requires a [dynamic import](https://nextjs.org/docs/advanced-features/dynamic-import) because Leaflet assumes a browser `document` object.
+
+```jsx
+import dynamic from "next/dynamic";
+
+const Map = dynamic(
+  () => import("@samvera/clover-iiif").then((Clover) => Clover.Map),
+  { ssr: false },
+);
+```
+
+---
+
+## navPlace
+
+Render geographic features from a IIIF [navPlace](https://iiif.io/api/extension/navplace/) value. The `navPlace` prop accepts a GeoJSON `FeatureCollection`, `Feature`, or bare geometry object. Feature `properties.label` may be a plain string or a IIIF `InternationalString`, and will be shown as a tooltip and popup.
+
+You can also pass a IIIF resource through `iiifContent`. Clover will extract navPlace values from Collections, Manifests, Canvases, and Annotations, and the popup will include the resource context that supplied the feature, including its label, summary, and thumbnail when present.
+
+```jsx
+<Map
+  iiifContent="https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/manifest.json"
+  navPlaceLevel="Canvas"
+  fitToData
+/>
+```
+
+The example below uses features from the [IIIF Cookbook recipe 0240 — navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/), where `navPlace` is declared directly on each Canvas. To consume it, fetch the manifest and read `canvas.navPlace` from each item:
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    // Fetch the manifest and collect navPlace features from all canvases
+    const manifest = await fetch(
+      "https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/manifest.json"
+    ).then((r) => r.json());
+
+    const navPlace = {
+      type: "FeatureCollection",
+      features: manifest.items.flatMap(
+        (canvas) => canvas.navPlace?.features ?? []
+      ),
+    };
+
+    // navPlace now contains two features:
+    // - Current Location of the Laocoön Bronze  [-118.47, 34.07]  (Getty, Los Angeles)
+    // - Current Location of Painting            [-77.02,  38.89]  (National Gallery, DC)
+
+    <div style={{ height: "400px" }}>
+      <Map navPlace={navPlace} fitToData />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap navPlace={navPlace} fitToData />
+    </div>
+  </Tab>
+</Tabs>
+
+### Polygon
+
+A `Polygon` geometry draws a filled region. This example uses a bounding box from [GeoNames](https://www.geonames.org/) to outline the extent of Lake Michigan.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    const navPlace = {
+      type: "Feature",
+      properties: { label: { en: ["Lake Michigan"] } },
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-87.91178, 41.61793], // SW
+            [-84.72398, 41.61793], // SE
+            [-84.72398, 46.10230], // NE
+            [-87.91178, 46.10230], // NW
+            [-87.91178, 41.61793], // close ring
+          ],
+        ],
+      },
+    };
+
+    <div style={{ height: "400px" }}>
+      <Map navPlace={navPlace} fitToData />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap navPlace={navPlacePolygon} fitToData />
+    </div>
+  </Tab>
+</Tabs>
+
+### LineString
+
+A `LineString` draws a connected path between an ordered sequence of coordinates. This example traces [Historic Route 66](https://en.wikipedia.org/wiki/U.S._Route_66) from Chicago to Santa Monica using city coordinates from GeoNames.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    const navPlace = {
+      type: "Feature",
+      properties: { label: { en: ["Historic Route 66"] } },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-87.65005, 41.85003], // Chicago, IL
+          [-89.64371, 39.80172], // Springfield, IL
+          [-90.19789, 38.62727], // St. Louis, MO
+          [-94.51328, 37.08423], // Joplin, MO
+          [-97.51643, 35.46756], // Oklahoma City, OK
+          [-101.83130, 35.22200], // Amarillo, TX
+          [-106.65114, 35.08449], // Albuquerque, NM
+          [-111.65127, 35.19807], // Flagstaff, AZ
+          [-118.49138, 34.01949], // Santa Monica, CA
+        ],
+      },
+    };
+
+    <div style={{ height: "400px" }}>
+      <Map navPlace={navPlace} fitToData />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap navPlace={navPlaceRoute66} fitToData />
+    </div>
+  </Tab>
+</Tabs>
+
+### GeometryCollection
+
+A `GeometryCollection` bundles multiple geometry types into a single `navPlace` feature. This example maps the western Lake Michigan shoreline as a composite: a bounding `Polygon` for the lake, a `LineString` tracing the shore from Gary to Green Bay, and a `MultiPoint` marking five lakeshore cities — all sharing one label.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    const navPlace = {
+      type: "Feature",
+      properties: { label: { en: ["Lake Michigan Shoreline"] } },
+      geometry: {
+        type: "GeometryCollection",
+        geometries: [
+          {
+            type: "Polygon",
+            coordinates: [[
+              [-87.91178, 41.61793],
+              [-84.72398, 41.61793],
+              [-84.72398, 46.10230],
+              [-87.91178, 46.10230],
+              [-87.91178, 41.61793],
+            ]],
+          },
+          {
+            type: "LineString",
+            coordinates: [
+              [-87.34643, 41.59337], // Gary, IN
+              [-87.65005, 41.85003], // Chicago, IL
+              [-87.90647, 43.03890], // Milwaukee, WI
+              [-88.01983, 44.51916], // Green Bay, WI
+            ],
+          },
+          {
+            type: "MultiPoint",
+            coordinates: [
+              [-87.34643, 41.59337], // Gary, IN
+              [-87.65005, 41.85003], // Chicago, IL
+              [-87.90647, 43.03890], // Milwaukee, WI
+              [-88.01983, 44.51916], // Green Bay, WI
+              [-85.62063, 44.76306], // Traverse City, MI
+            ],
+          },
+        ],
+      },
+    };
+
+    <div style={{ height: "400px" }}>
+      <Map navPlace={navPlace} fitToData />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap navPlace={navPlaceLakeMichigan} fitToData />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Georeference Extension
+
+Render Ground Control Points (GCPs) from a IIIF [Georeference Extension](https://iiif.io/api/extension/georef/) annotation. Pass a parsed annotation object to `georefAnnotation` and the component will extract the GCPs and display them as numbered markers on the map. GCPs are included in `fitToData` bounds.
+
+The example below uses a real annotation from Northwestern University Libraries' [Map of the Township of Evanston, Cook County, Illinois](https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d). The annotation's `target.source` is a Canvas.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    // Annotation as returned by dc-api — target.source.type is "Canvas"
+    const georefAnnotation = {
+      "@context": [
+        "http://iiif.io/api/extension/georef/1/context.json",
+        "http://iiif.io/api/presentation/3/context.json",
+      ],
+      id: "urn:meadow:georeference:2fb1e81a-...",
+      type: "Annotation",
+      motivation: "georeferencing",
+      target: {
+        type: "SpecificResource",
+        source: {
+          id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif",
+          type: "Canvas",
+          width: 7337,
+          height: 9833,
+        },
+        selector: { type: "SvgSelector", value: "<svg ...>" },
+      },
+      body: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { confidence: "medium", resourceCoords: [577.7, 1074.97] },
+            geometry: { type: "Point", coordinates: [-87.71064, 42.06793] },
+          },
+          // ... 2 more GCPs
+        ],
+      },
+    };
+
+    <div style={{ height: "400px" }}>
+      <Map georefAnnotation={georefAnnotation} fitToData />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap georefAnnotation={georefAnnotation} fitToData />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Warped Image Overlay
+
+When `showImageOverlay` is enabled and a `georefAnnotation` with at least 3 GCPs is provided, the component renders a warped IIIF image overlay using [@allmaps/leaflet](https://allmaps.org/).
+
+**Important:** `@allmaps/leaflet` requires the annotation's `target.source` to reference an IIIF Image API endpoint (`type: "ImageService2"` or `"ImageService3"`), not a Canvas. Annotations saved by authoring tools typically use a Canvas source. Use the `adaptGeoreferenceAnnotationForOverlay` helper to swap the source before passing it to `<Map>`.
+
+The example below uses the same Evanston map annotation adapted with the FileSet's IIIF Image API v2 endpoint as the ImageService2 source.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    import Map, { adaptGeoreferenceAnnotationForOverlay } from "@samvera/clover-iiif/map";
+
+    // Annotation target.source.type is "Canvas"
+    const storedAnnotation = { /* ... */ };
+
+    // IIIF Image API v2 base URL for the FileSet
+    const imageServiceId =
+      "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
+
+    // Adapt the annotation so @allmaps/leaflet can use it
+    const overlayAnnotation = adaptGeoreferenceAnnotationForOverlay(
+      storedAnnotation,
+      imageServiceId,
+    );
+
+    <div style={{ height: "500px" }}>
+      <Map
+        georefAnnotation={overlayAnnotation}
+        showImageOverlay
+        imageOverlayOpacity={0.65}
+        fitToData
+      />
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "500px" }}>
+      <CloverMap
+        georefAnnotation={georefAnnotationOverlay}
+        showImageOverlay
+        imageOverlayOpacity={0.65}
+        fitToData
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+`@allmaps/leaflet` is an optional dependency — it is only loaded when `showImageOverlay` is `true`, so consumers who don't use this feature pay no bundle cost.
+
+---
+
+## Combining navPlace and Georeference
+
+`navPlace` and `georefAnnotation` can be used together. When `fitToData` is enabled the viewport will expand to cover all features, GCPs, and any additional `markers`.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    <div style={{ height: "400px" }}>
+      <Map navPlace={navPlace} georefAnnotation={georefAnnotation} fitToData />
+    </div>
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "400px" }}>
+      <CloverMap
+        navPlace={navPlace}
+        georefAnnotation={georefAnnotation}
+        fitToData
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Coordinate Picking
+
+Use `onMapClick` and `useCrosshairCursor` to turn the map into a coordinate picker. The callback receives `[longitude, latitude]` rounded to five decimal places.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    const [coordinates, setCoordinates] = React.useState(null);
+
+    <div>
+      <div style={{ height: "400px" }}>
+        <Map
+          center={{ latitude: 42.045, longitude: -87.688, zoom: 11 }}
+          markers={
+            coordinates
+              ? [
+                  {
+                    latitude: coordinates.lat,
+                    longitude: coordinates.lng,
+                    label: "Selected coordinate",
+                  },
+                ]
+              : []
+          }
+          onMapClick={([lng, lat]) => setCoordinates({ lng, lat })}
+          useCrosshairCursor
+        />
+      </div>
+
+      <output>
+        {coordinates
+          ? `longitude: ${coordinates.lng}, latitude: ${coordinates.lat}`
+          : "Click the map to pick coordinates."}
+      </output>
+    </div>
+    ```
+
+  </Tab>
+  <Tab>
+    <CoordinatePickingDemo />
+  </Tab>
+</Tabs>
+
+---
+
+## API Reference
+
+### Map props
+
+| Prop                  | Type                                                    | Required | Default       |
+| --------------------- | ------------------------------------------------------- | -------- | ------------- |
+| `navPlace`            | `GeoJSON.FeatureCollection \| Feature \| Geometry`      | No       |               |
+| `iiifContent`         | `string \| object`                                      | No       |               |
+| `navPlaceLevel`       | `Collection \| Manifest \| Canvas \| Annotation \| all` | No       | `all`         |
+| `georefAnnotation`    | [`GeoreferenceAnnotation`](#georefannotation-type)      | No       |               |
+| `showControlPoints`   | `boolean`                                               | No       | `true`        |
+| `showImageOverlay`    | `boolean`                                               | No       | `false`       |
+| `imageOverlayOpacity` | `number` (0–1)                                          | No       | `0.65`        |
+| `geoJson`             | `GeoJSON.FeatureCollection \| Feature`                  | No       |               |
+| `markers`             | [`MapMarker[]`](#mapmarker-type)                        | No       | `[]`          |
+| `center`              | [`MapCenter`](#mapcenter-type)                          | No       | World view    |
+| `fitToData`           | `boolean`                                               | No       | `false`       |
+| `onMapClick`          | `(coordinates: [number, number]) => void`               | No       |               |
+| `useCrosshairCursor`  | `boolean`                                               | No       | `false`       |
+| `tileLayer`           | [`MapTileLayer`](#maptilelayer-type)                    | No       | OpenStreetMap |
+
+### `GeoreferenceAnnotation` type
+
+A IIIF [Georeference Extension](https://iiif.io/api/extension/georef/) annotation. The `body` is a GeoJSON `FeatureCollection` whose features carry `properties.resourceCoords` (image pixel `[x, y]`) paired with a `Point` geometry (geographic `[longitude, latitude]`).
+
+```ts
+interface GeoreferenceAnnotation {
+  "@context"?: string | string[];
+  id?: string;
+  type: "Annotation";
+  motivation: "georeferencing";
+  target: {
+    type: "SpecificResource";
+    source: {
+      id: string;
+      type: string; // "Canvas" | "ImageService2" | "ImageService3"
+      width?: number;
+      height?: number;
+    };
+    selector?: { type: "SvgSelector"; value: string };
+  };
+  body: GeoJSON.FeatureCollection;
+}
+```
+
+### `MapMarker` type
+
+```ts
+interface MapMarker {
+  latitude: number;
+  longitude: number;
+  label?: string;
+  color?: string;
+}
+```
+
+### `MapCenter` type
+
+```ts
+interface MapCenter {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+}
+```
+
+### `MapTileLayer` type
+
+```ts
+interface MapTileLayer {
+  url: string; // e.g. "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+  attribution: string;
+}
+```
+
+---
+
+## Helpers
+
+The following functions are exported from `@samvera/clover-iiif/helpers` and `@samvera/clover-iiif` to assist with processing IIIF georeference and navPlace data.
+
+### `parseGeoreferenceAnnotation`
+
+Extracts Ground Control Points from a `GeoreferenceAnnotation`. Features with missing or non-numeric coordinates are silently skipped.
+
+```ts
+import { helpers } from "@samvera/clover-iiif";
+
+const gcps = helpers.parseGeoreferenceAnnotation(annotation);
+// → [{ id, resourceCoords: [x, y], geoCoords: [lng, lat] }, ...]
+```
+
+### `adaptGeoreferenceAnnotationForOverlay`
+
+Swaps a Canvas source for an ImageService source so the annotation can be used with `@allmaps/leaflet`. Does not mutate the input.
+
+```ts
+import { adaptGeoreferenceAnnotationForOverlay } from "@samvera/clover-iiif";
+
+const overlayAnnotation = adaptGeoreferenceAnnotationForOverlay(
+  storedAnnotation, // GeoreferenceAnnotation with Canvas source
+  imageServiceId, // IIIF Image API base URL
+  "ImageService2", // "ImageService2" (default) or "ImageService3"
+);
+```
+
+### `normalizeNavPlace`
+
+Normalises any GeoJSON value (FeatureCollection, Feature, or bare geometry) to a `FeatureCollection`. Returns `null` for unrecognised input.
+
+```ts
+import { helpers } from "@samvera/clover-iiif";
+
+const featureCollection = helpers.normalizeNavPlace(canvas.navPlace);
+```
+
+### `extractNavPlaceFeatures`
+
+Extracts navPlace features from IIIF resources and annotates each feature with the Collection, Manifest, Canvas, or Annotation that supplied it.
+
+```ts
+import { extractNavPlaceFeatures } from "@samvera/clover-iiif";
+
+const features = extractNavPlaceFeatures(manifest, { levels: ["Canvas"] });
+```
+
+### `getNavPlaceLabel`
+
+Resolves a navPlace Feature `label` property to a display string, handling both plain strings and IIIF [InternationalString](https://iiif.io/api/presentation/3.0/#44-language-of-property-values).
+
+```ts
+import { helpers } from "@samvera/clover-iiif";
+
+const label = helpers.getNavPlaceLabel(feature.properties.label);
+// → "Current Location of the Laocoön Bronze"
+```

--- a/pages/docs/map.mdx
+++ b/pages/docs/map.mdx
@@ -3,8 +3,8 @@ title: Map
 ---
 
 import CloverMap from "docs/components/DynamicImports/Map";
+import CoordinatePickingDemo from "docs/components/Map/CoordinatePickingDemo";
 import IIIFBadge from "docs/components/IIIFBadge";
-import { useState } from "react";
 import { Tabs, Tab } from "nextra/components";
 import {
   DC_GEOREF_ANNOTATION_CANVAS as georefAnnotation,
@@ -113,45 +113,6 @@ export const navPlaceLakeMichigan = {
   },
 };
 
-export const CoordinatePickingDemo = () => {
-  const [coordinates, setCoordinates] = useState(null);
-
-  return (
-    <div style={{ display: "grid", gap: "0.75rem" }}>
-      <div style={{ position: "relative", height: "400px" }}>
-        <CloverMap
-          center={{ latitude: 42.045, longitude: -87.688, zoom: 11 }}
-          markers={
-            coordinates
-              ? [
-                  {
-                    latitude: coordinates.lat,
-                    longitude: coordinates.lng,
-                    label: "Selected coordinate",
-                  },
-                ]
-              : []
-          }
-          onMapClick={([lng, lat]) => setCoordinates({ lng, lat })}
-          useCrosshairCursor
-        />
-      </div>
-      <output
-        style={{
-          display: "block",
-          minHeight: "1.5rem",
-          fontFamily: "monospace",
-          fontSize: "0.875rem",
-        }}
-      >
-        {coordinates
-          ? `longitude: ${coordinates.lng}, latitude: ${coordinates.lat}`
-          : "Click the map to pick coordinates."}
-      </output>
-    </div>
-  );
-};
-
 # Map
 
 A UI component that renders a geographic map using [Leaflet](https://leafletjs.com/), with native support for IIIF [navPlace](https://iiif.io/api/extension/navplace/) geographic annotations and [Georeference Extension](https://iiif.io/api/extension/georef/) control points. Optionally renders warped IIIF image overlays via [@allmaps/leaflet](https://allmaps.org/).
@@ -246,7 +207,7 @@ You can also pass a IIIF resource through `iiifContent`. Clover will extract nav
 />
 ```
 
-The example below uses features from the [IIIF Cookbook recipe 0240 — navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/), where `navPlace` is declared directly on each Canvas. To consume it, fetch the manifest and read `canvas.navPlace` from each item:
+The example below uses features from [IIIF Cookbook recipe 0240: navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/), where `navPlace` is declared directly on each Canvas. To consume it, fetch the manifest and read `canvas.navPlace` from each item:
 
 <Tabs items={["Code", "Preview"]}>
   <Tab>
@@ -358,7 +319,7 @@ A `LineString` draws a connected path between an ordered sequence of coordinates
 
 ### GeometryCollection
 
-A `GeometryCollection` bundles multiple geometry types into a single `navPlace` feature. This example maps the western Lake Michigan shoreline as a composite: a bounding `Polygon` for the lake, a `LineString` tracing the shore from Gary to Green Bay, and a `MultiPoint` marking five lakeshore cities — all sharing one label.
+A `GeometryCollection` bundles multiple geometry types into a single `navPlace` feature. This example maps the western Lake Michigan shoreline as a composite: a bounding `Polygon` for the lake, a `LineString` tracing the shore from Gary to Green Bay, and a `MultiPoint` marking five lakeshore cities, all sharing one label.
 
 <Tabs items={["Code", "Preview"]}>
   <Tab>
@@ -426,7 +387,7 @@ The example below uses a real annotation from Northwestern University Libraries'
 <Tabs items={["Code", "Preview"]}>
   <Tab>
     ```jsx
-    // Annotation as returned by dc-api — target.source.type is "Canvas"
+    // Annotation as returned by dc-api; target.source.type is "Canvas"
     const georefAnnotation = {
       "@context": [
         "http://iiif.io/api/extension/georef/1/context.json",
@@ -479,7 +440,7 @@ When `showImageOverlay` is enabled and a `georefAnnotation` with at least 3 GCPs
 
 **Important:** `@allmaps/leaflet` requires the annotation's `target.source` to reference an IIIF Image API endpoint (`type: "ImageService2"` or `"ImageService3"`), not a Canvas. Annotations saved by authoring tools typically use a Canvas source. Use the `adaptGeoreferenceAnnotationForOverlay` helper to swap the source before passing it to `<Map>`.
 
-The example below uses the same Evanston map annotation adapted with the FileSet's IIIF Image API v2 endpoint as the ImageService2 source.
+The example below uses the same Evanston map annotation adapted with the FileSet's IIIF Image API v3 endpoint as the ImageService3 source.
 
 <Tabs items={["Code", "Preview"]}>
   <Tab>
@@ -489,9 +450,9 @@ The example below uses the same Evanston map annotation adapted with the FileSet
     // Annotation target.source.type is "Canvas"
     const storedAnnotation = { /* ... */ };
 
-    // IIIF Image API v2 base URL for the FileSet
+    // IIIF Image API v3 base URL for the FileSet
     const imageServiceId =
-      "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
+      "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
 
     // Adapt the annotation so @allmaps/leaflet can use it
     const overlayAnnotation = adaptGeoreferenceAnnotationForOverlay(
@@ -522,7 +483,7 @@ The example below uses the same Evanston map annotation adapted with the FileSet
   </Tab>
 </Tabs>
 
-`@allmaps/leaflet` is an optional dependency — it is only loaded when `showImageOverlay` is `true`, so consumers who don't use this feature pay no bundle cost.
+`@allmaps/leaflet` is an optional dependency. It is only loaded when `showImageOverlay` is `true`, so consumers who don't use this feature pay no bundle cost.
 
 ---
 
@@ -608,7 +569,7 @@ Use `onMapClick` and `useCrosshairCursor` to turn the map into a coordinate pick
 | `georefAnnotation`    | [`GeoreferenceAnnotation`](#georefannotation-type)      | No       |               |
 | `showControlPoints`   | `boolean`                                               | No       | `true`        |
 | `showImageOverlay`    | `boolean`                                               | No       | `false`       |
-| `imageOverlayOpacity` | `number` (0–1)                                          | No       | `0.65`        |
+| `imageOverlayOpacity` | `number` (0-1)                                          | No       | `0.65`        |
 | `geoJson`             | `GeoJSON.FeatureCollection \| Feature`                  | No       |               |
 | `markers`             | [`MapMarker[]`](#mapmarker-type)                        | No       | `[]`          |
 | `center`              | [`MapCenter`](#mapcenter-type)                          | No       | World view    |
@@ -698,7 +659,7 @@ import { adaptGeoreferenceAnnotationForOverlay } from "@samvera/clover-iiif";
 const overlayAnnotation = adaptGeoreferenceAnnotationForOverlay(
   storedAnnotation, // GeoreferenceAnnotation with Canvas source
   imageServiceId, // IIIF Image API base URL
-  "ImageService2", // "ImageService2" (default) or "ImageService3"
+  "ImageService3", // default; pass "ImageService2" for Image API 2 services
 );
 ```
 

--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -54,6 +54,112 @@ export const prefetchedManifestJson = {
   ],
 };
 
+export const pendOreilleNavPlaceManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif",
+  type: "Manifest",
+  label: {
+    none: ["Crossing the Pend d'Oreille - Kalispel"],
+  },
+  summary: {
+    none: [
+      "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record.",
+    ],
+  },
+  navPlace: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+        properties: {
+          label: {
+            none: ["Pend Oreille River"],
+          },
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [-117.61775, 49.00381],
+        },
+      },
+    ],
+  },
+  thumbnail: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38/thumbnail",
+      type: "Image",
+      format: "image/jpeg",
+      height: 300,
+      width: 300,
+    },
+  ],
+  homepage: [
+    {
+      id: "https://dc.library.northwestern.edu/items/8a833741-74a8-40dc-bd1d-c416a3b1bb38",
+      type: "Text",
+      format: "text/html",
+      label: {
+        none: [
+          "Homepage at Northwestern University Libraries Digital Collections",
+        ],
+      },
+    },
+  ],
+  items: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif",
+      type: "Canvas",
+      height: 2326,
+      width: 3072,
+      label: {
+        none: ["vol_ct07047u.tif"],
+      },
+      thumbnail: [
+        {
+          id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/!300,300/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          height: 300,
+          width: 300,
+        },
+      ],
+      items: [
+        {
+          id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif/annotation-page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif/annotation/0",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/tiff",
+                height: 2326,
+                width: 3072,
+                label: {
+                  en: ["vol_ct07047u.tif"],
+                },
+                service: [
+                  {
+                    "@id":
+                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    "@type": "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 # Viewer
 
 A UI component that renders a multicanvas IIIF item viewer with pan-zoom support for `Image` via [OpenSeadragon](https://openseadragon.github.io/) and `Video` and `Sound` content resources using the [HTML video element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video).
@@ -84,6 +190,7 @@ Provide a [IIIF Presentation API](https://iiif.io/api/presentation/3.0/) Manifes
 - Renders annotations with the [motivation](https://iiif.io/api/presentation/3.0/#values-for-motivation) of `supplementing` with a content resource having the format of `text/vtt` for _Video_ and _Sound_
 - _Video_ and _Sound_ are rendered within a HTML5 `<video>` element
 - _Image_ canvases are renderered with [OpenSeadragon](https://openseadragon.github.io/)
+- Can optionally render IIIF navPlace data with the Clover Map component
 - Supports HLS streaming for Video and Audio canvases
 - Supports IIIF Collections and toggling between child Manifests
 - Supports `placeholderCanvas` for _Image_ canvases.
@@ -264,6 +371,7 @@ const MyCustomViewer = () => {
 | `options.crossOrigin`            | `anonymous`, `use-credentials`, or `undefined` [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) | No       | `anonymous`                              |
 | `options.ignoreCaptionLabels`    | `string[]`                                                                                                                                       | No       | []                                       |
 | `options.openSeadragon`          | `OpenSeadragon.Options`                                                                                                                          | No       |                                          |
+| `options.map`                    | [See Map Display](#map-display)                                                                                                                  | No       |                                          |
 | `options.informationPanel`       | [See Information Panel](#information-panel)                                                                                                      | No       |                                          |
 | `options.annotations`            | `{ motivations?: string[] }`                                                                                                                     | No       | All motivations                          |
 | `options.requestHeaders`         | `IncomingHttpHeaders`                                                                                                                            | No       | `{ "Content-Type": "application/json" }` |
@@ -277,6 +385,114 @@ const MyCustomViewer = () => {
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.
 - Option `options.openSeadragon` will grant you ability to override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within the Clover IIIF Viewer to adjust touch and mouse gesture settings and various other configurations.
+
+### Map Display
+
+The Viewer can use the Clover `Map` component as its primary canvas display when navPlace data is available. This is opt-in through `options.map.enabled`.
+
+With `navPlaceLevel: "auto"`, Clover displays the most specific available map data for the current view: Annotation, Canvas, Manifest, then Collection. Use a fixed level to force a Collection, Manifest, Canvas, Annotation, or all available navPlace features.
+
+This example adds Manifest-level navPlace to Northwestern's _Crossing the Pend d'Oreille - Kalispel_ Manifest. The point geometry uses the [Pend Oreille River GeoNames record](https://www.geonames.org/7315798/pend-oreille-river.html) coordinates, and the map popup is enriched from the Manifest label, summary, and thumbnail.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    const northwesternManifest = await fetch(
+      "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif",
+    ).then((response) => response.json());
+
+    const manifest = {
+      ...northwesternManifest,
+      summary: {
+        none: [
+          "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record.",
+        ],
+      },
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+            properties: {
+              label: { none: ["Pend Oreille River"] },
+            },
+            geometry: {
+              type: "Point",
+              coordinates: [-117.61775, 49.00381],
+            },
+          },
+        ],
+      },
+    };
+
+    <div style={{ position: "relative", height: "580px" }}>
+      <Viewer
+        iiifContent={manifest}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: {
+            open: false,
+            renderToggle: false,
+          },
+          map: {
+            enabled: true,
+            navPlaceLevel: "Manifest",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>;
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={pendOreilleNavPlaceManifestJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: {
+            open: false,
+            renderToggle: false,
+          },
+          map: {
+            enabled: true,
+            navPlaceLevel: "Manifest",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+```jsx
+<Viewer
+  iiifContent="https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/manifest.json"
+  options={{
+    map: {
+      enabled: true,
+      navPlaceLevel: "auto",
+      fitToData: true,
+    },
+  }}
+/>
+```
+
+| Prop                              | Type                                                            | Required | Default  |
+| --------------------------------- | --------------------------------------------------------------- | -------- | -------- |
+| `options.map.enabled`             | `boolean`                                                       | No       | false    |
+| `options.map.fitToData`           | `boolean`                                                       | No       | true     |
+| `options.map.navPlaceLevel`       | `auto \| Collection \| Manifest \| Canvas \| Annotation \| all` | No       | auto     |
+| `options.map.showImageOverlay`    | `boolean`                                                       | No       | false    |
+| `options.map.imageOverlayOpacity` | `number` (0–1)                                                  | No       | 0.65     |
+| `options.map.showControlPoints`   | `boolean`                                                       | No       | true     |
+| `options.map.overlayScope`        | `manifest \| canvas`                                            | No       | manifest |
+
+When `showImageOverlay` is enabled, Clover auto-discovers [Georeference Extension](https://iiif.io/api/extension/georef/) annotations (`motivation: "georeferencing"`) on the in-scope canvases and warps the source images onto the map via [@allmaps/leaflet](https://allmaps.org/). Canvas-sourced annotations are adapted to each canvas's painting image service automatically. `overlayScope: "manifest"` (default) renders every georeferenced sheet in the manifest at once; `"canvas"` follows the active canvas. See [Image Overlays](viewer/map#image-overlays-georeference) for a worked example combining multiple sheets with navPlace geometry.
 
 ### Annotation Motivations
 

--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -145,10 +145,9 @@ export const pendOreilleNavPlaceManifestJson = {
                 },
                 service: [
                   {
-                    "@id":
-                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
-                    "@type": "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },

--- a/pages/docs/viewer/_meta.json
+++ b/pages/docs/viewer/_meta.json
@@ -21,6 +21,13 @@
     },
     "title": "Content State"
   },
+  "map": {
+    "theme": {
+      "layout": "full",
+      "sidebar": false
+    },
+    "title": "Map"
+  },
   "prefetched": {
     "display": "hidden",
     "theme": {

--- a/pages/docs/viewer/map.mdx
+++ b/pages/docs/viewer/map.mdx
@@ -1,0 +1,1027 @@
+import Viewer from "docs/components/DynamicImports/Viewer";
+import CloverMap from "docs/components/DynamicImports/Map";
+import CallToAction from "docs/components/CallToAction";
+import { Tabs, Tab } from "nextra/components";
+import { Callout } from "nextra/components";
+
+export const pendOreilleNavPlaceManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38?as=iiif",
+  type: "Manifest",
+  label: {
+    none: ["Crossing the Pend d'Oreille - Kalispel"],
+  },
+  summary: {
+    none: [
+      "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record.",
+    ],
+  },
+  navPlace: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+        properties: {
+          label: {
+            none: ["Pend Oreille River"],
+          },
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [-117.61775, 49.00381],
+        },
+      },
+    ],
+  },
+  thumbnail: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38/thumbnail",
+      type: "Image",
+      format: "image/jpeg",
+      height: 300,
+      width: 300,
+    },
+  ],
+  homepage: [
+    {
+      id: "https://dc.library.northwestern.edu/items/8a833741-74a8-40dc-bd1d-c416a3b1bb38",
+      type: "Text",
+      format: "text/html",
+      label: {
+        none: [
+          "Homepage at Northwestern University Libraries Digital Collections",
+        ],
+      },
+    },
+  ],
+  items: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif",
+      type: "Canvas",
+      height: 2326,
+      width: 3072,
+      label: { none: ["vol_ct07047u.tif"] },
+      thumbnail: [
+        {
+          id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/!300,300/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          height: 300,
+          width: 300,
+        },
+      ],
+      items: [
+        {
+          id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif/annotation-page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif/annotation/0",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "https://api.dc.library.northwestern.edu/api/v2/file-sets/440bcf10-a7ee-4824-a1fb-e505cad222df?as=iiif",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/jpeg",
+                height: 2326,
+                width: 3072,
+                service: [
+                  {
+                    "@id":
+                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    "@type": "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const multiLevelNavPlaceManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "http://localhost:3000/manifest/nav-place/multi-level.json",
+  type: "Manifest",
+  label: { none: ["navPlace Multi-level Demo"] },
+  summary: {
+    none: [
+      "A manifest with navPlace at both the Manifest level (Pend Oreille region) and on each Canvas (specific sites along the river).",
+    ],
+  },
+  navPlace: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { label: { none: ["Pend Oreille River region"] } },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [-118.5, 47.5],
+              [-116.5, 47.5],
+              [-116.5, 49.5],
+              [-118.5, 49.5],
+              [-118.5, 47.5],
+            ],
+          ],
+        },
+      },
+    ],
+  },
+  thumbnail: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38/thumbnail",
+      type: "Image",
+      format: "image/jpeg",
+      height: 300,
+      width: 300,
+    },
+  ],
+  items: [
+    {
+      id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/1",
+      type: "Canvas",
+      height: 2326,
+      width: 3072,
+      label: { none: ["Crossing the Pend d'Oreille – Kalispel"] },
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+            properties: { label: { none: ["Pend Oreille River"] } },
+            geometry: {
+              type: "Point",
+              coordinates: [-117.61775, 49.00381],
+            },
+          },
+        ],
+      },
+      thumbnail: [
+        {
+          id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/!300,300/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          height: 300,
+          width: 300,
+        },
+      ],
+      items: [
+        {
+          id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/1/page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/1/page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/1",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/jpeg",
+                height: 2326,
+                width: 3072,
+                service: [
+                  {
+                    "@id":
+                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    "@type": "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/2",
+      type: "Canvas",
+      height: 9833,
+      width: 7337,
+      label: { en: ["Map of the Township of Evanston"] },
+      items: [
+        {
+          id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/2/page/1",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/2/page/1/annotation/1",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "http://localhost:3000/manifest/nav-place/multi-level.json/canvas/2",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/jpeg",
+                height: 9833,
+                width: 7337,
+                service: [
+                  {
+                    "@id":
+                      "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                    "@type": "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const collectionNavPlaceJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json",
+  type: "Collection",
+  label: { en: ["navPlace Demo Collection"] },
+  items: [
+    {
+      id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1",
+      type: "Manifest",
+      label: { none: ["Crossing the Pend d'Oreille – Kalispel"] },
+      summary: {
+        none: [
+          "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record.",
+        ],
+      },
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+            properties: {
+              label: { none: ["Pend Oreille River, Idaho/Washington"] },
+            },
+            geometry: { type: "Point", coordinates: [-117.61775, 49.00381] },
+          },
+        ],
+      },
+      homepage: [
+        {
+          id: "https://dc.library.northwestern.edu/items/8a833741-74a8-40dc-bd1d-c416a3b1bb38",
+          type: "Text",
+          format: "text/html",
+          label: {
+            none: [
+              "Homepage at Northwestern University Libraries Digital Collections",
+            ],
+          },
+        },
+      ],
+      thumbnail: [
+        {
+          id: "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38/thumbnail",
+          type: "Image",
+          format: "image/jpeg",
+          height: 300,
+          width: 300,
+        },
+      ],
+      items: [
+        {
+          id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1",
+          type: "Canvas",
+          height: 2326,
+          width: 3072,
+          label: { none: ["vol_ct07047u.tif"] },
+          thumbnail: [
+            {
+              id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/!300,300/0/default.jpg",
+              type: "Image",
+              format: "image/jpeg",
+              height: 300,
+              width: 300,
+            },
+          ],
+          items: [
+            {
+              id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1/page/1",
+              type: "AnnotationPage",
+              items: [
+                {
+                  id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1/page/1/annotation/1",
+                  type: "Annotation",
+                  motivation: "painting",
+                  target:
+                    "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1",
+                  body: {
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/600,/0/default.jpg",
+                    type: "Image",
+                    format: "image/jpeg",
+                    height: 2326,
+                    width: 3072,
+                    service: [
+                      {
+                        "@id":
+                          "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                        "@type": "ImageService2",
+                        profile: "http://iiif.io/api/image/2/level2.json",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2",
+      type: "Manifest",
+      label: { en: ["Map of the Township of Evanston, Cook County, Illinois"] },
+      summary: {
+        en: [
+          "An 1874 cadastral plat map of Evanston, Illinois from Northwestern University Libraries Digital Collections.",
+        ],
+      },
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "https://www.geonames.org/4890864/evanston.html",
+            properties: {
+              label: { en: ["Evanston, Cook County, Illinois"] },
+            },
+            geometry: { type: "Point", coordinates: [-87.68838, 42.04502] },
+          },
+        ],
+      },
+      homepage: [
+        {
+          id: "https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d",
+          type: "Text",
+          format: "text/html",
+          label: {
+            en: [
+              "Homepage at Northwestern University Libraries Digital Collections",
+            ],
+          },
+        },
+      ],
+      thumbnail: [
+        {
+          id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/!300,300/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          height: 300,
+          width: 300,
+        },
+      ],
+      items: [
+        {
+          id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1",
+          type: "Canvas",
+          height: 9833,
+          width: 7337,
+          label: { en: ["Evanston map recto"] },
+          thumbnail: [
+            {
+              id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/!300,300/0/default.jpg",
+              type: "Image",
+              format: "image/jpeg",
+              height: 300,
+              width: 300,
+            },
+          ],
+          items: [
+            {
+              id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1/page/1",
+              type: "AnnotationPage",
+              items: [
+                {
+                  id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1/page/1/annotation/1",
+                  type: "Annotation",
+                  motivation: "painting",
+                  target:
+                    "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1",
+                  body: {
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
+                    type: "Image",
+                    format: "image/jpeg",
+                    height: 9833,
+                    width: 7337,
+                    service: [
+                      {
+                        "@id":
+                          "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                        "@type": "ImageService2",
+                        profile: "http://iiif.io/api/image/2/level2.json",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const overlayManifestJson = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "http://localhost:3000/manifest/nav-place/north-shore-maps.json",
+  type: "Manifest",
+  label: { en: ["North Shore Map Sheets"] },
+  summary: {
+    en: [
+      "Two adjacent georeferenced plat maps — Evanston and Wilmette, Cook County, Illinois — that tile together onto one map. Manifest-level navPlace marks the shared region.",
+    ],
+  },
+  navPlace: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        id: "https://www.geonames.org/4890864/evanston.html",
+        properties: { label: { en: ["Evanston & Wilmette, North Shore"] } },
+        geometry: { type: "Point", coordinates: [-87.7204, 42.0628] },
+      },
+    ],
+  },
+  items: [
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif",
+      type: "Canvas",
+      height: 9833,
+      width: 7337,
+      label: { en: ["Map of the Township of Evanston"] },
+      items: [
+        {
+          id: "http://localhost:3000/north-shore/evanston/page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://localhost:3000/north-shore/evanston/annotation",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/jpeg",
+                height: 9833,
+                width: 7337,
+                service: [
+                  {
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                    type: "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      annotations: [
+        {
+          id: "http://localhost:3000/north-shore/evanston/georef-page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "urn:meadow:georeference:2fb1e81a",
+              type: "Annotation",
+              motivation: "georeferencing",
+              target: {
+                type: "SpecificResource",
+                source: {
+                  id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif",
+                  type: "Canvas",
+                  height: 9833,
+                  width: 7337,
+                },
+              },
+              body: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [577.7, 1074.97] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.71064, 42.06793],
+                    },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [3023.66, 1560.92] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.67961, 42.06283],
+                    },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [3499.96, 6785.6] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.6752, 42.01607],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif",
+      type: "Canvas",
+      height: 6595,
+      width: 18844,
+      label: { en: ["Map of the Village of Wilmette"] },
+      items: [
+        {
+          id: "http://localhost:3000/north-shore/wilmette/page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "http://localhost:3000/north-shore/wilmette/annotation",
+              type: "Annotation",
+              motivation: "painting",
+              target:
+                "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif",
+              body: {
+                id: "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b/full/600,/0/default.jpg",
+                type: "Image",
+                format: "image/jpeg",
+                height: 6595,
+                width: 18844,
+                service: [
+                  {
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b",
+                    type: "ImageService2",
+                    profile: "http://iiif.io/api/image/2/level2.json",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      annotations: [
+        {
+          id: "http://localhost:3000/north-shore/wilmette/georef-page",
+          type: "AnnotationPage",
+          items: [
+            {
+              id: "urn:meadow:georeference:f8fd564d",
+              type: "Annotation",
+              motivation: "georeferencing",
+              target: {
+                type: "SpecificResource",
+                source: {
+                  id: "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif",
+                  type: "Canvas",
+                  height: 6595,
+                  width: 18844,
+                },
+              },
+              body: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [11818.74, 3855.76] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.69964, 42.07017],
+                    },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [1815.28, 4233.17] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.77029, 42.06886],
+                    },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [11349.49, 1444.54] },
+                    geometry: {
+                      type: "Point",
+                      coordinates: [-87.70287, 42.08273],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+## Viewer (Map)
+
+<br />
+
+<CallToAction href="/docs/viewer" text="Docs" size="small" />
+
+The Viewer can replace the default image canvas with a geographic map whenever `navPlace` data is available. Click either marker below to see the popup — each one is a manifest in the collection, enriched with its label, summary, thumbnail, and a link back to the source.
+
+<div
+  style={{
+    position: "relative",
+    height: "480px",
+    marginTop: "1.5rem",
+    marginBottom: "1.5rem",
+  }}
+>
+  <CloverMap
+    iiifContent={collectionNavPlaceJson}
+    navPlaceLevel="Manifest"
+    fitToData
+  />
+</div>
+
+Enable the map in the Viewer with `options.map.enabled: true`, then use `options.map.navPlaceLevel` to control which level of the IIIF resource hierarchy supplies the features.
+
+| Option                      | Type                                                            | Default |
+| --------------------------- | --------------------------------------------------------------- | ------- |
+| `options.map.enabled`       | `boolean`                                                       | `false` |
+| `options.map.fitToData`     | `boolean`                                                       | `true`  |
+| `options.map.navPlaceLevel` | `auto \| Collection \| Manifest \| Canvas \| Annotation \| all` | `auto`  |
+
+---
+
+## Canvas
+
+`navPlaceLevel: "Canvas"` renders the navPlace features from the **currently active canvas**. Navigating between canvases updates the map, making this level ideal for search-result interfaces: each canvas is a result, and the map always shows where the selected item is located.
+
+The example below uses the [IIIF Cookbook recipe 0240 – navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/). The manifest has two canvases, each with its own `navPlace` point. Click the thumbnails to switch canvases and watch the map update.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    <Viewer
+      iiifContent="https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/manifest.json"
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          navPlaceLevel: "Canvas",
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent="https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/manifest.json"
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            navPlaceLevel: "Canvas",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Manifest
+
+`navPlaceLevel: "Manifest"` renders the navPlace features declared on the **active manifest**. This is the right choice for a detail page that displays a single item and wants to show its geographic context. The map does not change when navigating between canvases.
+
+Map popups are enriched from the manifest's `label`, `summary`, `thumbnail`, and `homepage` when present.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    // Manifest with navPlace injected at the Manifest level
+    const manifest = {
+      ...northwesternManifest,
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "https://www.geonames.org/7315798/pend-oreille-river.html",
+            properties: { label: { none: ["Pend Oreille River"] } },
+            geometry: { type: "Point", coordinates: [-117.61775, 49.00381] },
+          },
+        ],
+      },
+    };
+
+    <Viewer
+      iiifContent={manifest}
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          navPlaceLevel: "Manifest",
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={pendOreilleNavPlaceManifestJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            navPlaceLevel: "Manifest",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Collection
+
+`navPlaceLevel: "Manifest"` on a **Collection** iiifContent shows the active manifest's location and updates as the user navigates between manifests in the collection browser. This pattern is useful for collection-level browse interfaces where each item in the collection has its own geographic context.
+
+The example below loads a two-manifest collection. Select a manifest from the thumbnail browser — the map will update to that manifest's navPlace.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx // Collection where each embedded Manifest carries Manifest-level
+    navPlace
+    <Viewer
+      iiifContent={collectionNavPlaceJson}
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          navPlaceLevel: "Manifest",
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={collectionNavPlaceJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            navPlaceLevel: "Manifest",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## All Levels
+
+`navPlaceLevel: "all"` renders **every** navPlace feature found across the entire resource hierarchy — Collection, Manifest, Canvas, and Annotation — at once. Use this to give a complete geographic overview of an item and all of its parts.
+
+The example below uses a manifest with navPlace at both the Manifest level (a bounding polygon for the Pend Oreille region) and on the first Canvas (a specific point on the river). Both features are shown together on the map.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    // Manifest with navPlace at the Manifest level (polygon) AND Canvas level (point)
+    const manifest = {
+      // ...
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { label: { none: ["Pend Oreille River region"] } },
+            geometry: {
+              type: "Polygon",
+              coordinates: [[
+                [-118.5, 47.5], [-116.5, 47.5],
+                [-116.5, 49.5], [-118.5, 49.5], [-118.5, 47.5],
+              ]],
+            },
+          },
+        ],
+      },
+      items: [
+        {
+          // ...
+          navPlace: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: { label: { none: ["Pend Oreille River"] } },
+                geometry: { type: "Point", coordinates: [-117.61775, 49.00381] },
+              },
+            ],
+          },
+        },
+        // canvas 2 has no navPlace
+      ],
+    };
+
+    <Viewer
+      iiifContent={manifest}
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          navPlaceLevel: "all",
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={multiLevelNavPlaceManifestJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            navPlaceLevel: "all",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Auto (default)
+
+`navPlaceLevel: "auto"` — the default — selects the **most specific level available** for the active canvas in order: Annotation → Canvas → Manifest → Collection. If the current canvas has its own navPlace, that is shown. If not, the viewer falls back to the manifest, and so on.
+
+The example below uses the same two-canvas manifest. The first canvas has Canvas-level navPlace (the specific river point), while the second canvas has none. Navigate to the second canvas and the map automatically falls back to the manifest-level polygon.
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx
+    <Viewer
+      iiifContent={manifest}
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          // navPlaceLevel: "auto" is the default — can be omitted
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={multiLevelNavPlaceManifestJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+---
+
+## Image Overlays (Georeference)
+
+When a manifest's canvases carry [Georeference Extension](https://iiif.io/api/extension/georef/) annotations, the Viewer can warp the source images onto the map as overlays via [@allmaps/leaflet](https://allmaps.org/) — and render **multiple sheets together**, alongside any `navPlace` geometry.
+
+Set `options.map.showImageOverlay: true`. Clover then:
+
+- **auto-discovers** `motivation: "georeferencing"` annotations on the in-scope canvases,
+- **auto-adapts** each Canvas-sourced annotation to that canvas's painting image service (no manual image-service URL needed), and
+- hosts every warped sheet in a single map layer.
+
+`options.map.overlayScope` controls which canvases contribute: `"manifest"` (default) warps **every** georeferenced canvas in the manifest at once; `"canvas"` follows only the active/visible canvas.
+
+The example below combines two adjacent Northwestern University Libraries plat maps — the [Township of Evanston](https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d) and the Village of Wilmette — which tile together on the North Shore. The manifest-level `navPlace` point is rendered at the same time.
+
+| Option                            | Type                 | Default    |
+| --------------------------------- | -------------------- | ---------- |
+| `options.map.showImageOverlay`    | `boolean`            | `false`    |
+| `options.map.imageOverlayOpacity` | `number` (0–1)       | `0.65`     |
+| `options.map.showControlPoints`   | `boolean`            | `true`     |
+| `options.map.overlayScope`        | `manifest \| canvas` | `manifest` |
+
+<Tabs items={["Code", "Preview"]}>
+  <Tab>
+    ```jsx // A manifest whose canvases each carry a georeferencing annotation
+    // (target.source is a Canvas). Clover adapts them to each canvas's //
+    painting image service automatically.
+    <Viewer
+      iiifContent={northShoreManifest}
+      options={{
+        canvasHeight: "500px",
+        showIIIFBadge: false,
+        informationPanel: { open: false, renderToggle: false },
+        map: {
+          enabled: true,
+          showImageOverlay: true,
+          imageOverlayOpacity: 0.7,
+          overlayScope: "manifest", // warp every georeferenced sheet at once
+          navPlaceLevel: "Manifest", // also show the region point
+          fitToData: true,
+        },
+      }}
+    />
+    ```
+  </Tab>
+  <Tab>
+    <div style={{ position: "relative", height: "580px", zIndex: "0" }}>
+      <Viewer
+        iiifContent={overlayManifestJson}
+        options={{
+          canvasHeight: "500px",
+          showIIIFBadge: false,
+          informationPanel: { open: false, renderToggle: false },
+          map: {
+            enabled: true,
+            showImageOverlay: true,
+            imageOverlayOpacity: 0.7,
+            overlayScope: "manifest",
+            navPlaceLevel: "Manifest",
+            fitToData: true,
+          },
+        }}
+      />
+    </div>
+  </Tab>
+</Tabs>
+
+<Callout type="info">
+  `@allmaps/leaflet` is an optional dependency, loaded only when
+  `showImageOverlay` is `true`. The georeference annotation's `target.source`
+  must resolve to an IIIF Image API endpoint for warping; Clover handles this by
+  reading the canvas's painting image service, so stored Canvas-sourced
+  annotations work without manual adaptation. Set `showControlPoints: false` to
+  hide the ground control point markers.
+</Callout>

--- a/pages/docs/viewer/map.mdx
+++ b/pages/docs/viewer/map.mdx
@@ -90,10 +90,9 @@ export const pendOreilleNavPlaceManifestJson = {
                 width: 3072,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
-                    "@type": "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },
@@ -151,7 +150,7 @@ export const multiLevelNavPlaceManifestJson = {
       type: "Canvas",
       height: 2326,
       width: 3072,
-      label: { none: ["Crossing the Pend d'Oreille – Kalispel"] },
+      label: { none: ["Crossing the Pend d'Oreille - Kalispel"] },
       navPlace: {
         type: "FeatureCollection",
         features: [
@@ -194,10 +193,9 @@ export const multiLevelNavPlaceManifestJson = {
                 width: 3072,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
-                    "@type": "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },
@@ -231,10 +229,9 @@ export const multiLevelNavPlaceManifestJson = {
                 width: 7337,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
-                    "@type": "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },
@@ -255,7 +252,7 @@ export const collectionNavPlaceJson = {
     {
       id: "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1",
       type: "Manifest",
-      label: { none: ["Crossing the Pend d'Oreille – Kalispel"] },
+      label: { none: ["Crossing the Pend d'Oreille - Kalispel"] },
       summary: {
         none: [
           "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record.",
@@ -330,10 +327,9 @@ export const collectionNavPlaceJson = {
                     width: 3072,
                     service: [
                       {
-                        "@id":
-                          "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
-                        "@type": "ImageService2",
-                        profile: "http://iiif.io/api/image/2/level2.json",
+                        id: "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                        type: "ImageService3",
+                        profile: "http://iiif.io/api/image/3/level2.json",
                       },
                     ],
                   },
@@ -422,10 +418,9 @@ export const collectionNavPlaceJson = {
                     width: 7337,
                     service: [
                       {
-                        "@id":
-                          "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
-                        "@type": "ImageService2",
-                        profile: "http://iiif.io/api/image/2/level2.json",
+                        id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                        type: "ImageService3",
+                        profile: "http://iiif.io/api/image/3/level2.json",
                       },
                     ],
                   },
@@ -446,7 +441,7 @@ export const overlayManifestJson = {
   label: { en: ["North Shore Map Sheets"] },
   summary: {
     en: [
-      "Two adjacent georeferenced plat maps — Evanston and Wilmette, Cook County, Illinois — that tile together onto one map. Manifest-level navPlace marks the shared region.",
+      "Two adjacent georeferenced plat maps: Evanston and Wilmette, Cook County, Illinois. They tile together onto one map. Manifest-level navPlace marks the shared region.",
     ],
   },
   navPlace: {
@@ -479,16 +474,16 @@ export const overlayManifestJson = {
               target:
                 "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif",
               body: {
-                id: "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
                 type: "Image",
                 format: "image/jpeg",
                 height: 9833,
                 width: 7337,
                 service: [
                   {
-                    id: "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
-                    type: "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },
@@ -566,16 +561,16 @@ export const overlayManifestJson = {
               target:
                 "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif",
               body: {
-                id: "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b/full/600,/0/default.jpg",
+                id: "https://iiif.dc.library.northwestern.edu/iiif/3/f8fd564d-2d0d-4c58-badb-e575bdaaac5b/full/600,/0/default.jpg",
                 type: "Image",
                 format: "image/jpeg",
                 height: 6595,
                 width: 18844,
                 service: [
                   {
-                    id: "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b",
-                    type: "ImageService2",
-                    profile: "http://iiif.io/api/image/2/level2.json",
+                    id: "https://iiif.dc.library.northwestern.edu/iiif/3/f8fd564d-2d0d-4c58-badb-e575bdaaac5b",
+                    type: "ImageService3",
+                    profile: "http://iiif.io/api/image/3/level2.json",
                   },
                 ],
               },
@@ -644,7 +639,7 @@ export const overlayManifestJson = {
 
 <CallToAction href="/docs/viewer" text="Docs" size="small" />
 
-The Viewer can replace the default image canvas with a geographic map whenever `navPlace` data is available. Click either marker below to see the popup — each one is a manifest in the collection, enriched with its label, summary, thumbnail, and a link back to the source.
+The Viewer can replace the default image canvas with a geographic map whenever `navPlace` data is available. Click either marker below to see the popup. Each one is a manifest in the collection, enriched with its label, summary, thumbnail, and a link back to the source.
 
 <div
   style={{
@@ -675,7 +670,7 @@ Enable the map in the Viewer with `options.map.enabled: true`, then use `options
 
 `navPlaceLevel: "Canvas"` renders the navPlace features from the **currently active canvas**. Navigating between canvases updates the map, making this level ideal for search-result interfaces: each canvas is a result, and the map always shows where the selected item is located.
 
-The example below uses the [IIIF Cookbook recipe 0240 – navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/). The manifest has two canvases, each with its own `navPlace` point. Click the thumbnails to switch canvases and watch the map update.
+The example below uses [IIIF Cookbook recipe 0240: navPlace on Canvases](https://iiif.io/api/cookbook/recipe/0240-navPlace-on-canvases/). The manifest has two canvases, each with its own `navPlace` point. Click the thumbnails to switch canvases and watch the map update.
 
 <Tabs items={["Code", "Preview"]}>
   <Tab>
@@ -782,7 +777,7 @@ Map popups are enriched from the manifest's `label`, `summary`, `thumbnail`, and
 
 `navPlaceLevel: "Manifest"` on a **Collection** iiifContent shows the active manifest's location and updates as the user navigates between manifests in the collection browser. This pattern is useful for collection-level browse interfaces where each item in the collection has its own geographic context.
 
-The example below loads a two-manifest collection. Select a manifest from the thumbnail browser — the map will update to that manifest's navPlace.
+The example below loads a two-manifest collection. Select a manifest from the thumbnail browser, and the map will update to that manifest's navPlace.
 
 <Tabs items={["Code", "Preview"]}>
   <Tab>
@@ -826,7 +821,7 @@ The example below loads a two-manifest collection. Select a manifest from the th
 
 ## All Levels
 
-`navPlaceLevel: "all"` renders **every** navPlace feature found across the entire resource hierarchy — Collection, Manifest, Canvas, and Annotation — at once. Use this to give a complete geographic overview of an item and all of its parts.
+`navPlaceLevel: "all"` renders **every** navPlace feature found across the entire resource hierarchy: Collection, Manifest, Canvas, and Annotation. Use this to give a complete geographic overview of an item and all of its parts.
 
 The example below uses a manifest with navPlace at both the Manifest level (a bounding polygon for the Pend Oreille region) and on the first Canvas (a specific point on the river). Both features are shown together on the map.
 
@@ -909,7 +904,7 @@ The example below uses a manifest with navPlace at both the Manifest level (a bo
 
 ## Auto (default)
 
-`navPlaceLevel: "auto"` — the default — selects the **most specific level available** for the active canvas in order: Annotation → Canvas → Manifest → Collection. If the current canvas has its own navPlace, that is shown. If not, the viewer falls back to the manifest, and so on.
+`navPlaceLevel: "auto"`, the default, selects the **most specific level available** for the active canvas in order: Annotation → Canvas → Manifest → Collection. If the current canvas has its own navPlace, that is shown. If not, the viewer falls back to the manifest, and so on.
 
 The example below uses the same two-canvas manifest. The first canvas has Canvas-level navPlace (the specific river point), while the second canvas has none. Navigate to the second canvas and the map automatically falls back to the manifest-level polygon.
 
@@ -924,7 +919,7 @@ The example below uses the same two-canvas manifest. The first canvas has Canvas
         informationPanel: { open: false, renderToggle: false },
         map: {
           enabled: true,
-          // navPlaceLevel: "auto" is the default — can be omitted
+          // navPlaceLevel: "auto" is the default; it can be omitted
           fitToData: true,
         },
       }}
@@ -953,7 +948,7 @@ The example below uses the same two-canvas manifest. The first canvas has Canvas
 
 ## Image Overlays (Georeference)
 
-When a manifest's canvases carry [Georeference Extension](https://iiif.io/api/extension/georef/) annotations, the Viewer can warp the source images onto the map as overlays via [@allmaps/leaflet](https://allmaps.org/) — and render **multiple sheets together**, alongside any `navPlace` geometry.
+When a manifest's canvases carry [Georeference Extension](https://iiif.io/api/extension/georef/) annotations, the Viewer can warp the source images onto the map as overlays via [@allmaps/leaflet](https://allmaps.org/). It can render **multiple sheets together**, alongside any `navPlace` geometry.
 
 Set `options.map.showImageOverlay: true`. Clover then:
 
@@ -963,12 +958,12 @@ Set `options.map.showImageOverlay: true`. Clover then:
 
 `options.map.overlayScope` controls which canvases contribute: `"manifest"` (default) warps **every** georeferenced canvas in the manifest at once; `"canvas"` follows only the active/visible canvas.
 
-The example below combines two adjacent Northwestern University Libraries plat maps — the [Township of Evanston](https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d) and the Village of Wilmette — which tile together on the North Shore. The manifest-level `navPlace` point is rendered at the same time.
+The example below combines two adjacent Northwestern University Libraries plat maps, the [Township of Evanston](https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d) and the Village of Wilmette, which tile together on the North Shore. The manifest-level `navPlace` point is rendered at the same time.
 
 | Option                            | Type                 | Default    |
 | --------------------------------- | -------------------- | ---------- |
 | `options.map.showImageOverlay`    | `boolean`            | `false`    |
-| `options.map.imageOverlayOpacity` | `number` (0–1)       | `0.65`     |
+| `options.map.imageOverlayOpacity` | `number` (0-1)       | `0.65`     |
 | `options.map.showControlPoints`   | `boolean`            | `true`     |
 | `options.map.overlayScope`        | `manifest \| canvas` | `manifest` |
 

--- a/public/manifest/nav-place/collection-manifest-level.json
+++ b/public/manifest/nav-place/collection-manifest-level.json
@@ -1,0 +1,195 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json",
+  "type": "Collection",
+  "label": { "en": ["navPlace Demo Collection"] },
+  "summary": {
+    "en": [
+      "A small demo collection showing two manifests with Manifest-level navPlace from different geographic locations."
+    ]
+  },
+  "items": [
+    {
+      "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1",
+      "type": "Manifest",
+      "label": { "none": ["Crossing the Pend d'Oreille – Kalispel"] },
+      "summary": {
+        "none": [
+          "Photogravure from Edward S. Curtis's The North American Indian, Volume 7, mapped to the Pend Oreille River GeoNames record."
+        ]
+      },
+      "navPlace": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "id": "https://www.geonames.org/7315798/pend-oreille-river.html",
+            "properties": {
+              "label": { "none": ["Pend Oreille River, Idaho/Washington"] }
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [-117.61775, 49.00381]
+            }
+          }
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/8a833741-74a8-40dc-bd1d-c416a3b1bb38",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "none": ["Homepage at Northwestern University Libraries Digital Collections"]
+          }
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://api.dc.library.northwestern.edu/api/v2/works/8a833741-74a8-40dc-bd1d-c416a3b1bb38/thumbnail",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1",
+          "type": "Canvas",
+          "height": 2326,
+          "width": 3072,
+          "label": { "none": ["vol_ct07047u.tif"] },
+          "thumbnail": [
+            {
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/!300,300/0/default.jpg",
+              "type": "Image",
+              "format": "image/jpeg",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1/page/1",
+              "type": "AnnotationPage",
+              "items": [
+                {
+                  "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1/page/1/annotation/1",
+                  "type": "Annotation",
+                  "motivation": "painting",
+                  "target": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/1/canvas/1",
+                  "body": {
+                    "id": "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df/full/600,/0/default.jpg",
+                    "type": "Image",
+                    "format": "image/jpeg",
+                    "height": 2326,
+                    "width": 3072,
+                    "service": [
+                      {
+                        "@id": "https://iiif.dc.library.northwestern.edu/iiif/3/440bcf10-a7ee-4824-a1fb-e505cad222df",
+                        "@type": "ImageService2",
+                        "profile": "http://iiif.io/api/image/2/level2.json"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2",
+      "type": "Manifest",
+      "label": { "en": ["Map of the Township of Evanston, Cook County, Illinois"] },
+      "summary": {
+        "en": [
+          "An 1874 cadastral plat map of Evanston, Illinois from Northwestern University Libraries Digital Collections."
+        ]
+      },
+      "navPlace": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "id": "https://www.geonames.org/4890864/evanston.html",
+            "properties": {
+              "label": { "en": ["Evanston, Cook County, Illinois"] }
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [-87.68838, 42.04502]
+            }
+          }
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/c9869cb2-e735-4010-a493-84a66fcd065d",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "en": ["Homepage at Northwestern University Libraries Digital Collections"]
+          }
+        }
+      ],
+      "thumbnail": [
+        {
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/!300,300/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "height": 300,
+          "width": 300
+        }
+      ],
+      "items": [
+        {
+          "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1",
+          "type": "Canvas",
+          "height": 9833,
+          "width": 7337,
+          "label": { "en": ["Evanston map recto"] },
+          "thumbnail": [
+            {
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/!300,300/0/default.jpg",
+              "type": "Image",
+              "format": "image/jpeg",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "items": [
+            {
+              "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1/page/1",
+              "type": "AnnotationPage",
+              "items": [
+                {
+                  "id": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1/page/1/annotation/1",
+                  "type": "Annotation",
+                  "motivation": "painting",
+                  "target": "http://localhost:3000/manifest/nav-place/collection-manifest-level.json/manifest/2/canvas/1",
+                  "body": {
+                    "id": "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf/full/600,/0/default.jpg",
+                    "type": "Image",
+                    "format": "image/jpeg",
+                    "height": 9833,
+                    "width": 7337,
+                    "service": [
+                      {
+                        "@id": "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf",
+                        "@type": "ImageService2",
+                        "profile": "http://iiif.io/api/image/2/level2.json"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/Map/Map.styled.tsx
+++ b/src/components/Map/Map.styled.tsx
@@ -1,0 +1,140 @@
+import { styled } from "src/styles/stitches.config";
+
+const Wrapper = styled("div", {
+  position: "relative",
+  width: "100%",
+  height: "100%",
+  minHeight: "20rem",
+  overflow: "hidden",
+  isolation: "isolate",
+  zIndex: "0",
+
+  ".leaflet-container": {
+    fontFamily: "inherit",
+  },
+
+  ".leaflet-container a": {
+    color: "$accentAlt",
+  },
+
+  ".leaflet-control-container": {
+    fontFamily: "inherit",
+  },
+
+  // Crosshair cursor override (applied via className)
+  "&.clover-map-crosshair .leaflet-pane, &.clover-map-crosshair .leaflet-pane *":
+    {
+      cursor: "crosshair !important",
+    },
+
+  // Dragging cursor override
+  "&.clover-map-dragging .leaflet-pane, &.clover-map-dragging .leaflet-pane *":
+    {
+      cursor: "grabbing !important",
+    },
+
+  ".leaflet-interactive": {
+    transition: "stroke-width 120ms ease, fill-opacity 120ms ease",
+  },
+
+  ".leaflet-interactive:hover": {
+    strokeWidth: "3",
+    fillOpacity: "0.95",
+  },
+
+  ".clover-map-leaflet-popup": {
+    marginBottom: "0.75rem",
+  },
+
+  ".clover-map-leaflet-popup .leaflet-popup-content-wrapper": {
+    overflow: "hidden",
+    padding: "0",
+    borderRadius: "0.25rem",
+    border: "1px solid #0002",
+    boxShadow: "0 14px 36px #0004",
+  },
+
+  ".clover-map-leaflet-popup .leaflet-popup-content": {
+    width: "auto !important",
+    margin: "0",
+    color: "$primary",
+    fontFamily: "inherit",
+  },
+
+  ".clover-map-leaflet-popup .leaflet-popup-tip": {
+    boxShadow: "0 6px 18px #0003",
+  },
+
+  ".clover-map-leaflet-popup .leaflet-popup-close-button": {
+    display: "none",
+  },
+
+  ".clover-map-popup": {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: "15rem",
+    maxWidth: "20rem",
+    backgroundColor: "$secondary",
+  },
+
+  ".clover-map-popup-media": {
+    width: "100%",
+    maxHeight: "10.5rem",
+    overflow: "hidden",
+    backgroundColor: "#6663",
+
+    img: {
+      display: "block",
+      width: "100%",
+      height: "100%",
+      maxHeight: "10rem",
+      objectFit: "cover",
+      objectPosition: "50% 50%",
+    },
+  },
+
+  ".clover-map-popup-body": {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.382rem",
+    padding: "0.875rem 1rem 1rem",
+  },
+
+  ".clover-map-popup-context": {
+    color: "$secondaryAlt",
+    fontSize: "0.72rem",
+    fontWeight: "500",
+    letterSpacing: "0.04em",
+    lineHeight: "1rem",
+    textTransform: "uppercase",
+  },
+
+  ".clover-map-popup-title": {
+    color: "$primary",
+    display: "block",
+    fontSize: "1.0625rem",
+    fontWeight: "500",
+    lineHeight: "1.3",
+    textDecoration: "none",
+  },
+
+  "a.clover-map-popup-title:hover, a.clover-map-popup-title:focus-visible": {
+    color: "$accentAlt",
+    textDecoration: "underline",
+    textUnderlineOffset: "0.18em",
+  },
+
+  ".clover-map-popup-location": {
+    color: "$accentAlt",
+    fontSize: "0.875rem",
+    lineHeight: "1.25rem",
+  },
+
+  ".clover-map-popup-summary": {
+    color: "$secondaryAlt",
+    fontSize: "0.875rem",
+    lineHeight: "1.4",
+  },
+});
+
+export { Wrapper };

--- a/src/components/Map/index.test.tsx
+++ b/src/components/Map/index.test.tsx
@@ -1,0 +1,249 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import CloverMap from "src/components/Map";
+import React from "react";
+import {
+  DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY,
+  EXAMPLE_NAV_PLACE,
+  EXAMPLE_NAV_PLACE_FEATURE,
+  EXAMPLE_NAV_PLACE_POLYGON,
+  GEOREF_ANNOTATION_CANVAS,
+  GEOREF_ANNOTATION_IMAGE_SERVICE,
+} from "src/fixtures/georef";
+
+// ── Leaflet mock ──────────────────────────────────────────────────────────────
+// Leaflet manipulates the DOM directly and can't run in jsdom without mocking.
+
+vi.mock("leaflet", async () => {
+  const circleMarker = vi.fn(() => ({
+    bindPopup: vi.fn().mockReturnThis(),
+    bindTooltip: vi.fn().mockReturnThis(),
+    addTo: vi.fn().mockReturnThis(),
+  }));
+
+  const geoJSON = vi.fn(() => ({
+    addTo: vi.fn().mockReturnThis(),
+    getBounds: vi.fn(() => ({
+      isValid: vi.fn().mockReturnValue(true),
+      extend: vi.fn(),
+    })),
+    remove: vi.fn(),
+  }));
+
+  const layerGroup = vi.fn(() => ({
+    addTo: vi.fn().mockReturnThis(),
+    clearLayers: vi.fn(),
+  }));
+
+  const latLngBounds = vi.fn(() => ({
+    extend: vi.fn(),
+    isValid: vi.fn().mockReturnValue(false),
+    getNorthEast: vi.fn(() => ({ equals: vi.fn().mockReturnValue(false) })),
+    getSouthWest: vi.fn(() => ({ equals: vi.fn().mockReturnValue(false) })),
+    getCenter: vi.fn(() => ({ lat: 0, lng: 0 })),
+  }));
+
+  const map = vi.fn(() => ({
+    getContainer: vi.fn(() => ({
+      classList: { toggle: vi.fn(), add: vi.fn(), remove: vi.fn() },
+    })),
+    setView: vi.fn(),
+    fitBounds: vi.fn(),
+    on: vi.fn(),
+    remove: vi.fn(),
+    invalidateSize: vi.fn(),
+  }));
+
+  const tileLayer = vi.fn(() => ({ addTo: vi.fn().mockReturnThis() }));
+
+  const api = {
+    map,
+    tileLayer,
+    layerGroup,
+    circleMarker,
+    geoJSON,
+    latLngBounds,
+  };
+
+  // Expose both as named exports and as `default` so `await import("leaflet")`
+  // works whether the component reads `L.map` or `L.default.map`.
+  return { ...api, default: api };
+});
+
+const { WarpedMapLayer, addGeoreferenceAnnotation } = vi.hoisted(() => {
+  const addGeoreferenceAnnotation = vi.fn().mockResolvedValue([]);
+  const WarpedMapLayer = vi.fn(() => ({
+    addTo: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
+    addGeoreferenceAnnotation,
+  }));
+  return { WarpedMapLayer, addGeoreferenceAnnotation };
+});
+
+vi.mock("@allmaps/leaflet", () => ({ WarpedMapLayer }));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("CloverMap", () => {
+  it("renders the map container with the correct test id", () => {
+    render(<CloverMap />);
+    expect(screen.getByTestId("clover-map")).toBeInTheDocument();
+  });
+
+  it("renders with default props without throwing", () => {
+    expect(() => render(<CloverMap />)).not.toThrow();
+  });
+
+  it("accepts a georeference annotation with a Canvas source", () => {
+    expect(() =>
+      render(<CloverMap georefAnnotation={GEOREF_ANNOTATION_CANVAS} />),
+    ).not.toThrow();
+  });
+
+  it("accepts the adapted ImageService annotation (for overlay)", () => {
+    expect(() =>
+      render(
+        <CloverMap
+          georefAnnotation={GEOREF_ANNOTATION_IMAGE_SERVICE}
+          showImageOverlay
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts a navPlace FeatureCollection", () => {
+    expect(() =>
+      render(<CloverMap navPlace={EXAMPLE_NAV_PLACE} />),
+    ).not.toThrow();
+  });
+
+  it("accepts a navPlace single Feature", () => {
+    expect(() =>
+      render(<CloverMap navPlace={EXAMPLE_NAV_PLACE_FEATURE} />),
+    ).not.toThrow();
+  });
+
+  it("accepts a navPlace Polygon FeatureCollection", () => {
+    expect(() =>
+      render(<CloverMap navPlace={EXAMPLE_NAV_PLACE_POLYGON} />),
+    ).not.toThrow();
+  });
+
+  it("accepts fitToData with combined navPlace + georefAnnotation", () => {
+    expect(() =>
+      render(
+        <CloverMap
+          navPlace={EXAMPLE_NAV_PLACE}
+          georefAnnotation={GEOREF_ANNOTATION_CANVAS}
+          fitToData
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts all new props together without throwing", () => {
+    expect(() =>
+      render(
+        <CloverMap
+          navPlace={EXAMPLE_NAV_PLACE}
+          georefAnnotation={GEOREF_ANNOTATION_IMAGE_SERVICE}
+          showControlPoints
+          showImageOverlay
+          imageOverlayOpacity={0.5}
+          fitToData
+          useCrosshairCursor
+          onMapClick={vi.fn()}
+          center={{ latitude: 42.045, longitude: -87.688, zoom: 12 }}
+          markers={[{ latitude: 42.045, longitude: -87.688, label: "Example" }]}
+          tileLayer={{
+            url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            attribution: "&copy; OpenStreetMap contributors",
+          }}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("renders without crashing when georefAnnotation has 0 GCPs (no overlay)", () => {
+    const emptyAnnotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: { type: "FeatureCollection" as const, features: [] },
+    };
+    expect(() =>
+      render(<CloverMap georefAnnotation={emptyAnnotation} showImageOverlay />),
+    ).not.toThrow();
+  });
+
+  it("renders without crashing when georefAnnotation has < 3 GCPs (no overlay)", () => {
+    const twoGcpAnnotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: {
+        type: "FeatureCollection" as const,
+        features: GEOREF_ANNOTATION_CANVAS.body.features.slice(0, 2),
+      },
+    };
+    expect(() =>
+      render(
+        <CloverMap georefAnnotation={twoGcpAnnotation} showImageOverlay />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts multiple georef annotations via georefAnnotations", () => {
+    expect(() =>
+      render(
+        <CloverMap
+          georefAnnotations={[
+            GEOREF_ANNOTATION_IMAGE_SERVICE,
+            DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY,
+          ]}
+          fitToData
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("hosts multiple overlays in one warped layer (seed + add the rest)", async () => {
+    const { unmount } = render(
+      <CloverMap
+        georefAnnotations={[
+          GEOREF_ANNOTATION_IMAGE_SERVICE,
+          DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY,
+        ]}
+        showImageOverlay
+        showControlPoints={false}
+      />,
+    );
+
+    // One WarpedMapLayer is constructed (seeded with the first annotation)…
+    await vi.waitFor(() => expect(WarpedMapLayer).toHaveBeenCalledTimes(1));
+    // …and the remaining annotation(s) are added to that same layer.
+    await vi.waitFor(() =>
+      expect(addGeoreferenceAnnotation).toHaveBeenCalledTimes(1),
+    );
+    expect(addGeoreferenceAnnotation).toHaveBeenCalledWith(
+      DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY,
+    );
+
+    unmount();
+  });
+
+  it("combines the single georefAnnotation prop with georefAnnotations", () => {
+    expect(() =>
+      render(
+        <CloverMap
+          georefAnnotation={GEOREF_ANNOTATION_IMAGE_SERVICE}
+          georefAnnotations={[DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY]}
+          showImageOverlay
+          fitToData
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,0 +1,757 @@
+/**
+ * CloverMap — a Leaflet-based map component for IIIF resources.
+ *
+ * Supports:
+ *   - navPlace GeoJSON (https://iiif.io/api/extension/navplace/)
+ *   - Georeference Extension annotations + optional warped image overlay
+ *     (https://iiif.io/api/extension/georef/)
+ *   - Arbitrary GeoJSON via the `geoJson` escape-hatch prop
+ */
+
+import "leaflet/dist/leaflet.css";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+import { ErrorBoundary } from "react-error-boundary";
+import ErrorFallback from "src/components/UI/ErrorFallback/ErrorFallback";
+import { Wrapper } from "src/components/Map/Map.styled";
+import {
+  GeoreferenceAnnotation,
+  GroundControlPoint,
+  NavPlaceDisplayLevel,
+  NavPlaceGeoJSON,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getNavPlaceLabel,
+  normalizeNavPlace,
+  parseGeoreferenceAnnotation,
+} from "src/lib/georef-helpers";
+
+// ── Public types (re-exported from index) ─────────────────────────────────────
+
+export type {
+  GeoreferenceAnnotation,
+  GroundControlPoint,
+  NavPlaceDisplayLevel,
+  NavPlaceGeoJSON,
+};
+
+export interface MapMarker {
+  latitude: number;
+  longitude: number;
+  label?: string;
+  color?: string;
+}
+
+export interface MapCenter {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+}
+
+export interface MapTileLayer {
+  url: string;
+  attribution: string;
+}
+
+export interface CloverMapProps {
+  /** Map center and default zoom level. Defaults to a world view. */
+  center?: MapCenter;
+  /** Auto-fit the viewport to display all data (navPlace, GCPs, geoJson markers). */
+  fitToData?: boolean;
+
+  /**
+   * IIIF navPlace GeoJSON to render as geographic feature overlays.
+   * Accepts a FeatureCollection, Feature, or bare geometry object.
+   * Feature `properties.label` may be a plain string or an IIIF InternationalString.
+   * https://iiif.io/api/extension/navplace/
+   */
+  navPlace?: NavPlaceGeoJSON | null;
+
+  /**
+   * IIIF Presentation resource used to derive navPlace features with resource
+   * context for map popups. Accepts a URL or a prefetched IIIF object.
+   */
+  iiifContent?: string | object | null;
+
+  /**
+   * Resource level to extract when `iiifContent` is set. `all` extracts every
+   * navPlace value found while traversing the IIIF resource.
+   * @default "all"
+   */
+  navPlaceLevel?: Exclude<NavPlaceDisplayLevel, "auto">;
+
+  /**
+   * A IIIF Georeference Extension annotation.
+   * https://iiif.io/api/extension/georef/
+   *
+   * When provided the component will:
+   *   1. Parse the annotation's GCPs and (if `showControlPoints` is true) render
+   *      them as numbered circle markers on the map.
+   *   2. Include GCP geo-coordinates in `fitToData` bounds.
+   *   3. If `showImageOverlay` is true and there are ≥ 3 GCPs, load
+   *      @allmaps/leaflet and display the warped IIIF image on the map.
+   *
+   * For the image overlay to work the annotation's `target.source` must reference
+   * an IIIF Image API endpoint (type "ImageService2" or "ImageService3") rather
+   * than a Canvas.  Pass the same "preview annotation" you would build for
+   * the Allmaps viewer.
+   */
+  georefAnnotation?: GeoreferenceAnnotation | null;
+
+  /**
+   * Multiple IIIF Georeference Extension annotations to render together.
+   * Each is parsed for GCPs and (when `showImageOverlay` is true and it has
+   * ≥ 3 GCPs) added to a single warped-image overlay layer, so several
+   * georeferenced sheets can tile onto one map at once. Combined with
+   * `georefAnnotation` when both are provided.
+   * https://iiif.io/api/extension/georef/
+   */
+  georefAnnotations?: GeoreferenceAnnotation[] | null;
+
+  /**
+   * Show the GCP markers extracted from the georeference annotation(s).
+   * Each marker is numbered and shows its index as a tooltip.
+   * @default true
+   */
+  showControlPoints?: boolean;
+
+  /**
+   * When true (and `georefAnnotation` is set with ≥ 3 GCPs), render the
+   * georeferenced IIIF image as a warped overlay using @allmaps/leaflet.
+   * @default false
+   */
+  showImageOverlay?: boolean;
+
+  /**
+   * Opacity of the warped image overlay (0 – 1).
+   * @default 0.65
+   */
+  imageOverlayOpacity?: number;
+
+  /**
+   * Raw GeoJSON escape-hatch for data that doesn't fit the navPlace model.
+   * Accepts a FeatureCollection or Feature.
+   */
+  geoJson?: GeoJSON.FeatureCollection | GeoJSON.Feature | null;
+
+  /** Additional point markers to render (e.g. search results, custom pins). */
+  markers?: MapMarker[];
+
+  /** Called with [longitude, latitude] when the user clicks the map. */
+  onMapClick?: (coordinates: [number, number]) => void;
+
+  /** Display a crosshair cursor over the map (useful for coordinate picking). */
+  useCrosshairCursor?: boolean;
+
+  /** Tile layer. Defaults to OpenStreetMap. */
+  tileLayer?: MapTileLayer;
+}
+
+// ── Defaults ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_CENTER: MapCenter = { latitude: 20, longitude: 0, zoom: 2 };
+const DEFAULT_TILE_LAYER: MapTileLayer = {
+  url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+  attribution: "&copy; OpenStreetMap contributors",
+};
+
+/** Color used for navPlace features */
+const NAV_PLACE_COLOR = "#007fa3";
+/** Color used for GCP control point markers */
+const GCP_COLOR = "#c05c00";
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const getNavPlaceResource = (feature: GeoJSON.Feature) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (feature?.properties as any)?.iiifResource;
+};
+
+const getNavPlaceTitle = (feature: GeoJSON.Feature): string => {
+  const resource = getNavPlaceResource(feature);
+  return (
+    getNavPlaceLabel(resource?.label) ||
+    getNavPlaceLabel(feature?.properties?.label) ||
+    resource?.id ||
+    ""
+  );
+};
+
+const buildNavPlacePopup = (feature: GeoJSON.Feature): string => {
+  const resource = getNavPlaceResource(feature);
+  const title = getNavPlaceTitle(feature);
+  const featureLabel = getNavPlaceLabel(feature?.properties?.label);
+  const summary =
+    getNavPlaceLabel(feature?.properties?.summary) ||
+    getNavPlaceLabel(resource?.summary);
+  const parentLabel = getNavPlaceLabel(resource?.parent?.label);
+  const thumbnail = resource?.thumbnail;
+  const context = [resource?.type, parentLabel].filter(Boolean).join(" in ");
+  const href = resource?.homepage || resource?.id;
+
+  if (!title && !featureLabel && !summary && !thumbnail && !context) return "";
+
+  const escapedTitle = escapeHtml(title || featureLabel || "Location");
+  const escapedFeatureLabel =
+    featureLabel && featureLabel !== title ? escapeHtml(featureLabel) : "";
+  const escapedSummary = summary ? escapeHtml(summary) : "";
+  const escapedContext = context ? escapeHtml(context) : "";
+  const escapedThumbnail = thumbnail ? escapeHtml(thumbnail) : "";
+  const escapedHref = href ? escapeHtml(href) : "";
+
+  return `
+    <div class="clover-map-popup">
+      ${
+        escapedThumbnail
+          ? `<div class="clover-map-popup-media"><img src="${escapedThumbnail}" alt="" loading="lazy" /></div>`
+          : ""
+      }
+      <div class="clover-map-popup-body">
+        ${escapedContext ? `<div class="clover-map-popup-context">${escapedContext}</div>` : ""}
+        ${
+          escapedHref
+            ? `<a class="clover-map-popup-title" href="${escapedHref}" target="_blank" rel="noopener noreferrer">${escapedTitle}</a>`
+            : `<div class="clover-map-popup-title">${escapedTitle}</div>`
+        }
+        ${
+          escapedFeatureLabel
+            ? `<div class="clover-map-popup-location">${escapedFeatureLabel}</div>`
+            : ""
+        }
+        ${
+          escapedSummary
+            ? `<div class="clover-map-popup-summary">${escapedSummary}</div>`
+            : ""
+        }
+      </div>
+    </div>
+  `;
+};
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+const CloverMap: React.FC<CloverMapProps> = ({
+  center = DEFAULT_CENTER,
+  fitToData = false,
+  navPlace = null,
+  iiifContent = null,
+  navPlaceLevel = "all",
+  georefAnnotation = null,
+  georefAnnotations = null,
+  showControlPoints = true,
+  showImageOverlay = false,
+  imageOverlayOpacity = 0.65,
+  geoJson = null,
+  markers = [],
+  onMapClick,
+  useCrosshairCursor = false,
+  tileLayer = DEFAULT_TILE_LAYER,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<import("leaflet").Map | null>(null);
+  const navPlaceLayerRef = useRef<import("leaflet").GeoJSON | null>(null);
+  const geoJsonLayerRef = useRef<import("leaflet").GeoJSON | null>(null);
+  const markerLayerRef = useRef<import("leaflet").LayerGroup | null>(null);
+  const gcpLayerRef = useRef<import("leaflet").LayerGroup | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const warpedLayerRef = useRef<any>(null);
+  const onMapClickRef = useRef(onMapClick);
+  const [mapReady, setMapReady] = useState(false);
+  const [iiifNavPlace, setIiifNavPlace] =
+    useState<GeoJSON.FeatureCollection | null>(null);
+
+  // Combine the single + multiple georef annotation props into one list.
+  const allGeorefAnnotations = useMemo(
+    () =>
+      [
+        ...(georefAnnotation ? [georefAnnotation] : []),
+        ...(georefAnnotations ?? []),
+      ].filter(Boolean) as GeoreferenceAnnotation[],
+    [georefAnnotation, georefAnnotations],
+  );
+
+  // Each annotation's parsed GCPs, kept aligned with allGeorefAnnotations.
+  const gcpsByAnnotation = useMemo(
+    () =>
+      allGeorefAnnotations.map((annotation) =>
+        parseGeoreferenceAnnotation(annotation),
+      ),
+    [allGeorefAnnotations],
+  );
+
+  // Flat list of every GCP across all annotations (for rendering + fit bounds).
+  const gcps = useMemo(() => gcpsByAnnotation.flat(), [gcpsByAnnotation]);
+
+  const resolvedNavPlace = useMemo(() => {
+    const collections = [normalizeNavPlace(navPlace), iiifNavPlace].filter(
+      (collection): collection is GeoJSON.FeatureCollection =>
+        Boolean(collection?.features?.length),
+    );
+
+    if (!collections.length) return null;
+
+    return createNavPlaceFeatureCollection(
+      collections.flatMap((collection) => collection.features),
+    );
+  }, [navPlace, iiifNavPlace]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadIiifNavPlace() {
+      if (!iiifContent) {
+        setIiifNavPlace(null);
+        return;
+      }
+
+      try {
+        const resource =
+          typeof iiifContent === "string"
+            ? await fetch(iiifContent, {
+                headers: { Accept: "application/json, application/ld+json" },
+              }).then((response) => response.json())
+            : iiifContent;
+
+        if (!isMounted) return;
+
+        const levels =
+          navPlaceLevel === "all"
+            ? undefined
+            : [navPlaceLevel as Exclude<NavPlaceDisplayLevel, "auto" | "all">];
+        const features = extractNavPlaceFeatures(resource, { levels });
+        setIiifNavPlace(
+          features.length ? createNavPlaceFeatureCollection(features) : null,
+        );
+      } catch (error) {
+        if (!isMounted) return;
+        console.error(`IIIF navPlace failed to load: ${error}`);
+        setIiifNavPlace(null);
+      }
+    }
+
+    loadIiifNavPlace();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [iiifContent, navPlaceLevel]);
+
+  // Keep click handler current without re-initialising the map
+  useEffect(() => {
+    onMapClickRef.current = onMapClick;
+  }, [onMapClick]);
+
+  // Toggle crosshair cursor class
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    mapRef.current
+      .getContainer()
+      .classList.toggle("clover-map-crosshair", useCrosshairCursor);
+  }, [mapReady, useCrosshairCursor]);
+
+  // ── Map size invalidation helpers ─────────────────────────────────────────
+
+  const refreshMap = () => mapRef.current?.invalidateSize();
+
+  const queueMapRefresh = () => {
+    window.requestAnimationFrame(() => {
+      refreshMap();
+      window.requestAnimationFrame(refreshMap);
+    });
+    window.setTimeout(refreshMap, 0);
+    window.setTimeout(refreshMap, 100);
+  };
+
+  // ── Initialise Leaflet (runs once on mount) ───────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function initializeMap() {
+      if (!containerRef.current || mapRef.current) return;
+
+      const L = await import("leaflet");
+      if (!isMounted || !containerRef.current) return;
+
+      mapRef.current = L.map(containerRef.current, {
+        center: [center.latitude, center.longitude],
+        zoom: center.zoom,
+      });
+
+      L.tileLayer(tileLayer.url, {
+        attribution: tileLayer.attribution,
+      }).addTo(mapRef.current);
+
+      markerLayerRef.current = L.layerGroup().addTo(mapRef.current);
+      gcpLayerRef.current = L.layerGroup().addTo(mapRef.current);
+
+      mapRef.current.on("click", (event) => {
+        onMapClickRef.current?.([
+          Number(event.latlng.lng.toFixed(5)),
+          Number(event.latlng.lat.toFixed(5)),
+        ]);
+      });
+
+      mapRef.current.on("dragstart", () =>
+        mapRef.current?.getContainer().classList.add("clover-map-dragging"),
+      );
+      mapRef.current.on("dragend", () =>
+        mapRef.current?.getContainer().classList.remove("clover-map-dragging"),
+      );
+
+      setMapReady(true);
+      queueMapRefresh();
+    }
+
+    initializeMap();
+
+    return () => {
+      isMounted = false;
+      setMapReady(false);
+      mapRef.current?.remove();
+      mapRef.current = null;
+      navPlaceLayerRef.current = null;
+      geoJsonLayerRef.current = null;
+      markerLayerRef.current = null;
+      gcpLayerRef.current = null;
+      warpedLayerRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Re-centre when center prop changes ────────────────────────────────────
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || fitToData) return;
+    mapRef.current.setView([center.latitude, center.longitude], center.zoom);
+    queueMapRefresh();
+    // `fitToData` intentionally omitted — only recenter on explicit center changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [center.latitude, center.longitude, center.zoom, mapReady]);
+
+  // ── Render navPlace GeoJSON layer ─────────────────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function renderNavPlace() {
+      if (!mapReady || !mapRef.current) return;
+      const L = await import("leaflet");
+      if (!isMounted || !mapRef.current) return;
+
+      if (navPlaceLayerRef.current) {
+        navPlaceLayerRef.current.remove();
+        navPlaceLayerRef.current = null;
+      }
+
+      const featureCollection = normalizeNavPlace(resolvedNavPlace);
+      if (!featureCollection?.features?.length) return;
+
+      navPlaceLayerRef.current = L.geoJSON(featureCollection, {
+        pointToLayer: (_feature, latLng) =>
+          L.circleMarker(latLng, {
+            radius: 6,
+            color: NAV_PLACE_COLOR,
+            fillColor: NAV_PLACE_COLOR,
+            fillOpacity: 0.8,
+            weight: 2,
+          }),
+        style: {
+          color: NAV_PLACE_COLOR,
+          fillColor: NAV_PLACE_COLOR,
+          fillOpacity: 0.18,
+          weight: 2,
+        },
+        onEachFeature: (feature, layer) => {
+          const popup = buildNavPlacePopup(feature);
+          if (popup) {
+            layer.bindPopup(popup, {
+              className: "clover-map-leaflet-popup",
+              maxWidth: 320,
+              minWidth: 240,
+            });
+            return;
+          }
+
+          const label = getNavPlaceTitle(feature);
+          if (label) layer.bindTooltip(label);
+        },
+      }).addTo(mapRef.current);
+
+      queueMapRefresh();
+    }
+
+    renderNavPlace();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolvedNavPlace, mapReady]);
+
+  // ── Render raw geoJson layer ──────────────────────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function renderGeoJson() {
+      if (!mapReady || !mapRef.current) return;
+      const L = await import("leaflet");
+      if (!isMounted || !mapRef.current) return;
+
+      if (geoJsonLayerRef.current) {
+        geoJsonLayerRef.current.remove();
+        geoJsonLayerRef.current = null;
+      }
+
+      const features =
+        geoJson && "features" in geoJson ? geoJson.features : null;
+      const hasData = geoJson && (features ? features.length > 0 : true);
+      if (!hasData) return;
+
+      geoJsonLayerRef.current = L.geoJSON(geoJson as GeoJSON.GeoJsonObject, {
+        pointToLayer: (_feature, latLng) =>
+          L.circleMarker(latLng, {
+            radius: 6,
+            color: NAV_PLACE_COLOR,
+            fillColor: NAV_PLACE_COLOR,
+            fillOpacity: 0.8,
+            weight: 2,
+          }),
+        style: {
+          color: NAV_PLACE_COLOR,
+          fillColor: NAV_PLACE_COLOR,
+          fillOpacity: 0.18,
+          weight: 2,
+        },
+        onEachFeature: (feature, layer) => {
+          const label = getNavPlaceLabel(feature?.properties?.label);
+          if (label) layer.bindTooltip(label);
+        },
+      }).addTo(mapRef.current);
+
+      queueMapRefresh();
+    }
+
+    renderGeoJson();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [geoJson, mapReady]);
+
+  // ── Render custom marker layer ────────────────────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function renderMarkers() {
+      if (!mapReady || !mapRef.current || !markerLayerRef.current) return;
+      const L = await import("leaflet");
+      if (!isMounted || !markerLayerRef.current) return;
+
+      markerLayerRef.current.clearLayers();
+      markers.forEach((marker, index) => {
+        L.circleMarker([marker.latitude, marker.longitude], {
+          radius: 6,
+          color: marker.color ?? "#4e2a84",
+          fillColor: marker.color ?? "#4e2a84",
+          fillOpacity: 0.8,
+          weight: 2,
+        })
+          .bindTooltip(marker.label ?? `Point ${index + 1}`)
+          .addTo(markerLayerRef.current!);
+      });
+
+      queueMapRefresh();
+    }
+
+    renderMarkers();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady, markers]);
+
+  // ── Render GCP control-point markers ─────────────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function renderGCPs() {
+      if (!mapReady || !mapRef.current || !gcpLayerRef.current) return;
+      if (!showControlPoints) {
+        gcpLayerRef.current.clearLayers();
+        return;
+      }
+
+      const L = await import("leaflet");
+      if (!isMounted || !gcpLayerRef.current) return;
+
+      gcpLayerRef.current.clearLayers();
+      // Number control points per-annotation so each georeferenced sheet's
+      // markers read "Control Point 1..n" rather than a single global sequence.
+      const multipleMaps = gcpsByAnnotation.length > 1;
+      gcpsByAnnotation.forEach((annotationGcps, mapIndex) => {
+        annotationGcps.forEach((gcp, index) => {
+          const tooltip = multipleMaps
+            ? `Map ${mapIndex + 1} · Control Point ${index + 1}`
+            : `Control Point ${index + 1}`;
+          L.circleMarker([gcp.geoCoords[1], gcp.geoCoords[0]], {
+            radius: 7,
+            color: GCP_COLOR,
+            fillColor: GCP_COLOR,
+            fillOpacity: 0.85,
+            weight: 2,
+          })
+            .bindTooltip(tooltip)
+            .addTo(gcpLayerRef.current!);
+        });
+      });
+
+      queueMapRefresh();
+    }
+
+    renderGCPs();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady, gcpsByAnnotation, showControlPoints]);
+
+  // ── Render warped image overlay (via @allmaps/leaflet) ────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function renderWarpedLayer() {
+      if (!mapReady || !mapRef.current) return;
+
+      // Remove any existing warped layer
+      if (warpedLayerRef.current) {
+        warpedLayerRef.current.remove();
+        warpedLayerRef.current = null;
+      }
+
+      if (!showImageOverlay) return;
+
+      // Only annotations with ≥ 3 GCPs can be warped.
+      const overlayAnnotations = allGeorefAnnotations.filter(
+        (_annotation, index) => gcpsByAnnotation[index]?.length >= 3,
+      );
+      if (overlayAnnotations.length === 0) return;
+
+      const { WarpedMapLayer } = await import("@allmaps/leaflet");
+      if (!isMounted || !mapRef.current) return;
+
+      // A single WarpedMapLayer can host many georeferenced maps. Seed it with
+      // the first annotation, then add the rest so multiple sheets tile onto
+      // one map.
+      const [first, ...rest] = overlayAnnotations;
+      const layer = new WarpedMapLayer(first, {
+        opacity: imageOverlayOpacity,
+      });
+      layer.addTo(mapRef.current);
+
+      for (const annotation of rest) {
+        try {
+          await layer.addGeoreferenceAnnotation(annotation);
+        } catch (error) {
+          console.error(`Failed to add georeference annotation: ${error}`);
+        }
+        if (!isMounted) break;
+      }
+
+      warpedLayerRef.current = layer;
+    }
+
+    renderWarpedLayer();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    mapReady,
+    allGeorefAnnotations,
+    gcpsByAnnotation,
+    showImageOverlay,
+    imageOverlayOpacity,
+  ]);
+
+  // ── Fit viewport to all data ──────────────────────────────────────────────
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fitDataBounds() {
+      if (!fitToData || !mapReady || !mapRef.current) return;
+      const L = await import("leaflet");
+      if (!isMounted || !mapRef.current) return;
+
+      const bounds = L.latLngBounds([]);
+
+      // navPlace features
+      const navPlaceFC = normalizeNavPlace(resolvedNavPlace);
+      if (navPlaceFC?.features?.length) {
+        const nb = L.geoJSON(navPlaceFC).getBounds();
+        if (nb.isValid()) bounds.extend(nb);
+      }
+
+      // raw geoJson
+      if (geoJson) {
+        const gb = L.geoJSON(geoJson as GeoJSON.GeoJsonObject).getBounds();
+        if (gb.isValid()) bounds.extend(gb);
+      }
+
+      // custom markers
+      markers.forEach((marker) => {
+        bounds.extend([marker.latitude, marker.longitude]);
+      });
+
+      // GCPs (geographic coordinates)
+      gcps.forEach((gcp) => {
+        bounds.extend([gcp.geoCoords[1], gcp.geoCoords[0]]);
+      });
+
+      if (!bounds.isValid()) return;
+
+      if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+        mapRef.current.setView(bounds.getCenter(), 8);
+      } else {
+        mapRef.current.fitBounds(bounds, { maxZoom: 12, padding: [32, 32] });
+      }
+
+      queueMapRefresh();
+    }
+
+    fitDataBounds();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    center.latitude,
+    center.longitude,
+    center.zoom,
+    fitToData,
+    resolvedNavPlace,
+    geoJson,
+    mapReady,
+    markers,
+    gcps,
+  ]);
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <Wrapper ref={containerRef} data-testid="clover-map" />
+    </ErrorBoundary>
+  );
+};
+
+export default CloverMap;

--- a/src/components/Viewer/Painting/Painting.test.tsx
+++ b/src/components/Viewer/Painting/Painting.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { IIIFExternalWebResource } from "@iiif/presentation-3";
 import ImageViewer from "src/components/Image";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
+import Map from "src/components/Map";
 import Painting from "src/components/Viewer/Painting/Painting";
 import Placeholder from "src/components/Viewer/Painting/Placeholder";
 import Player from "src/components/Viewer/Player/Player";
@@ -60,6 +61,9 @@ vi.mock("src/components/Image");
 vi.mocked(ImageViewer).mockReturnValue(
   <div data-testid="mock-image-viewer">ImageViewer</div>,
 );
+
+vi.mock("src/components/Map");
+vi.mocked(Map).mockReturnValue(<div data-testid="mock-map">Map</div>);
 
 vi.mock("src/components/Viewer/Painting/Placeholder");
 vi.mocked(Placeholder).mockReturnValue(
@@ -158,6 +162,431 @@ describe("Painting component", () => {
     expect(screen.queryByTestId("placeholder-toggle")).toBeNull();
     expect(screen.queryByTestId("mock-player")).not.toBeInTheDocument();
     expect(screen.getByTestId("mock-image-viewer")).toBeInTheDocument();
+  });
+
+  it("displays the Map viewer when map mode is enabled and active canvases have navPlace", async () => {
+    const mapVault = new Vault();
+    const activeCanvas = "https://example.org/iiif/canvas/navplace/1";
+    const manifest = {
+      "@context": "http://iiif.io/api/presentation/3/context.json",
+      id: "https://example.org/iiif/manifest/navplace",
+      type: "Manifest",
+      label: { en: ["Map Manifest"] },
+      items: [
+        {
+          id: activeCanvas,
+          type: "Canvas",
+          height: 1000,
+          width: 1000,
+          label: { en: ["Canvas with navPlace"] },
+          navPlace: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: { label: { en: ["Canvas point"] } },
+                geometry: {
+                  type: "Point",
+                  coordinates: [-87.6881, 42.045],
+                },
+              },
+            ],
+          },
+          items: [
+            {
+              id: `${activeCanvas}/page`,
+              type: "AnnotationPage",
+              items: [
+                {
+                  id: `${activeCanvas}/annotation`,
+                  type: "Annotation",
+                  motivation: "painting",
+                  body: painting[0],
+                  target: activeCanvas,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    await mapVault.loadManifest("", manifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest: manifest.id,
+          configOptions: {
+            ...defaultState.configOptions,
+            map: {
+              enabled: true,
+              fitToData: true,
+              navPlaceLevel: "auto",
+            },
+          },
+          vault: mapVault,
+          visibleCanvases: [{ id: activeCanvas, type: "Canvas" }],
+        }}
+      >
+        <Painting {...defaultProps} activeCanvas={activeCanvas} />
+      </ViewerProvider>,
+    );
+
+    expect(screen.getByTestId("mock-map")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-image-viewer")).not.toBeInTheDocument();
+    expect(vi.mocked(Map)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fitToData: true,
+        navPlace: expect.objectContaining({
+          type: "FeatureCollection",
+        }),
+      }),
+      expect.anything(),
+    );
+
+    const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+    const navPlace = mapProps?.navPlace as GeoJSON.FeatureCollection;
+    expect(navPlace.features[0].properties?.iiifResource).toMatchObject({
+      id: activeCanvas,
+      type: "Canvas",
+      parent: {
+        id: manifest.id,
+        type: "Manifest",
+      },
+    });
+  });
+
+  it("displays Manifest-level navPlace when map mode targets the Manifest", async () => {
+    const mapVault = new Vault();
+    const activeCanvas = "https://example.org/iiif/canvas/manifest-navplace/1";
+    const manifest = {
+      "@context": "http://iiif.io/api/presentation/3/context.json",
+      id: "https://example.org/iiif/manifest/manifest-navplace",
+      type: "Manifest",
+      label: { en: ["Manifest with navPlace"] },
+      summary: { en: ["Manifest-level map summary"] },
+      thumbnail: [{ id: "https://example.org/thumb.jpg", type: "Image" }],
+      homepage: [{ id: "https://example.org/work", type: "Text" }],
+      navPlace: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { label: { en: ["Pend Oreille River"] } },
+            geometry: {
+              type: "Point",
+              coordinates: [-117.61775, 49.00381],
+            },
+          },
+        ],
+      },
+      items: [
+        {
+          id: activeCanvas,
+          type: "Canvas",
+          height: 1000,
+          width: 1000,
+          label: { en: ["Canvas 1"] },
+          items: [
+            {
+              id: `${activeCanvas}/page`,
+              type: "AnnotationPage",
+              items: [
+                {
+                  id: `${activeCanvas}/annotation`,
+                  type: "Annotation",
+                  motivation: "painting",
+                  body: painting[0],
+                  target: activeCanvas,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    await mapVault.loadManifest("", manifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest: manifest.id,
+          configOptions: {
+            ...defaultState.configOptions,
+            map: {
+              enabled: true,
+              fitToData: true,
+              navPlaceLevel: "Manifest",
+            },
+          },
+          vault: mapVault,
+          visibleCanvases: [{ id: activeCanvas, type: "Canvas" }],
+        }}
+      >
+        <Painting {...defaultProps} activeCanvas={activeCanvas} />
+      </ViewerProvider>,
+    );
+
+    expect(screen.getByTestId("mock-map")).toBeInTheDocument();
+
+    const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+    const navPlace = mapProps?.navPlace as GeoJSON.FeatureCollection;
+    expect(navPlace.features[0].properties?.iiifResource).toMatchObject({
+      id: manifest.id,
+      type: "Manifest",
+      label: manifest.label,
+      summary: manifest.summary,
+      thumbnail: "https://example.org/thumb.jpg",
+      homepage: "https://example.org/work",
+    });
+  });
+
+  it("gathers and adapts georef annotations across the manifest for overlays", async () => {
+    const overlayVault = new Vault();
+    const canvas1 = "https://example.org/iiif/canvas/georef/1";
+    const canvas2 = "https://example.org/iiif/canvas/georef/2";
+    const service1 = "https://iiif.example.org/image/2/sheet-1";
+    const service2 = "https://iiif.example.org/image/2/sheet-2";
+
+    const georefBody = (coords: [number, number][]) => ({
+      type: "FeatureCollection",
+      features: coords.map((coordinates, index) => ({
+        type: "Feature",
+        properties: { resourceCoords: [index * 10, index * 10] },
+        geometry: { type: "Point", coordinates },
+      })),
+    });
+
+    const buildCanvas = (
+      canvasId: string,
+      serviceId: string,
+      coords: [number, number][],
+    ) => ({
+      id: canvasId,
+      type: "Canvas",
+      height: 1000,
+      width: 1000,
+      items: [
+        {
+          id: `${canvasId}/page`,
+          type: "AnnotationPage",
+          items: [
+            {
+              id: `${canvasId}/annotation`,
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: `${serviceId}/full/600,/0/default.jpg`,
+                type: "Image",
+                format: "image/jpeg",
+                height: 1000,
+                width: 1000,
+                service: [{ id: serviceId, type: "ImageService2" }],
+              },
+              target: canvasId,
+            },
+          ],
+        },
+      ],
+      annotations: [
+        {
+          id: `${canvasId}/georef-page`,
+          type: "AnnotationPage",
+          items: [
+            {
+              id: `${canvasId}/georef`,
+              type: "Annotation",
+              motivation: "georeferencing",
+              target: {
+                type: "SpecificResource",
+                source: { id: canvasId, type: "Canvas", width: 1000, height: 1000 },
+              },
+              body: georefBody(coords),
+            },
+          ],
+        },
+      ],
+    });
+
+    const manifest = {
+      "@context": "http://iiif.io/api/presentation/3/context.json",
+      id: "https://example.org/iiif/manifest/georef",
+      type: "Manifest",
+      label: { en: ["Georeferenced Sheets"] },
+      items: [
+        buildCanvas(canvas1, service1, [
+          [-87.71, 42.06],
+          [-87.68, 42.06],
+          [-87.68, 42.01],
+        ]),
+        buildCanvas(canvas2, service2, [
+          [-87.78, 42.07],
+          [-87.7, 42.07],
+          [-87.7, 42.08],
+        ]),
+      ],
+    };
+    await overlayVault.loadManifest("", manifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest: manifest.id,
+          configOptions: {
+            ...defaultState.configOptions,
+            map: {
+              enabled: true,
+              fitToData: true,
+              showImageOverlay: true,
+              overlayScope: "manifest",
+            },
+          },
+          vault: overlayVault,
+          visibleCanvases: [{ id: canvas1, type: "Canvas" }],
+        }}
+      >
+        <Painting {...defaultProps} activeCanvas={canvas1} />
+      </ViewerProvider>,
+    );
+
+    expect(screen.getByTestId("mock-map")).toBeInTheDocument();
+
+    await vi.waitFor(() => {
+      const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+      const annotations = mapProps?.georefAnnotations ?? [];
+      expect(annotations).toHaveLength(2);
+    });
+
+    const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+    const annotations = mapProps?.georefAnnotations ?? [];
+
+    // Each Canvas-sourced annotation is adapted to its painting image service.
+    const sources = annotations
+      .map((annotation) => annotation.target?.source)
+      .sort((a, b) => (a?.id ?? "").localeCompare(b?.id ?? ""));
+    expect(sources[0]).toMatchObject({ id: service1, type: "ImageService2" });
+    expect(sources[1]).toMatchObject({ id: service2, type: "ImageService2" });
+
+    // Overlay options are threaded through.
+    expect(mapProps?.showImageOverlay).toBe(true);
+  });
+
+  it("limits overlay discovery to the visible canvas when overlayScope is 'canvas'", async () => {
+    const overlayVault = new Vault();
+    const canvas1 = "https://example.org/iiif/canvas/scope/1";
+    const canvas2 = "https://example.org/iiif/canvas/scope/2";
+    const service1 = "https://iiif.example.org/image/2/scope-1";
+    const service2 = "https://iiif.example.org/image/2/scope-2";
+
+    const buildCanvas = (canvasId: string, serviceId: string) => ({
+      id: canvasId,
+      type: "Canvas",
+      height: 1000,
+      width: 1000,
+      items: [
+        {
+          id: `${canvasId}/page`,
+          type: "AnnotationPage",
+          items: [
+            {
+              id: `${canvasId}/annotation`,
+              type: "Annotation",
+              motivation: "painting",
+              body: {
+                id: `${serviceId}/full/600,/0/default.jpg`,
+                type: "Image",
+                format: "image/jpeg",
+                height: 1000,
+                width: 1000,
+                service: [{ id: serviceId, type: "ImageService2" }],
+              },
+              target: canvasId,
+            },
+          ],
+        },
+      ],
+      annotations: [
+        {
+          id: `${canvasId}/georef-page`,
+          type: "AnnotationPage",
+          items: [
+            {
+              id: `${canvasId}/georef`,
+              type: "Annotation",
+              motivation: "georeferencing",
+              target: {
+                type: "SpecificResource",
+                source: { id: canvasId, type: "Canvas", width: 1000, height: 1000 },
+              },
+              body: {
+                type: "FeatureCollection",
+                features: [
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [0, 0] },
+                    geometry: { type: "Point", coordinates: [-87.7, 42.0] },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [10, 10] },
+                    geometry: { type: "Point", coordinates: [-87.6, 42.0] },
+                  },
+                  {
+                    type: "Feature",
+                    properties: { resourceCoords: [20, 20] },
+                    geometry: { type: "Point", coordinates: [-87.6, 42.1] },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const manifest = {
+      "@context": "http://iiif.io/api/presentation/3/context.json",
+      id: "https://example.org/iiif/manifest/scope",
+      type: "Manifest",
+      label: { en: ["Scope Test"] },
+      items: [buildCanvas(canvas1, service1), buildCanvas(canvas2, service2)],
+    };
+    await overlayVault.loadManifest("", manifest);
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          activeManifest: manifest.id,
+          configOptions: {
+            ...defaultState.configOptions,
+            map: {
+              enabled: true,
+              fitToData: true,
+              showImageOverlay: true,
+              overlayScope: "canvas",
+            },
+          },
+          vault: overlayVault,
+          visibleCanvases: [{ id: canvas1, type: "Canvas" }],
+        }}
+      >
+        <Painting {...defaultProps} activeCanvas={canvas1} />
+      </ViewerProvider>,
+    );
+
+    await vi.waitFor(() => {
+      const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+      expect(mapProps?.georefAnnotations ?? []).toHaveLength(1);
+    });
+
+    const mapProps = vi.mocked(Map).mock.calls.at(-1)?.[0];
+    expect(mapProps?.georefAnnotations?.[0]?.target?.source).toMatchObject({
+      id: service1,
+    });
   });
 
   it.skip("renders the Choice select dropdown", () => {

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -22,9 +22,20 @@ import AnimationControls, {
 import { AnnotationResources } from "src/types/annotations";
 import ImageViewer from "src/components/Image";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
+import Map from "src/components/Map";
 import PaintingPlaceholder from "./Placeholder";
 import Player from "src/components/Viewer/Player/Player";
 import Toggle from "./Toggle";
+import {
+  GeoreferenceAnnotation,
+  NavPlaceDisplayLevel,
+  NavPlaceResourceContext,
+  NavPlaceResourceLevel,
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+} from "src/lib/georef-helpers";
 import { getAnimationFrames } from "src/hooks/use-iiif/getAnimationFrames";
 import { getCanvasBehavior } from "src/hooks/use-iiif/getCanvasBehavior";
 import { getPaintingResource } from "src/hooks/use-iiif";
@@ -38,6 +49,44 @@ interface PaintingProps {
   isMedia: boolean;
   painting: LabeledIIIFExternalWebResource[];
 }
+
+const getFirstThumbnailUrl = (thumbnail: unknown): string | undefined => {
+  if (!thumbnail) return undefined;
+  const thumbnailList = Array.isArray(thumbnail) ? thumbnail : [thumbnail];
+  const first = thumbnailList.find(Boolean);
+  if (!first || typeof first !== "object") return undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (first as any).id || (first as any)["@id"];
+};
+
+const getFirstHomepageUrl = (homepage: unknown): string | undefined => {
+  if (!homepage) return undefined;
+  const homepageList = Array.isArray(homepage) ? homepage : [homepage];
+  const first = homepageList.find(Boolean);
+  if (!first || typeof first !== "object") return undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (first as any).id || (first as any)["@id"];
+};
+
+const getNavPlaceContext = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resource: any,
+  parent?: NavPlaceResourceContext,
+): NavPlaceResourceContext | undefined => {
+  if (!resource) return undefined;
+
+  return {
+    id: resource.id || resource["@id"],
+    type: resource.type || resource["@type"],
+    label: resource.label ?? null,
+    summary: resource.summary ?? null,
+    thumbnail: getFirstThumbnailUrl(resource.thumbnail),
+    homepage: getFirstHomepageUrl(resource.homepage),
+    parent,
+  };
+};
 
 const Painting: React.FC<PaintingProps> = ({
   activeCanvas,
@@ -62,6 +111,7 @@ const Painting: React.FC<PaintingProps> = ({
   const {
     activeManifest,
     annotationCollection,
+    collection,
     configOptions,
     customDisplays,
     contentStateAnnotation,
@@ -224,6 +274,259 @@ const Painting: React.FC<PaintingProps> = ({
     return match;
   });
 
+  const [mapGeorefAnnotations, setMapGeorefAnnotations] = useState<
+    GeoreferenceAnnotation[]
+  >([]);
+
+  const mapNavPlace = useMemo(() => {
+    if (!configOptions.map?.enabled) return null;
+
+    const manifest = vault.get(activeManifest);
+    const canvases = visibleCanvases
+      .map((canvas) => vault.get(canvas.id))
+      .filter(Boolean);
+    const collectionResource =
+      collection && Object.keys(collection).length > 0 ? collection : null;
+    const collectionContext = getNavPlaceContext(collectionResource);
+    const manifestContext = getNavPlaceContext(manifest, collectionContext);
+    const configuredLevel = configOptions.map.navPlaceLevel ?? "auto";
+
+    const featuresForLevel = (level: NavPlaceResourceLevel) => {
+      if (level === "Collection") {
+        return collectionResource
+          ? extractNavPlaceFeatures(collectionResource, {
+              levels: ["Collection"],
+            })
+          : [];
+      }
+
+      if (level === "Manifest") {
+        return manifest
+          ? extractNavPlaceFeatures(manifest, {
+              levels: ["Manifest"],
+              parent: collectionContext,
+            })
+          : [];
+      }
+
+      return canvases.flatMap((canvas) =>
+        extractNavPlaceFeatures(canvas, {
+          levels: [level],
+          parent: manifestContext,
+        }),
+      );
+    };
+
+    const featuresForConfiguredLevel = (
+      level: NavPlaceDisplayLevel,
+    ): GeoJSON.Feature[] => {
+      if (level === "all") {
+        return [
+          ...featuresForLevel("Collection"),
+          ...featuresForLevel("Manifest"),
+          ...featuresForLevel("Canvas"),
+          ...featuresForLevel("Annotation"),
+        ];
+      }
+
+      if (level !== "auto") return featuresForLevel(level);
+
+      const levels: NavPlaceResourceLevel[] = [
+        "Annotation",
+        "Canvas",
+        "Manifest",
+        "Collection",
+      ];
+
+      for (const candidateLevel of levels) {
+        const features = featuresForLevel(candidateLevel);
+        if (features.length) return features;
+      }
+
+      return [];
+    };
+
+    const features = featuresForConfiguredLevel(configuredLevel);
+
+    return features.length ? createNavPlaceFeatureCollection(features) : null;
+  }, [
+    activeManifest,
+    collection,
+    configOptions.map?.enabled,
+    configOptions.map?.navPlaceLevel,
+    vault,
+    visibleCanvases,
+  ]);
+
+  // Discover georeferencing annotations across the in-scope canvases and adapt
+  // any Canvas-sourced annotation to the canvas's painting image service so
+  // @allmaps/leaflet can warp it. `overlayScope` controls breadth: "manifest"
+  // gathers every georeferenced canvas (sheets tile onto one map), "canvas"
+  // follows the active/visible canvas(es).
+  useEffect(() => {
+    let isMounted = true;
+
+    async function collectGeorefAnnotations() {
+      if (!configOptions.map?.enabled || !configOptions.map?.showImageOverlay) {
+        setMapGeorefAnnotations([]);
+        return;
+      }
+
+      const scope = configOptions.map?.overlayScope ?? "manifest";
+      const manifest = vault.get(activeManifest);
+      const canvasIds =
+        scope === "canvas"
+          ? visibleCanvases.map((canvas) => canvas.id)
+          : ((manifest?.items ?? []) as Array<{ id: string }>).map(
+              (item) => item.id,
+            );
+
+      const collected: GeoreferenceAnnotation[] = [];
+      const seen = new Set<string>();
+
+      for (const canvasId of canvasIds) {
+        const canvas = vault.get(canvasId);
+        if (!canvas?.annotations?.length) continue;
+
+        // Resolve the canvas's painting image service once for adaptation.
+        const paintingBodies = getPaintingResource(vault, canvasId) ?? [];
+        const imageService = paintingBodies
+          .map((body) => getImageServiceId(body))
+          .find(Boolean);
+
+        const pages = vault.get(canvas.annotations) as Array<{
+          id: string;
+          items?: Array<{ id: string }>;
+        }>;
+
+        for (const page of pages) {
+          let items = page?.items;
+          if (!items || items.length === 0) {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const loaded = (await vault.load(page.id)) as any;
+              items = loaded?.items;
+            } catch (error) {
+              console.error(`Annotation page failed to load: ${error}`);
+            }
+          }
+          if (!items?.length) continue;
+
+          for (const itemRef of items) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const annotation = vault.get(itemRef as any) as any;
+
+            const motivations = Array.isArray(annotation?.motivation)
+              ? annotation.motivation
+              : [annotation?.motivation];
+            if (!motivations.includes("georeferencing")) continue;
+            if (annotation.id && seen.has(annotation.id)) continue;
+
+            // The vault normalizes the FeatureCollection body into a
+            // `vault://` ContentResource reference — resolve it back to the
+            // GeoJSON and strip vault-internal fields before handing it to
+            // @allmaps/leaflet.
+            const bodyRefs = Array.isArray(annotation?.body)
+              ? annotation.body
+              : annotation?.body
+                ? [annotation.body]
+                : [];
+            let featureCollection: GeoJSON.FeatureCollection | null = null;
+            for (const ref of bodyRefs) {
+              const resolved =
+                ref?.type === "FeatureCollection"
+                  ? ref
+                  : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (vault.get(ref as any) as any);
+              if (resolved?.type === "FeatureCollection") {
+                featureCollection = {
+                  type: "FeatureCollection",
+                  features: resolved.features ?? [],
+                };
+                break;
+              }
+            }
+            if (!featureCollection) continue;
+
+            const source = annotation.target?.source;
+
+            // @allmaps/leaflet requires `target.selector`. Preserve a stored
+            // SvgSelector when present, otherwise synthesize a full-image
+            // polygon from the source dimensions.
+            const storedSelectorValue = annotation.target?.selector?.value;
+            const { width, height } = source ?? {};
+            const selectorValue =
+              storedSelectorValue ||
+              (width && height
+                ? `<svg width="${width}" height="${height}"><polygon points="0,0 ${width},0 ${width},${height} 0,${height}" /></svg>`
+                : undefined);
+            if (!selectorValue) continue; // can't warp without a selector
+
+            const candidate: GeoreferenceAnnotation = {
+              "@context": [
+                "http://iiif.io/api/extension/georef/1/context.json",
+                "http://iiif.io/api/presentation/3/context.json",
+              ],
+              id: annotation.id,
+              type: "Annotation",
+              motivation: "georeferencing",
+              target: {
+                type: "SpecificResource",
+                source: {
+                  id: source?.id,
+                  type: source?.type,
+                  width: source?.width,
+                  height: source?.height,
+                },
+                selector: {
+                  type: "SvgSelector",
+                  value: selectorValue,
+                },
+              },
+              body: featureCollection,
+            };
+
+            if (annotation.id) seen.add(annotation.id);
+
+            if (source?.type === "Canvas") {
+              if (!imageService) continue; // can't warp without an image service
+              collected.push(
+                adaptGeoreferenceAnnotationForOverlay(
+                  candidate,
+                  imageService.id,
+                  imageService.type,
+                ),
+              );
+            } else {
+              collected.push(candidate);
+            }
+          }
+        }
+      }
+
+      if (isMounted) setMapGeorefAnnotations(collected);
+    }
+
+    collectGeorefAnnotations();
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    activeManifest,
+    configOptions.map?.enabled,
+    configOptions.map?.showImageOverlay,
+    configOptions.map?.overlayScope,
+    vault,
+    visibleCanvases,
+  ]);
+
+  const showMap = Boolean(
+    !showPlaceholder &&
+      !customDisplay &&
+      !isMedia &&
+      (mapNavPlace || mapGeorefAnnotations.length),
+  );
+
   useEffect(() => {
     if (hasContentStateAnnotation && showPlaceholder && toggleCount === 0) {
       handleToggle();
@@ -231,7 +534,7 @@ const Painting: React.FC<PaintingProps> = ({
   }, [hasContentStateAnnotation, showPlaceholder]);
 
   useEffect(() => {
-    if (showPlaceholder) {
+    if (showPlaceholder || showMap) {
       dispatch({
         type: "updateOpenSeadragonViewer",
         openSeadragonViewer: undefined,
@@ -241,7 +544,7 @@ const Painting: React.FC<PaintingProps> = ({
         selector: undefined,
       });
     }
-  }, [showPlaceholder]);
+  }, [showPlaceholder, showMap]);
 
   useEffect(() => {
     const resources: Array<{
@@ -451,7 +754,18 @@ const Painting: React.FC<PaintingProps> = ({
             setIsInteractive={setIsInteractive}
           />
         )}
-        {!showPlaceholder &&
+        {showMap && (
+          <Map
+            navPlace={mapNavPlace}
+            georefAnnotations={mapGeorefAnnotations}
+            showImageOverlay={configOptions.map?.showImageOverlay}
+            imageOverlayOpacity={configOptions.map?.imageOverlayOpacity}
+            showControlPoints={configOptions.map?.showControlPoints}
+            fitToData={configOptions.map?.fitToData}
+          />
+        )}
+        {!showMap &&
+          !showPlaceholder &&
           !customDisplay &&
           (isMedia ? (
             <Player
@@ -548,7 +862,9 @@ const Painting: React.FC<PaintingProps> = ({
               }}
               onNextFrame={() => {
                 setIsPlaying(false);
-                setAnnotationIndex((prev) => Math.min(totalFrames - 1, prev + 1));
+                setAnnotationIndex((prev) =>
+                  Math.min(totalFrames - 1, prev + 1),
+                );
               }}
               onToggleRepeat={() => setIsRepeat((prev) => !prev)}
               onSetPlaybackRate={setPlaybackRate}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -11,6 +11,7 @@ import { IncomingHttpHeaders } from "http";
 import { Vault } from "@iiif/helpers/vault";
 import { AnnotationCollectionNormalized } from "src/types/annotation-collection";
 import { deepMerge } from "src/lib/utils";
+import type { NavPlaceDisplayLevel } from "src/lib/georef-helpers";
 import { v4 as uuidv4 } from "uuid";
 
 export type AutoScrollSettings = {
@@ -37,6 +38,15 @@ export type ViewerConfigOptions = {
   };
   crossOrigin?: MediaHTMLAttributes<HTMLVideoElement>["crossOrigin"];
   ignoreCaptionLabels?: string[];
+  map?: {
+    enabled?: boolean;
+    fitToData?: boolean;
+    navPlaceLevel?: NavPlaceDisplayLevel;
+    showImageOverlay?: boolean;
+    imageOverlayOpacity?: number;
+    showControlPoints?: boolean;
+    overlayScope?: "manifest" | "canvas";
+  };
   informationPanel?: {
     open?: boolean;
     renderAbout?: boolean;
@@ -115,6 +125,15 @@ const defaultConfigOptions: ViewerConfigOptions = {
   },
   crossOrigin: "anonymous",
   ignoreCaptionLabels: [],
+  map: {
+    enabled: false,
+    fitToData: true,
+    navPlaceLevel: "auto",
+    showImageOverlay: false,
+    imageOverlayOpacity: 0.65,
+    showControlPoints: true,
+    overlayScope: "manifest",
+  },
   informationPanel: {
     vtt: {
       autoScroll: {
@@ -259,11 +278,14 @@ export function expandAutoScrollOptions(
 ): AutoScrollOptions {
   // Get safe defaults, avoiding potential undefined values
   const getDefaults = (): AutoScrollOptions => {
-    const configDefaults = defaultConfigOptions?.informationPanel?.vtt?.autoScroll as AutoScrollOptions;
-    return configDefaults || {
-      enabled: true,
-      settings: defaultAutoScrollSettings,
-    };
+    const configDefaults = defaultConfigOptions?.informationPanel?.vtt
+      ?.autoScroll as AutoScrollOptions;
+    return (
+      configDefaults || {
+        enabled: true,
+        settings: defaultAutoScrollSettings,
+      }
+    );
   };
 
   const defaults = getDefaults();
@@ -525,23 +547,19 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
   const [state, dispatch] = useReducer<
     React.Reducer<ViewerContextStore, ViewerAction>,
     ViewerContextStore | undefined
-  >(
-    viewerReducer,
-    initialState,
-    (initArg?: ViewerContextStore) => {
-      if (initArg) {
-        return {
-          ...initArg,
-          configOptions: cloneViewerConfigOptions(
-            initArg.configOptions ?? defaultConfigOptions,
-          ),
-          viewerId: initArg.viewerId ?? uuidv4(),
-        };
-      }
+  >(viewerReducer, initialState, (initArg?: ViewerContextStore) => {
+    if (initArg) {
+      return {
+        ...initArg,
+        configOptions: cloneViewerConfigOptions(
+          initArg.configOptions ?? defaultConfigOptions,
+        ),
+        viewerId: initArg.viewerId ?? uuidv4(),
+      };
+    }
 
-      return createDefaultState();
-    },
-  );
+    return createDefaultState();
+  });
 
   const { openSeadragonViewer } = state;
 

--- a/src/fixtures/georef.ts
+++ b/src/fixtures/georef.ts
@@ -1,0 +1,350 @@
+/**
+ * Fixture data for the IIIF Georeference Extension and navPlace Extension.
+ *
+ * Unit-test fixtures use example.org following IIIF spec conventions.
+ * Geographic coordinates are real WGS-84 values from a scan of the
+ * "Map of the Township of Evanston, Cook County, Illinois" held by
+ * Northwestern University Libraries (FileSet 2fb1e81a).
+ *
+ * Real NUL identifiers are exported separately (DC_*) for docs and
+ * visual/integration tests.  See src/fixtures/dc_annotation.json for
+ * the full dc-api response.
+ */
+
+import type { GeoreferenceAnnotation } from "src/lib/georef-helpers";
+
+// ── Identifiers (example.org — for unit tests) ────────────────────────────────
+
+export const CANVAS_ID = "https://example.org/iiif/canvas/map-1";
+export const IMAGE_SERVICE_V2_ID = "https://iiif.example.org/image/2/map-1";
+export const IMAGE_SERVICE_V3_ID = "https://iiif.example.org/image/3/map-1";
+
+// ── Real NUL identifiers (from dc_annotation.json) ───────────────────────────
+
+/** Canvas source URL. */
+export const DC_CANVAS_ID =
+  "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif";
+
+/**
+ * IIIF Image API v2 base URL for the same FileSet.
+ * Used with `adaptGeoreferenceAnnotationForOverlay` to produce an overlay
+ * annotation compatible with @allmaps/leaflet.
+ */
+export const DC_IMAGE_SERVICE_V2_ID =
+  "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
+
+// ── Canvas dimensions ──────────────────────────────────────────────────────────
+
+export const CANVAS_WIDTH = 7337;
+export const CANVAS_HEIGHT = 9833;
+
+// ── Georeference annotation (Canvas source — as stored) ───────────────────────
+
+/**
+ * A IIIF Georeference Extension annotation whose `target.source` is a Canvas.
+ * This is the form an annotation takes when saved by an authoring tool.
+ * Pass to `adaptGeoreferenceAnnotationForOverlay` before using with
+ * @allmaps/leaflet, which requires an ImageService source.
+ */
+export const GEOREF_ANNOTATION_CANVAS: GeoreferenceAnnotation = {
+  "@context": [
+    "http://iiif.io/api/extension/georef/1/context.json",
+    "http://iiif.io/api/presentation/3/context.json",
+  ],
+  id: "https://example.org/iiif/annotation/georef-1",
+  type: "Annotation",
+  motivation: "georeferencing",
+  target: {
+    type: "SpecificResource",
+    source: {
+      id: CANVAS_ID,
+      type: "Canvas",
+      height: CANVAS_HEIGHT,
+      width: CANVAS_WIDTH,
+    },
+    selector: {
+      type: "SvgSelector",
+      value: `<svg width="${CANVAS_WIDTH}" height="${CANVAS_HEIGHT}"><polygon points="0,0 ${CANVAS_WIDTH},0 ${CANVAS_WIDTH},${CANVAS_HEIGHT} 0,${CANVAS_HEIGHT}" /></svg>`,
+    },
+  },
+  body: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { confidence: "medium", resourceCoords: [577.7, 1074.97] },
+        geometry: { type: "Point", coordinates: [-87.71064, 42.06793] },
+      },
+      {
+        type: "Feature",
+        properties: {
+          confidence: "medium",
+          resourceCoords: [3023.66, 1560.92],
+        },
+        geometry: { type: "Point", coordinates: [-87.67961, 42.06283] },
+      },
+      {
+        type: "Feature",
+        properties: { confidence: "medium", resourceCoords: [3499.96, 6785.6] },
+        geometry: { type: "Point", coordinates: [-87.6752, 42.01607] },
+      },
+    ],
+  },
+};
+
+/**
+ * The same annotation adapted for @allmaps/leaflet (ImageService2 source).
+ * Produced by `adaptGeoreferenceAnnotationForOverlay(GEOREF_ANNOTATION_CANVAS, IMAGE_SERVICE_V2_ID)`.
+ */
+export const GEOREF_ANNOTATION_IMAGE_SERVICE: GeoreferenceAnnotation = {
+  ...GEOREF_ANNOTATION_CANVAS,
+  target: {
+    ...GEOREF_ANNOTATION_CANVAS.target,
+    source: {
+      id: IMAGE_SERVICE_V2_ID,
+      type: "ImageService2",
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+    },
+  },
+};
+
+/**
+ * Real georeference annotation as returned by dc-api (content already JSON,
+ * not a JSON string).  Target source is a Canvas — pass to
+ * `adaptGeoreferenceAnnotationForOverlay` before using with @allmaps/leaflet.
+ *
+ * Source: src/fixtures/dc_annotation.json → data.annotations[0].content
+ */
+export const DC_GEOREF_ANNOTATION_CANVAS: GeoreferenceAnnotation = {
+  "@context": [
+    "http://iiif.io/api/extension/georef/1/context.json",
+    "http://iiif.io/api/presentation/3/context.json",
+  ],
+  id: "urn:meadow:georeference:2fb1e81a-9e24-420c-b224-0bfd6a279baf:2026-05-21T19%3A22%3A19.291Z",
+  type: "Annotation",
+  motivation: "georeferencing",
+  target: {
+    type: "SpecificResource",
+    source: {
+      id: DC_CANVAS_ID,
+      type: "Canvas",
+      height: CANVAS_HEIGHT,
+      width: CANVAS_WIDTH,
+    },
+    selector: {
+      type: "SvgSelector",
+      value: `<svg width="${CANVAS_WIDTH}" height="${CANVAS_HEIGHT}"><polygon points="0,0 ${CANVAS_WIDTH},0 ${CANVAS_WIDTH},${CANVAS_HEIGHT} 0,${CANVAS_HEIGHT}" /></svg>`,
+    },
+  },
+  body: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { confidence: "medium", resourceCoords: [577.7, 1074.97] },
+        geometry: { type: "Point", coordinates: [-87.71064, 42.06793] },
+      },
+      {
+        type: "Feature",
+        properties: {
+          confidence: "medium",
+          resourceCoords: [3023.66, 1560.92],
+        },
+        geometry: { type: "Point", coordinates: [-87.67961, 42.06283] },
+      },
+      {
+        type: "Feature",
+        properties: { confidence: "medium", resourceCoords: [3499.96, 6785.6] },
+        geometry: { type: "Point", coordinates: [-87.6752, 42.01607] },
+      },
+    ],
+  },
+};
+
+/**
+ * The same annotation adapted for @allmaps/leaflet (ImageService2 source).
+ * Produced by `adaptGeoreferenceAnnotationForOverlay(DC_GEOREF_ANNOTATION_CANVAS, DC_IMAGE_SERVICE_V2_ID)`.
+ */
+export const DC_GEOREF_ANNOTATION_OVERLAY: GeoreferenceAnnotation = {
+  ...DC_GEOREF_ANNOTATION_CANVAS,
+  target: {
+    ...DC_GEOREF_ANNOTATION_CANVAS.target,
+    source: {
+      id: DC_IMAGE_SERVICE_V2_ID,
+      type: "ImageService2",
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+    },
+  },
+};
+
+// ── Second real NUL map (Wilmette) — for multi-overlay demos ─────────────────
+
+/**
+ * Canvas source URL for the "Map of the village of Wilmette, Cook County,
+ * Illinois" (FileSet f8fd564d).  Wilmette borders Evanston on the North Shore,
+ * so the two georeferenced sheets tile together on one map.
+ */
+export const DC_WILMETTE_CANVAS_ID =
+  "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif";
+
+/** IIIF Image API v2 base URL for the Wilmette FileSet. */
+export const DC_WILMETTE_IMAGE_SERVICE_V2_ID =
+  "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b";
+
+export const DC_WILMETTE_CANVAS_WIDTH = 18844;
+export const DC_WILMETTE_CANVAS_HEIGHT = 6595;
+
+/**
+ * Real georeference annotation for the Wilmette map as returned by dc-api
+ * (content already JSON).  Target source is a Canvas — pass to
+ * `adaptGeoreferenceAnnotationForOverlay` before using with @allmaps/leaflet.
+ */
+export const DC_WILMETTE_GEOREF_ANNOTATION_CANVAS: GeoreferenceAnnotation = {
+  "@context": [
+    "http://iiif.io/api/extension/georef/1/context.json",
+    "http://iiif.io/api/presentation/3/context.json",
+  ],
+  id: "urn:meadow:georeference:f8fd564d-2d0d-4c58-badb-e575bdaaac5b:2026-05-29T19%3A59%3A12.203Z",
+  type: "Annotation",
+  motivation: "georeferencing",
+  target: {
+    type: "SpecificResource",
+    source: {
+      id: DC_WILMETTE_CANVAS_ID,
+      type: "Canvas",
+      height: DC_WILMETTE_CANVAS_HEIGHT,
+      width: DC_WILMETTE_CANVAS_WIDTH,
+    },
+    selector: {
+      type: "SvgSelector",
+      value: `<svg width="${DC_WILMETTE_CANVAS_WIDTH}" height="${DC_WILMETTE_CANVAS_HEIGHT}"><polygon points="0,0 ${DC_WILMETTE_CANVAS_WIDTH},0 ${DC_WILMETTE_CANVAS_WIDTH},${DC_WILMETTE_CANVAS_HEIGHT} 0,${DC_WILMETTE_CANVAS_HEIGHT}" /></svg>`,
+    },
+  },
+  body: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: {
+          confidence: "medium",
+          resourceCoords: [11818.74, 3855.76],
+        },
+        geometry: { type: "Point", coordinates: [-87.69964, 42.07017] },
+      },
+      {
+        type: "Feature",
+        properties: {
+          confidence: "medium",
+          resourceCoords: [1815.28, 4233.17],
+        },
+        geometry: { type: "Point", coordinates: [-87.77029, 42.06886] },
+      },
+      {
+        type: "Feature",
+        properties: {
+          confidence: "medium",
+          resourceCoords: [11349.49, 1444.54],
+        },
+        geometry: { type: "Point", coordinates: [-87.70287, 42.08273] },
+      },
+    ],
+  },
+};
+
+/**
+ * The Wilmette annotation adapted for @allmaps/leaflet (ImageService2 source).
+ * Produced by
+ * `adaptGeoreferenceAnnotationForOverlay(DC_WILMETTE_GEOREF_ANNOTATION_CANVAS, DC_WILMETTE_IMAGE_SERVICE_V2_ID)`.
+ */
+export const DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY: GeoreferenceAnnotation = {
+  ...DC_WILMETTE_GEOREF_ANNOTATION_CANVAS,
+  target: {
+    ...DC_WILMETTE_GEOREF_ANNOTATION_CANVAS.target,
+    source: {
+      id: DC_WILMETTE_IMAGE_SERVICE_V2_ID,
+      type: "ImageService2",
+      width: DC_WILMETTE_CANVAS_WIDTH,
+      height: DC_WILMETTE_CANVAS_HEIGHT,
+    },
+  },
+};
+
+/** Expected GCPs extracted by `parseGeoreferenceAnnotation`. */
+export const EXPECTED_GCPS = [
+  {
+    id: "gcp-0",
+    resourceCoords: [577.7, 1074.97] as [number, number],
+    geoCoords: [-87.71064, 42.06793] as [number, number],
+  },
+  {
+    id: "gcp-1",
+    resourceCoords: [3023.66, 1560.92] as [number, number],
+    geoCoords: [-87.67961, 42.06283] as [number, number],
+  },
+  {
+    id: "gcp-2",
+    resourceCoords: [3499.96, 6785.6] as [number, number],
+    geoCoords: [-87.6752, 42.01607] as [number, number],
+  },
+];
+
+// ── navPlace fixtures ──────────────────────────────────────────────────────────
+
+/** A navPlace FeatureCollection with a single Point feature. */
+export const EXAMPLE_NAV_PLACE: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      id: "https://example.org/place/1",
+      properties: {
+        label: { en: ["Example Location"] },
+        summary: { en: ["A representative geographic point"] },
+      },
+      geometry: {
+        type: "Point",
+        coordinates: [-87.6881, 42.045],
+      },
+    },
+  ],
+};
+
+/** A navPlace expressed as a single Feature (non-collection form). */
+export const EXAMPLE_NAV_PLACE_FEATURE: GeoJSON.Feature = {
+  type: "Feature",
+  id: "https://example.org/place/1",
+  properties: {
+    label: "Example Location",
+  },
+  geometry: {
+    type: "Point",
+    coordinates: [-87.6881, 42.045],
+  },
+};
+
+/** A navPlace with a Polygon geometry. */
+export const EXAMPLE_NAV_PLACE_POLYGON: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {
+        label: { en: ["Example Region"] },
+      },
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-88.263, 41.469],
+            [-87.524, 41.469],
+            [-87.524, 42.154],
+            [-88.263, 42.154],
+            [-88.263, 41.469],
+          ],
+        ],
+      },
+    },
+  ],
+};

--- a/src/fixtures/georef.ts
+++ b/src/fixtures/georef.ts
@@ -26,12 +26,12 @@ export const DC_CANVAS_ID =
   "https://api.dc.library.northwestern.edu/api/v2/file-sets/2fb1e81a-9e24-420c-b224-0bfd6a279baf?as=iiif";
 
 /**
- * IIIF Image API v2 base URL for the same FileSet.
+ * IIIF Image API v3 base URL for the same FileSet.
  * Used with `adaptGeoreferenceAnnotationForOverlay` to produce an overlay
  * annotation compatible with @allmaps/leaflet.
  */
-export const DC_IMAGE_SERVICE_V2_ID =
-  "https://iiif.dc.library.northwestern.edu/iiif/2/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
+export const DC_IMAGE_SERVICE_V3_ID =
+  "https://iiif.dc.library.northwestern.edu/iiif/3/2fb1e81a-9e24-420c-b224-0bfd6a279baf";
 
 // ── Canvas dimensions ──────────────────────────────────────────────────────────
 
@@ -163,16 +163,16 @@ export const DC_GEOREF_ANNOTATION_CANVAS: GeoreferenceAnnotation = {
 };
 
 /**
- * The same annotation adapted for @allmaps/leaflet (ImageService2 source).
- * Produced by `adaptGeoreferenceAnnotationForOverlay(DC_GEOREF_ANNOTATION_CANVAS, DC_IMAGE_SERVICE_V2_ID)`.
+ * The same annotation adapted for @allmaps/leaflet (ImageService3 source).
+ * Produced by `adaptGeoreferenceAnnotationForOverlay(DC_GEOREF_ANNOTATION_CANVAS, DC_IMAGE_SERVICE_V3_ID, "ImageService3")`.
  */
 export const DC_GEOREF_ANNOTATION_OVERLAY: GeoreferenceAnnotation = {
   ...DC_GEOREF_ANNOTATION_CANVAS,
   target: {
     ...DC_GEOREF_ANNOTATION_CANVAS.target,
     source: {
-      id: DC_IMAGE_SERVICE_V2_ID,
-      type: "ImageService2",
+      id: DC_IMAGE_SERVICE_V3_ID,
+      type: "ImageService3",
       width: CANVAS_WIDTH,
       height: CANVAS_HEIGHT,
     },
@@ -189,9 +189,9 @@ export const DC_GEOREF_ANNOTATION_OVERLAY: GeoreferenceAnnotation = {
 export const DC_WILMETTE_CANVAS_ID =
   "https://api.dc.library.northwestern.edu/api/v2/file-sets/f8fd564d-2d0d-4c58-badb-e575bdaaac5b?as=iiif";
 
-/** IIIF Image API v2 base URL for the Wilmette FileSet. */
-export const DC_WILMETTE_IMAGE_SERVICE_V2_ID =
-  "https://iiif.dc.library.northwestern.edu/iiif/2/f8fd564d-2d0d-4c58-badb-e575bdaaac5b";
+/** IIIF Image API v3 base URL for the Wilmette FileSet. */
+export const DC_WILMETTE_IMAGE_SERVICE_V3_ID =
+  "https://iiif.dc.library.northwestern.edu/iiif/3/f8fd564d-2d0d-4c58-badb-e575bdaaac5b";
 
 export const DC_WILMETTE_CANVAS_WIDTH = 18844;
 export const DC_WILMETTE_CANVAS_HEIGHT = 6595;
@@ -254,17 +254,17 @@ export const DC_WILMETTE_GEOREF_ANNOTATION_CANVAS: GeoreferenceAnnotation = {
 };
 
 /**
- * The Wilmette annotation adapted for @allmaps/leaflet (ImageService2 source).
+ * The Wilmette annotation adapted for @allmaps/leaflet (ImageService3 source).
  * Produced by
- * `adaptGeoreferenceAnnotationForOverlay(DC_WILMETTE_GEOREF_ANNOTATION_CANVAS, DC_WILMETTE_IMAGE_SERVICE_V2_ID)`.
+ * `adaptGeoreferenceAnnotationForOverlay(DC_WILMETTE_GEOREF_ANNOTATION_CANVAS, DC_WILMETTE_IMAGE_SERVICE_V3_ID, "ImageService3")`.
  */
 export const DC_WILMETTE_GEOREF_ANNOTATION_OVERLAY: GeoreferenceAnnotation = {
   ...DC_WILMETTE_GEOREF_ANNOTATION_CANVAS,
   target: {
     ...DC_WILMETTE_GEOREF_ANNOTATION_CANVAS.target,
     source: {
-      id: DC_WILMETTE_IMAGE_SERVICE_V2_ID,
-      type: "ImageService2",
+      id: DC_WILMETTE_IMAGE_SERVICE_V3_ID,
+      type: "ImageService3",
       width: DC_WILMETTE_CANVAS_WIDTH,
       height: DC_WILMETTE_CANVAS_HEIGHT,
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import Image from "src/components/Image";
+import Map from "src/components/Map";
 import Primitives from "src/components/Primitives";
 import Scroll from "src/components/Scroll";
 import Slider from "src/components/Slider";
@@ -9,6 +10,28 @@ import {
 } from "src/lib/annotation-helpers";
 import { createOpenSeadragonRect } from "src/lib/openseadragon-helpers";
 import { type Plugin, type PluginInformationPanel } from "src/types/plugins";
+import type {
+  CloverMapProps,
+  MapCenter,
+  MapMarker,
+  MapTileLayer,
+} from "src/components/Map";
+import {
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  isGeoreferenceAnnotation,
+} from "src/lib/georef-helpers";
+import type {
+  GeoreferenceAnnotation,
+  GeoreferenceAnnotationSource,
+  GroundControlPoint,
+  NavPlaceDisplayLevel,
+  NavPlaceGeoJSON,
+  NavPlaceResourceContext,
+  NavPlaceResourceLevel,
+} from "src/lib/georef-helpers";
 
 const helpers = {
   parseAnnotationTarget,
@@ -17,12 +40,29 @@ const helpers = {
 
 export {
   Image,
+  Map,
   Primitives,
   Scroll,
   Slider,
   Viewer,
   helpers,
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  isGeoreferenceAnnotation,
   type AnnotationTargetExtended,
+  type CloverMapProps,
+  type GeoreferenceAnnotation,
+  type GeoreferenceAnnotationSource,
+  type GroundControlPoint,
+  type MapCenter,
+  type MapMarker,
+  type MapTileLayer,
+  type NavPlaceDisplayLevel,
+  type NavPlaceGeoJSON,
+  type NavPlaceResourceContext,
+  type NavPlaceResourceLevel,
   type Plugin,
   type PluginInformationPanel,
 };

--- a/src/lib/georef-helpers.test.ts
+++ b/src/lib/georef-helpers.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CANVAS_HEIGHT,
+  CANVAS_ID,
+  CANVAS_WIDTH,
+  EXAMPLE_NAV_PLACE,
+  EXAMPLE_NAV_PLACE_FEATURE,
+  EXAMPLE_NAV_PLACE_POLYGON,
+  EXPECTED_GCPS,
+  GEOREF_ANNOTATION_CANVAS,
+  GEOREF_ANNOTATION_IMAGE_SERVICE,
+  IMAGE_SERVICE_V2_ID,
+} from "src/fixtures/georef";
+import {
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  getNavPlaceLabel,
+  isGeoreferenceAnnotation,
+  normalizeNavPlace,
+  parseGeoreferenceAnnotation,
+} from "src/lib/georef-helpers";
+
+// ── isGeoreferenceAnnotation ──────────────────────────────────────────────────
+
+describe("isGeoreferenceAnnotation", () => {
+  it("returns true for a georeferencing annotation with a FeatureCollection body", () => {
+    expect(isGeoreferenceAnnotation(GEOREF_ANNOTATION_CANVAS)).toBe(true);
+  });
+
+  it("accepts an array motivation that includes georeferencing", () => {
+    expect(
+      isGeoreferenceAnnotation({
+        ...GEOREF_ANNOTATION_CANVAS,
+        motivation: ["georeferencing"],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a painting annotation", () => {
+    expect(
+      isGeoreferenceAnnotation({
+        type: "Annotation",
+        motivation: "painting",
+        body: { type: "Image" },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for georeferencing without a FeatureCollection body", () => {
+    expect(
+      isGeoreferenceAnnotation({
+        type: "Annotation",
+        motivation: "georeferencing",
+        body: { type: "TextualBody" },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for nullish / non-object input", () => {
+    expect(isGeoreferenceAnnotation(null)).toBe(false);
+    expect(isGeoreferenceAnnotation(undefined)).toBe(false);
+    expect(isGeoreferenceAnnotation("georeferencing")).toBe(false);
+  });
+});
+
+// ── getImageServiceId ─────────────────────────────────────────────────────────
+
+describe("getImageServiceId", () => {
+  it("reads a Presentation 3 ImageService3 (id + type)", () => {
+    expect(
+      getImageServiceId({
+        service: [
+          { id: "https://iiif.example.org/image/3/x", type: "ImageService3" },
+        ],
+      }),
+    ).toEqual({
+      id: "https://iiif.example.org/image/3/x",
+      type: "ImageService3",
+    });
+  });
+
+  it("reads a Presentation 2 ImageService2 (@id + @type)", () => {
+    expect(
+      getImageServiceId({
+        service: [
+          {
+            "@id": "https://iiif.example.org/image/2/x",
+            "@type": "ImageService2",
+          },
+        ],
+      }),
+    ).toEqual({
+      id: "https://iiif.example.org/image/2/x",
+      type: "ImageService2",
+    });
+  });
+
+  it("prefers an ImageService over an unrelated service", () => {
+    expect(
+      getImageServiceId({
+        service: [
+          { id: "https://iiif.example.org/search", type: "SearchService2" },
+          { id: "https://iiif.example.org/image/2/x", type: "ImageService2" },
+        ],
+      }),
+    ).toEqual({
+      id: "https://iiif.example.org/image/2/x",
+      type: "ImageService2",
+    });
+  });
+
+  it("falls back to the first service id (assumes v2) when no type matches", () => {
+    expect(
+      getImageServiceId({
+        service: [{ id: "https://iiif.example.org/image/x" }],
+      }),
+    ).toEqual({
+      id: "https://iiif.example.org/image/x",
+      type: "ImageService2",
+    });
+  });
+
+  it("returns undefined when there is no service", () => {
+    expect(getImageServiceId({})).toBeUndefined();
+    expect(getImageServiceId({ service: [] })).toBeUndefined();
+    expect(getImageServiceId(undefined)).toBeUndefined();
+  });
+});
+
+// ── parseGeoreferenceAnnotation ───────────────────────────────────────────────
+
+describe("parseGeoreferenceAnnotation", () => {
+  it("extracts all three GCPs from the annotation fixture", () => {
+    const gcps = parseGeoreferenceAnnotation(GEOREF_ANNOTATION_CANVAS);
+    expect(gcps).toHaveLength(3);
+    expect(gcps).toEqual(EXPECTED_GCPS);
+  });
+
+  it("assigns stable auto-generated ids when Feature has no id", () => {
+    const gcps = parseGeoreferenceAnnotation(GEOREF_ANNOTATION_CANVAS);
+    expect(gcps[0].id).toBe("gcp-0");
+    expect(gcps[1].id).toBe("gcp-1");
+    expect(gcps[2].id).toBe("gcp-2");
+  });
+
+  it("preserves floating-point precision in resourceCoords", () => {
+    const gcps = parseGeoreferenceAnnotation(GEOREF_ANNOTATION_CANVAS);
+    expect(gcps[0].resourceCoords).toEqual([577.7, 1074.97]);
+    expect(gcps[1].resourceCoords).toEqual([3023.66, 1560.92]);
+    expect(gcps[2].resourceCoords).toEqual([3499.96, 6785.6]);
+  });
+
+  it("preserves floating-point precision in geoCoords", () => {
+    const gcps = parseGeoreferenceAnnotation(GEOREF_ANNOTATION_CANVAS);
+    expect(gcps[0].geoCoords).toEqual([-87.71064, 42.06793]);
+    expect(gcps[1].geoCoords).toEqual([-87.67961, 42.06283]);
+    expect(gcps[2].geoCoords).toEqual([-87.6752, 42.01607]);
+  });
+
+  it("returns an empty array for null input", () => {
+    expect(parseGeoreferenceAnnotation(null)).toEqual([]);
+  });
+
+  it("returns an empty array for undefined input", () => {
+    expect(parseGeoreferenceAnnotation(undefined)).toEqual([]);
+  });
+
+  it("silently skips a Feature whose geometry is not a Point", () => {
+    const annotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: {
+        type: "FeatureCollection" as const,
+        features: [
+          {
+            type: "Feature" as const,
+            properties: { resourceCoords: [100, 200] },
+            geometry: {
+              type: "Polygon" as const,
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+          // Valid point follows
+          GEOREF_ANNOTATION_CANVAS.body.features[0],
+        ],
+      },
+    };
+    const gcps = parseGeoreferenceAnnotation(annotation);
+    expect(gcps).toHaveLength(1);
+    expect(gcps[0].resourceCoords).toEqual([577.7, 1074.97]);
+  });
+
+  it("silently skips a Feature with missing resourceCoords", () => {
+    const annotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: {
+        type: "FeatureCollection" as const,
+        features: [
+          {
+            type: "Feature" as const,
+            properties: {}, // no resourceCoords
+            geometry: { type: "Point" as const, coordinates: [-87.7, 42.0] },
+          },
+        ],
+      },
+    };
+    expect(parseGeoreferenceAnnotation(annotation)).toEqual([]);
+  });
+
+  it("silently skips a Feature with NaN coordinates", () => {
+    const annotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: {
+        type: "FeatureCollection" as const,
+        features: [
+          {
+            type: "Feature" as const,
+            properties: { resourceCoords: ["x", "y"] },
+            geometry: { type: "Point" as const, coordinates: [-87.7, 42.0] },
+          },
+        ],
+      },
+    };
+    expect(parseGeoreferenceAnnotation(annotation)).toEqual([]);
+  });
+
+  it("uses an explicit Feature id when present", () => {
+    const annotation = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      body: {
+        type: "FeatureCollection" as const,
+        features: [
+          {
+            ...GEOREF_ANNOTATION_CANVAS.body.features[0],
+            id: "https://example.edu/gcp/1",
+          },
+        ],
+      },
+    };
+    const gcps = parseGeoreferenceAnnotation(annotation);
+    expect(gcps[0].id).toBe("https://example.edu/gcp/1");
+  });
+});
+
+// ── adaptGeoreferenceAnnotationForOverlay ─────────────────────────────────────
+
+describe("adaptGeoreferenceAnnotationForOverlay", () => {
+  it("swaps the Canvas source for an ImageService2 source", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(adapted.target.source).toEqual({
+      id: IMAGE_SERVICE_V2_ID,
+      type: "ImageService2",
+      width: CANVAS_WIDTH,
+      height: CANVAS_HEIGHT,
+    });
+  });
+
+  it("matches the expected IMAGE_SERVICE fixture exactly", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(adapted).toEqual(GEOREF_ANNOTATION_IMAGE_SERVICE);
+  });
+
+  it("preserves the original annotation's GCPs unchanged", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(adapted.body.features).toEqual(
+      GEOREF_ANNOTATION_CANVAS.body.features,
+    );
+  });
+
+  it("preserves the selector unchanged", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(adapted.target.selector).toEqual(
+      GEOREF_ANNOTATION_CANVAS.target.selector,
+    );
+  });
+
+  it("does not mutate the input annotation", () => {
+    const clone = JSON.parse(JSON.stringify(GEOREF_ANNOTATION_CANVAS));
+    adaptGeoreferenceAnnotationForOverlay(clone, IMAGE_SERVICE_V2_ID);
+    expect(clone.target.source.type).toBe("Canvas");
+    expect(clone.target.source.id).toBe(CANVAS_ID);
+  });
+
+  it("accepts ImageService3 as the service type", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      "https://iiif.example.edu/iiif/3/img-id",
+      "ImageService3",
+    );
+    expect(adapted.target.source.type).toBe("ImageService3");
+  });
+
+  it("passes through undefined dimensions when the original source omitted them", () => {
+    const noSize = {
+      ...GEOREF_ANNOTATION_CANVAS,
+      target: {
+        ...GEOREF_ANNOTATION_CANVAS.target,
+        source: { id: CANVAS_ID, type: "Canvas" },
+      },
+    };
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      noSize,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(adapted.target.source.width).toBeUndefined();
+    expect(adapted.target.source.height).toBeUndefined();
+  });
+
+  it("GCPs remain parseable after adaptation", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V2_ID,
+    );
+    expect(parseGeoreferenceAnnotation(adapted)).toEqual(EXPECTED_GCPS);
+  });
+});
+
+// ── normalizeNavPlace ─────────────────────────────────────────────────────────
+
+describe("normalizeNavPlace", () => {
+  it("returns a FeatureCollection unchanged", () => {
+    const result = normalizeNavPlace(EXAMPLE_NAV_PLACE);
+    expect(result).toBe(EXAMPLE_NAV_PLACE); // same reference
+    expect(result?.type).toBe("FeatureCollection");
+    expect(result?.features).toHaveLength(1);
+  });
+
+  it("wraps a single Feature in a FeatureCollection", () => {
+    const result = normalizeNavPlace(EXAMPLE_NAV_PLACE_FEATURE);
+    expect(result?.type).toBe("FeatureCollection");
+    expect(result?.features).toHaveLength(1);
+    expect(result?.features[0]).toBe(EXAMPLE_NAV_PLACE_FEATURE);
+  });
+
+  it("wraps a bare Point geometry in a Feature + FeatureCollection", () => {
+    const point: GeoJSON.Point = {
+      type: "Point",
+      coordinates: [-87.6881, 42.045],
+    };
+    const result = normalizeNavPlace(point);
+    expect(result?.type).toBe("FeatureCollection");
+    expect(result?.features).toHaveLength(1);
+    expect(result?.features[0].geometry).toEqual(point);
+    expect(result?.features[0].properties).toEqual({});
+  });
+
+  it("wraps a bare Polygon geometry", () => {
+    const polygon: GeoJSON.Polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    };
+    const result = normalizeNavPlace(polygon);
+    expect(result?.features[0].geometry).toEqual(polygon);
+  });
+
+  it("handles a FeatureCollection with a Polygon geometry", () => {
+    const result = normalizeNavPlace(EXAMPLE_NAV_PLACE_POLYGON);
+    expect(result?.features).toHaveLength(1);
+    expect(result?.features[0].geometry.type).toBe("Polygon");
+  });
+
+  it("returns null for null", () => {
+    expect(normalizeNavPlace(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(normalizeNavPlace(undefined)).toBeNull();
+  });
+
+  it("returns null for a non-GeoJSON object", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(normalizeNavPlace({ type: "Manifest" } as any)).toBeNull();
+  });
+});
+
+// ── getNavPlaceLabel ──────────────────────────────────────────────────────────
+
+describe("getNavPlaceLabel", () => {
+  it("returns a plain string as-is", () => {
+    expect(getNavPlaceLabel("Example Location")).toBe("Example Location");
+  });
+
+  it("extracts the first value from an IIIF InternationalString", () => {
+    expect(getNavPlaceLabel({ en: ["Example Location"] })).toBe(
+      "Example Location",
+    );
+  });
+
+  it("handles a multi-language InternationalString", () => {
+    const label = { en: ["Example"], fr: ["Exemple"] };
+    const result = getNavPlaceLabel(label);
+    expect(["Example", "Exemple"]).toContain(result);
+  });
+
+  it("extracts the label from a navPlace fixture feature", () => {
+    const feature = EXAMPLE_NAV_PLACE.features[0];
+    const label = feature.properties?.label as { en: string[] };
+    expect(getNavPlaceLabel(label)).toBe("Example Location");
+  });
+
+  it("returns empty string for null", () => {
+    expect(getNavPlaceLabel(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(getNavPlaceLabel(undefined)).toBe("");
+  });
+
+  it("returns empty string for an empty InternationalString", () => {
+    expect(getNavPlaceLabel({})).toBe("");
+  });
+
+  it("returns empty string for an InternationalString with empty arrays", () => {
+    expect(getNavPlaceLabel({ en: [] })).toBe("");
+  });
+});
+
+// ── extractNavPlaceFeatures ───────────────────────────────────────────────────
+
+describe("extractNavPlaceFeatures", () => {
+  const manifest = {
+    id: "https://example.org/iiif/manifest",
+    type: "Manifest",
+    label: { en: ["Example Manifest"] },
+    summary: { en: ["Manifest summary"] },
+    thumbnail: [{ id: "https://example.org/thumb.jpg", type: "Image" }],
+    homepage: [{ id: "https://example.org/work", type: "Text" }],
+    navPlace: EXAMPLE_NAV_PLACE,
+    items: [
+      {
+        id: "https://example.org/iiif/canvas/1",
+        type: "Canvas",
+        label: { en: ["Canvas 1"] },
+        navPlace: EXAMPLE_NAV_PLACE_FEATURE,
+      },
+    ],
+  };
+
+  it("enriches features with the IIIF resource that supplied navPlace", () => {
+    const features = extractNavPlaceFeatures(manifest, {
+      levels: ["Manifest"],
+    });
+
+    expect(features).toHaveLength(1);
+    expect(features[0].properties?.iiifResource).toMatchObject({
+      id: manifest.id,
+      type: "Manifest",
+      label: manifest.label,
+      summary: manifest.summary,
+      thumbnail: "https://example.org/thumb.jpg",
+      homepage: "https://example.org/work",
+    });
+  });
+
+  it("can extract canvas-level navPlace without manifest-level features", () => {
+    const features = extractNavPlaceFeatures(manifest, { levels: ["Canvas"] });
+
+    expect(features).toHaveLength(1);
+    expect(features[0].properties?.iiifResource).toMatchObject({
+      id: "https://example.org/iiif/canvas/1",
+      type: "Canvas",
+      label: { en: ["Canvas 1"] },
+    });
+    expect(features[0].properties?.iiifResource?.parent).toMatchObject({
+      id: manifest.id,
+      type: "Manifest",
+    });
+  });
+
+  it("creates a FeatureCollection from extracted features", () => {
+    const features = extractNavPlaceFeatures(manifest);
+    const collection = createNavPlaceFeatureCollection(features);
+
+    expect(collection).toEqual({
+      type: "FeatureCollection",
+      features,
+    });
+  });
+});

--- a/src/lib/georef-helpers.test.ts
+++ b/src/lib/georef-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   GEOREF_ANNOTATION_CANVAS,
   GEOREF_ANNOTATION_IMAGE_SERVICE,
   IMAGE_SERVICE_V2_ID,
+  IMAGE_SERVICE_V3_ID,
 } from "src/fixtures/georef";
 import {
   adaptGeoreferenceAnnotationForOverlay,
@@ -112,15 +113,12 @@ describe("getImageServiceId", () => {
     });
   });
 
-  it("falls back to the first service id (assumes v2) when no type matches", () => {
+  it("returns undefined when a service id has no ImageService type", () => {
     expect(
       getImageServiceId({
         service: [{ id: "https://iiif.example.org/image/x" }],
       }),
-    ).toEqual({
-      id: "https://iiif.example.org/image/x",
-      type: "ImageService2",
-    });
+    ).toBeUndefined();
   });
 
   it("returns undefined when there is no service", () => {
@@ -258,6 +256,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       GEOREF_ANNOTATION_CANVAS,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(adapted.target.source).toEqual({
       id: IMAGE_SERVICE_V2_ID,
@@ -271,6 +270,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       GEOREF_ANNOTATION_CANVAS,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(adapted).toEqual(GEOREF_ANNOTATION_IMAGE_SERVICE);
   });
@@ -279,6 +279,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       GEOREF_ANNOTATION_CANVAS,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(adapted.body.features).toEqual(
       GEOREF_ANNOTATION_CANVAS.body.features,
@@ -289,6 +290,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       GEOREF_ANNOTATION_CANVAS,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(adapted.target.selector).toEqual(
       GEOREF_ANNOTATION_CANVAS.target.selector,
@@ -297,7 +299,11 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
 
   it("does not mutate the input annotation", () => {
     const clone = JSON.parse(JSON.stringify(GEOREF_ANNOTATION_CANVAS));
-    adaptGeoreferenceAnnotationForOverlay(clone, IMAGE_SERVICE_V2_ID);
+    adaptGeoreferenceAnnotationForOverlay(
+      clone,
+      IMAGE_SERVICE_V2_ID,
+      "ImageService2",
+    );
     expect(clone.target.source.type).toBe("Canvas");
     expect(clone.target.source.id).toBe(CANVAS_ID);
   });
@@ -311,6 +317,17 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     expect(adapted.target.source.type).toBe("ImageService3");
   });
 
+  it("defaults to ImageService3", () => {
+    const adapted = adaptGeoreferenceAnnotationForOverlay(
+      GEOREF_ANNOTATION_CANVAS,
+      IMAGE_SERVICE_V3_ID,
+    );
+    expect(adapted.target.source).toMatchObject({
+      id: IMAGE_SERVICE_V3_ID,
+      type: "ImageService3",
+    });
+  });
+
   it("passes through undefined dimensions when the original source omitted them", () => {
     const noSize = {
       ...GEOREF_ANNOTATION_CANVAS,
@@ -322,6 +339,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       noSize,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(adapted.target.source.width).toBeUndefined();
     expect(adapted.target.source.height).toBeUndefined();
@@ -331,6 +349,7 @@ describe("adaptGeoreferenceAnnotationForOverlay", () => {
     const adapted = adaptGeoreferenceAnnotationForOverlay(
       GEOREF_ANNOTATION_CANVAS,
       IMAGE_SERVICE_V2_ID,
+      "ImageService2",
     );
     expect(parseGeoreferenceAnnotation(adapted)).toEqual(EXPECTED_GCPS);
   });

--- a/src/lib/georef-helpers.ts
+++ b/src/lib/georef-helpers.ts
@@ -1,0 +1,452 @@
+/**
+ * Helpers for the IIIF Georeference Extension and navPlace Extension.
+ *
+ * Georeference spec: https://iiif.io/api/extension/georef/
+ * navPlace spec:     https://iiif.io/api/extension/navplace/
+ */
+
+import { InternationalString } from "@iiif/presentation-3";
+
+// ── JSON-LD context URIs ──────────────────────────────────────────────────────
+
+export const GEOREFERENCE_CONTEXT =
+  "http://iiif.io/api/extension/georef/1/context.json";
+export const NAV_PLACE_CONTEXT =
+  "http://iiif.io/api/extension/navplace/context.json";
+export const PRESENTATION_CONTEXT =
+  "http://iiif.io/api/presentation/3/context.json";
+
+// ── Types: Georeference Extension ────────────────────────────────────────────
+
+/** A single Ground Control Point (GCP): one image pixel ↔ one geographic coordinate. */
+export interface GroundControlPoint {
+  id?: string;
+  /** Image pixel coordinates as [x, y]. */
+  resourceCoords: [number, number];
+  /** Geographic coordinates as [longitude, latitude] (WGS-84). */
+  geoCoords: [number, number];
+}
+
+/** The `source` of a Georeference Annotation target. */
+export interface GeoreferenceAnnotationSource {
+  id: string;
+  type: string; // e.g. "Canvas" | "ImageService2" | "ImageService3"
+  width?: number;
+  height?: number;
+}
+
+/**
+ * A IIIF Georeference Extension annotation.
+ * https://iiif.io/api/extension/georef/
+ *
+ * The `body` is a GeoJSON FeatureCollection whose Features each carry:
+ *   - `properties.resourceCoords`: image pixel [x, y]
+ *   - `geometry.coordinates`:      geographic [longitude, latitude]
+ */
+export interface GeoreferenceAnnotation {
+  "@context"?: string | string[];
+  id?: string;
+  type: "Annotation";
+  motivation: "georeferencing";
+  target: {
+    type: "SpecificResource";
+    source: GeoreferenceAnnotationSource;
+    selector?: {
+      type: "SvgSelector";
+      value: string;
+    };
+  };
+  body: GeoJSON.FeatureCollection;
+}
+
+// ── Types: navPlace Extension ─────────────────────────────────────────────────
+
+/**
+ * A navPlace GeoJSON FeatureCollection.
+ * Feature `properties.label` / `properties.summary` may be IIIF InternationalStrings.
+ * https://iiif.io/api/extension/navplace/
+ */
+export type NavPlaceGeoJSON =
+  | GeoJSON.FeatureCollection
+  | GeoJSON.Feature
+  | GeoJSON.Geometry;
+
+export type NavPlaceResourceLevel =
+  | "Collection"
+  | "Manifest"
+  | "Canvas"
+  | "Annotation";
+
+export type NavPlaceDisplayLevel = NavPlaceResourceLevel | "auto" | "all";
+
+export interface NavPlaceResourceContext {
+  id?: string;
+  type?: NavPlaceResourceLevel | string;
+  label?: string | InternationalString | null;
+  summary?: string | InternationalString | null;
+  thumbnail?: string;
+  homepage?: string;
+  parent?: NavPlaceResourceContext;
+}
+
+export type EnrichedNavPlaceProperties =
+  NonNullable<GeoJSON.GeoJsonProperties> & {
+    iiifResource?: NavPlaceResourceContext;
+  };
+
+export type EnrichedNavPlaceFeature = GeoJSON.Feature<
+  GeoJSON.Geometry,
+  EnrichedNavPlaceProperties
+>;
+
+export interface ExtractNavPlaceFeaturesOptions {
+  levels?: NavPlaceResourceLevel[];
+  parent?: NavPlaceResourceContext;
+}
+
+// ── Georeference helpers ──────────────────────────────────────────────────────
+
+/**
+ * Extract Ground Control Points from a IIIF Georeference Extension annotation.
+ * Features with missing or non-numeric coordinates are silently skipped.
+ */
+export function parseGeoreferenceAnnotation(
+  annotation: GeoreferenceAnnotation | null | undefined,
+): GroundControlPoint[] {
+  if (!annotation) return [];
+
+  const features = Array.isArray(annotation?.body?.features)
+    ? annotation.body.features
+    : [];
+
+  return features.reduce<GroundControlPoint[]>((acc, feature, index) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const props = (feature?.properties ?? {}) as any;
+    const resourceCoords = props.resourceCoords;
+    const geoCoords =
+      feature?.geometry?.type === "Point"
+        ? (feature.geometry as GeoJSON.Point).coordinates
+        : null;
+
+    if (!Array.isArray(resourceCoords) || !Array.isArray(geoCoords)) {
+      return acc;
+    }
+
+    const rc: [number, number] = [
+      Number(resourceCoords[0]),
+      Number(resourceCoords[1]),
+    ];
+    const gc: [number, number] = [Number(geoCoords[0]), Number(geoCoords[1])];
+
+    if (rc.some(Number.isNaN) || gc.some(Number.isNaN)) return acc;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    acc.push({
+      id: (feature as any).id ?? `gcp-${index}`,
+      resourceCoords: rc,
+      geoCoords: gc,
+    });
+    return acc;
+  }, []);
+}
+
+/**
+ * Adapt a stored Georeference Annotation for use with @allmaps/leaflet.
+ *
+ * For annotations that use `"type": "Canvas"` for their target source.
+ * @allmaps/leaflet requires an IIIF Image API endpoint (`"type": "ImageService2"`
+ * or `"ImageService3"`).  Call this helper to swap the source before passing
+ * `georefAnnotation` + `showImageOverlay` to `<Map>`.
+ *
+ * @param annotation  The stored georef annotation (Canvas source).
+ * @param imageServiceId  Base URL of the IIIF Image API for this canvas
+ *   (e.g. `"https://iiif.example.edu/iiif/2/<id>"` for v2,
+ *    or `"https://iiif.example.edu/iiif/3/<id>"` for v3).
+ * @param serviceType  IIIF Image API version string. Defaults to `"ImageService2"`.
+ */
+export function adaptGeoreferenceAnnotationForOverlay(
+  annotation: GeoreferenceAnnotation,
+  imageServiceId: string,
+  serviceType: "ImageService2" | "ImageService3" = "ImageService2",
+): GeoreferenceAnnotation {
+  return {
+    ...annotation,
+    target: {
+      ...annotation.target,
+      source: {
+        id: imageServiceId,
+        type: serviceType,
+        width: annotation.target.source.width,
+        height: annotation.target.source.height,
+      },
+    },
+  };
+}
+
+/**
+ * Type guard for a IIIF Georeference Extension annotation. Accepts a plain
+ * annotation object (as embedded in a Canvas annotation page) and returns true
+ * when it carries `motivation: "georeferencing"` and a FeatureCollection body.
+ */
+export function isGeoreferenceAnnotation(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  annotation: any,
+): annotation is GeoreferenceAnnotation {
+  if (!annotation || typeof annotation !== "object") return false;
+
+  const motivation = annotation.motivation;
+  const hasGeoreferencing = Array.isArray(motivation)
+    ? motivation.includes("georeferencing")
+    : motivation === "georeferencing";
+
+  return hasGeoreferencing && annotation?.body?.type === "FeatureCollection";
+}
+
+/**
+ * Extract the IIIF Image API service id from a painting annotation body.
+ * Handles Presentation 3 (`service[].id` + `type`) and Presentation 2
+ * (`service[].@id` + `@type`) shapes, returning the first service whose type
+ * is an ImageService (or the first service id as a fallback).
+ *
+ * @returns `{ id, type }` where `type` is `"ImageService2" | "ImageService3"`,
+ *   or `undefined` when no usable image service is present.
+ */
+export function getImageServiceId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  paintingBody: any,
+): { id: string; type: "ImageService2" | "ImageService3" } | undefined {
+  const services = paintingBody?.service;
+  if (!Array.isArray(services) || services.length === 0) return undefined;
+
+  for (const service of services) {
+    if (!service || typeof service !== "object") continue;
+
+    const id = service.id || service["@id"];
+    if (typeof id !== "string") continue;
+
+    const rawType = service.type || service["@type"];
+    const type = Array.isArray(rawType) ? rawType[0] : rawType;
+
+    if (type === "ImageService3") return { id, type: "ImageService3" };
+    if (type === "ImageService2") return { id, type: "ImageService2" };
+  }
+
+  // Fallback: first service with any id, assume v2.
+  for (const service of services) {
+    const id = service?.id || service?.["@id"];
+    if (typeof id === "string") return { id, type: "ImageService2" };
+  }
+
+  return undefined;
+}
+
+// ── navPlace helpers ──────────────────────────────────────────────────────────
+
+const GEO_GEOMETRY_TYPES = new Set<string>([
+  "Point",
+  "MultiPoint",
+  "LineString",
+  "MultiLineString",
+  "Polygon",
+  "MultiPolygon",
+  "GeometryCollection",
+]);
+
+/**
+ * Normalize any GeoJSON value (FeatureCollection, Feature, or bare geometry)
+ * to a FeatureCollection. Returns `null` if the value is not recognizable GeoJSON.
+ */
+export function normalizeNavPlace(
+  geoJson: NavPlaceGeoJSON | null | undefined,
+): GeoJSON.FeatureCollection | null {
+  if (!geoJson || typeof geoJson !== "object") return null;
+
+  if (geoJson.type === "FeatureCollection") {
+    return geoJson as GeoJSON.FeatureCollection;
+  }
+
+  if (geoJson.type === "Feature") {
+    return {
+      type: "FeatureCollection",
+      features: [geoJson as GeoJSON.Feature],
+    };
+  }
+
+  if (GEO_GEOMETRY_TYPES.has(geoJson.type)) {
+    return {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: geoJson as GeoJSON.Geometry,
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Extract a display string from a navPlace Feature property that may be a
+ * plain string or a IIIF InternationalString.
+ */
+export function getNavPlaceLabel(
+  label: string | InternationalString | null | undefined,
+): string {
+  if (!label) return "";
+  if (typeof label === "string") return label;
+
+  const values = Object.values(label as Record<string, string[]>).find(
+    (entry): entry is string[] => Array.isArray(entry) && entry.length > 0,
+  );
+  return values?.[0] ?? "";
+}
+
+function isNavPlaceResourceLevel(type: string): type is NavPlaceResourceLevel {
+  return ["Collection", "Manifest", "Canvas", "Annotation"].includes(type);
+}
+
+function getFirstThumbnailUrl(thumbnail: unknown): string | undefined {
+  if (!thumbnail) return undefined;
+
+  if (typeof thumbnail === "string") return thumbnail;
+
+  const thumbnailList = Array.isArray(thumbnail) ? thumbnail : [thumbnail];
+  const first = thumbnailList.find(Boolean);
+
+  if (!first || typeof first !== "object") return undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const resource = first as any;
+  if (typeof resource.id === "string") return resource.id;
+  if (typeof resource["@id"] === "string") return resource["@id"];
+
+  return undefined;
+}
+
+function getFirstHomepageUrl(homepage: unknown): string | undefined {
+  if (!homepage) return undefined;
+
+  if (typeof homepage === "string") return homepage;
+
+  const homepageList = Array.isArray(homepage) ? homepage : [homepage];
+  const first = homepageList.find(Boolean);
+
+  if (!first || typeof first !== "object") return undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const resource = first as any;
+  if (typeof resource.id === "string") return resource.id;
+  if (typeof resource["@id"] === "string") return resource["@id"];
+
+  return undefined;
+}
+
+function getNavPlaceResourceContext(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resource: any,
+  parent?: NavPlaceResourceContext,
+): NavPlaceResourceContext | undefined {
+  if (!resource || typeof resource !== "object") return undefined;
+
+  const rawType = resource.type || resource["@type"];
+  const type = Array.isArray(rawType) ? rawType[0] : rawType;
+  const id = resource.id || resource["@id"];
+
+  return {
+    id,
+    type,
+    label: resource.label ?? null,
+    summary: resource.summary ?? null,
+    thumbnail: getFirstThumbnailUrl(resource.thumbnail),
+    homepage: getFirstHomepageUrl(resource.homepage),
+    parent,
+  };
+}
+
+function enrichNavPlaceFeature(
+  feature: GeoJSON.Feature,
+  context?: NavPlaceResourceContext,
+): EnrichedNavPlaceFeature {
+  return {
+    ...feature,
+    properties: {
+      ...(feature.properties ?? {}),
+      ...(context ? { iiifResource: context } : {}),
+    },
+  } as EnrichedNavPlaceFeature;
+}
+
+function getChildResources(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resource: any,
+): unknown[] {
+  if (!resource || typeof resource !== "object") return [];
+
+  return [
+    resource.items,
+    resource.annotations,
+    resource.manifests,
+    resource.members,
+  ]
+    .filter(Array.isArray)
+    .flat();
+}
+
+/**
+ * Extract navPlace features from IIIF Presentation resources and annotate each
+ * feature with the resource that supplied it. This keeps map popups tied to the
+ * Collection, Manifest, Canvas, or Annotation context instead of reducing the
+ * feature to label-only GeoJSON.
+ */
+export function extractNavPlaceFeatures(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resource: any,
+  options: ExtractNavPlaceFeaturesOptions = {},
+): EnrichedNavPlaceFeature[] {
+  if (!resource || typeof resource !== "object") return [];
+
+  const rawType = resource.type || resource["@type"];
+  const type = Array.isArray(rawType) ? rawType[0] : rawType;
+  const context = getNavPlaceResourceContext(resource, options.parent);
+  const levels = options.levels;
+  const shouldInclude =
+    typeof type === "string" &&
+    isNavPlaceResourceLevel(type) &&
+    (!levels?.length || levels.includes(type));
+
+  const features: EnrichedNavPlaceFeature[] = [];
+
+  if (shouldInclude) {
+    const featureCollection = normalizeNavPlace(resource.navPlace);
+    if (featureCollection?.features?.length) {
+      features.push(
+        ...featureCollection.features.map((feature) =>
+          enrichNavPlaceFeature(feature, context),
+        ),
+      );
+    }
+  }
+
+  getChildResources(resource).forEach((child) => {
+    features.push(
+      ...extractNavPlaceFeatures(child, {
+        ...options,
+        parent: context ?? options.parent,
+      }),
+    );
+  });
+
+  return features;
+}
+
+export function createNavPlaceFeatureCollection(
+  features: GeoJSON.Feature[],
+): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}

--- a/src/lib/georef-helpers.ts
+++ b/src/lib/georef-helpers.ts
@@ -162,12 +162,12 @@ export function parseGeoreferenceAnnotation(
  * @param imageServiceId  Base URL of the IIIF Image API for this canvas
  *   (e.g. `"https://iiif.example.edu/iiif/2/<id>"` for v2,
  *    or `"https://iiif.example.edu/iiif/3/<id>"` for v3).
- * @param serviceType  IIIF Image API version string. Defaults to `"ImageService2"`.
+ * @param serviceType  IIIF Image API version string. Defaults to `"ImageService3"`.
  */
 export function adaptGeoreferenceAnnotationForOverlay(
   annotation: GeoreferenceAnnotation,
   imageServiceId: string,
-  serviceType: "ImageService2" | "ImageService3" = "ImageService2",
+  serviceType: "ImageService2" | "ImageService3" = "ImageService3",
 ): GeoreferenceAnnotation {
   return {
     ...annotation,
@@ -204,9 +204,9 @@ export function isGeoreferenceAnnotation(
 
 /**
  * Extract the IIIF Image API service id from a painting annotation body.
- * Handles Presentation 3 (`service[].id` + `type`) and Presentation 2
+ * Handles Presentation 3 (`service[].id` + `type`) and legacy
  * (`service[].@id` + `@type`) shapes, returning the first service whose type
- * is an ImageService (or the first service id as a fallback).
+ * is an ImageService.
  *
  * @returns `{ id, type }` where `type` is `"ImageService2" | "ImageService3"`,
  *   or `undefined` when no usable image service is present.
@@ -229,12 +229,6 @@ export function getImageServiceId(
 
     if (type === "ImageService3") return { id, type: "ImageService3" };
     if (type === "ImageService2") return { id, type: "ImageService2" };
-  }
-
-  // Fallback: first service with any id, assume v2.
-  for (const service of services) {
-    const id = service?.id || service?.["@id"];
-    if (typeof id === "string") return { id, type: "ImageService2" };
   }
 
   return undefined;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,48 @@
 import { parseAnnotationTarget } from "./annotation-helpers";
 import { createOpenSeadragonRect } from "./openseadragon-helpers";
+import {
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  getNavPlaceLabel,
+  isGeoreferenceAnnotation,
+  normalizeNavPlace,
+  parseGeoreferenceAnnotation,
+} from "./georef-helpers";
 
-export { parseAnnotationTarget, createOpenSeadragonRect };
-const helpers = { parseAnnotationTarget, createOpenSeadragonRect };
+export {
+  parseAnnotationTarget,
+  createOpenSeadragonRect,
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  getNavPlaceLabel,
+  isGeoreferenceAnnotation,
+  normalizeNavPlace,
+  parseGeoreferenceAnnotation,
+};
+export type {
+  GeoreferenceAnnotation,
+  GeoreferenceAnnotationSource,
+  GroundControlPoint,
+  NavPlaceDisplayLevel,
+  NavPlaceGeoJSON,
+  NavPlaceResourceContext,
+  NavPlaceResourceLevel,
+} from "./georef-helpers";
+
+const helpers = {
+  parseAnnotationTarget,
+  createOpenSeadragonRect,
+  adaptGeoreferenceAnnotationForOverlay,
+  createNavPlaceFeatureCollection,
+  extractNavPlaceFeatures,
+  getImageServiceId,
+  getNavPlaceLabel,
+  isGeoreferenceAnnotation,
+  normalizeNavPlace,
+  parseGeoreferenceAnnotation,
+};
 export default helpers;


### PR DESCRIPTION
## Summary

Adds first-class geographic support to Clover IIIF: a standalone `<Map />` component, plus a `Map` display mode inside the `<Viewer />` that renders `navPlace` geometry and warps Georeference Annotation images onto the map.

### Standalone `<Map />` component (`clover-iiif/map`)
- Renders IIIF resources on a Leaflet map using `navPlace` GeoJSON and/or Georeference Annotations, with an optional warped image overlay.
- Accepts navPlace directly, or via `iiifContent` (URL or prefetched object) with a `navPlaceLevel` (`Collection | Manifest | Canvas | Annotation | all`) to control which level's features are extracted; popups are enriched with the source resource's label, summary, thumbnail, and homepage.
- Delegates navPlace geometry rendering to Leaflet's `L.geoJSON()`, which natively handles all 7 GeoJSON geometry types: `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `GeometryCollection`.
- Accepts **multiple** Georeference Annotations via `georefAnnotations[]` (alongside the single `georefAnnotation`), hosting every warped sheet in one `WarpedMapLayer` so adjacent maps tile together.

### Viewer integration (`options.map`)
- New opt-in `Map` canvas display: `options.map.enabled`.
- `navPlaceLevel` (`auto | Collection | Manifest | Canvas | Annotation | all`) chooses which level supplies geometry; `auto` resolves the most specific available (Annotation → Canvas → Manifest → Collection).
- Image overlays: `showImageOverlay`, `imageOverlayOpacity`, `showControlPoints`, and `overlayScope` (`manifest` warps every georeferenced canvas in the manifest at once; `canvas` follows the active canvas).
- The Viewer auto-discovers `motivation: "georeferencing"` annotations on the in-scope canvases and auto-adapts Canvas-sourced annotations to each canvas's painting image service (no manual image-service URL needed); a `target.selector` is preserved or synthesized as required by `@allmaps/leaflet`.

### Helpers (`src/lib/georef-helpers`)
- `parseGeoreferenceAnnotation`, `normalizeNavPlace`, `getNavPlaceLabel`, `adaptGeoreferenceAnnotationForOverlay`, `extractNavPlaceFeatures`, `createNavPlaceFeatureCollection`, `isGeoreferenceAnnotation`, `getImageServiceId`.
- Exported types: `GeoreferenceAnnotation`, `GeoreferenceAnnotationSource`, `GroundControlPoint`, `NavPlaceGeoJSON`, `NavPlaceDisplayLevel`, `NavPlaceResourceLevel`, `NavPlaceResourceContext`.

### Packaging
- Wires up the new subpath export, Vite build entry, and TS path mapping.
- Marks `@allmaps/leaflet` as external so the ~800 kB overlay code is only pulled in when `showImageOverlay` is used.

### Docs
- Beta-tagged `/docs/map` page documenting the standalone component (navPlace geometry types, Georeference overlays, coordinate picking, full API reference).
- New `/docs/viewer/map` page demonstrating every `navPlaceLevel` permutation (Canvas, Manifest, Collection, all, auto) and the multi-sheet image-overlay workflow, plus updates to `/docs/viewer` and the `Map` sidebar entry.

## Testing
- Unit tests for the georef helpers and the `<Map />` component (including multi-annotation overlays).
- Viewer/`Painting` tests covering navPlace level resolution and georef discovery/adaptation across `overlayScope` settings.
- Verified the Viewer overlay end-to-end in the browser (two adjacent NUL plat maps tiling together with navPlace geometry, no console errors).

Screenshot of the documentation at `/docs/map`:
<img width="1597" height="938" alt="clover-map-docs" src="https://github.com/user-attachments/assets/1e9ffcda-e175-43e1-b475-43462d1d189b" />


Screenshot of the documentation at `docs/viewer/map`:
<img width="1527" height="1061" alt="clover-viewer-map-docs" src="https://github.com/user-attachments/assets/9c802483-6f9a-4de3-9d02-33bffa388288" />

Example of the `Viewer` with tiling georeferenced overlays:
<img width="1432" height="845" alt="clover-viewer-map-docs-overlays" src="https://github.com/user-attachments/assets/7c26e781-0544-47bc-8098-9f928259bdee" />
