### PR TITLE
fork iiif to forward web component options to react

### DIFF
--- a/src/components/UI/Icons/Open.tsx
+++ b/src/components/UI/Icons/Open.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const Open: React.FC = () => (
+  <>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M384 224v184a40 40 0 01-40 40H104a40 40 0 01-40-40V168a40 40 0 0140-40h184"
+    />
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M336 64h112v112M244 268L440 72"
+    />
+  </>
+);
+
+export default Open;

--- a/src/web-components/clover-viewer.tsx
+++ b/src/web-components/clover-viewer.tsx
@@ -2,9 +2,11 @@ import React, { useLayoutEffect, useRef } from "react";
 
 import Viewer from "src/components/Viewer";
 import register from "src/lib/preact-custom-element/preact-custom-element";
+import { ViewerConfigOptions } from "src/context/viewer-context";
 
 interface CloverViewerAttributes {
   id: string;
+  options?: ViewerConfigOptions;
   /** IIIF Manifest/Collection URL or content state */
   'iiif-content'?: string;
 }
@@ -19,7 +21,11 @@ function CloverViewerWebComponent(
   props: CloverViewerWCProps & CloverViewerAttributes,
 ) {
   const webComponent = useRef<HTMLElement>();
-  const { id } = props;
+  const { id, options } = props;
+
+  const parsedOptions = JSON.parse(options as string);
+  console.log("OPTIONS =====> ", parsedOptions);
+
   const iiifContent = props['iiif-content'];
 
   useLayoutEffect(() => {
@@ -31,7 +37,7 @@ function CloverViewerWebComponent(
   }, []);
 
   // @ts-ignore
-  return <Viewer id={id} iiifContent={iiifContent as any} />;
+  return <Viewer id={id} iiifContent={iiifContent as any} options={parsedOptions} />;
 }
 
 const cloverViewerWCProps = ["id", "iiif-content"];

--- a/src/web-components/clover-viewer.tsx
+++ b/src/web-components/clover-viewer.tsx
@@ -8,12 +8,12 @@ interface CloverViewerAttributes {
   id: string;
   options?: ViewerConfigOptions;
   /** IIIF Manifest/Collection URL or content state */
-  'iiif-content'?: string;
+  "iiif-content"?: string;
 }
 
 interface CloverViewerWCProps {
   id: string;
-  'iiif-content'?: string;
+  "iiif-content"?: string;
   __registerPublicApi: (component: any) => void;
 }
 
@@ -22,11 +22,8 @@ function CloverViewerWebComponent(
 ) {
   const webComponent = useRef<HTMLElement>();
   const { id, options } = props;
-
   const parsedOptions = JSON.parse(options as string);
-  console.log("OPTIONS =====> ", parsedOptions);
-
-  const iiifContent = props['iiif-content'];
+  const iiifContent = props["iiif-content"];
 
   useLayoutEffect(() => {
     if (props.__registerPublicApi) {
@@ -37,7 +34,9 @@ function CloverViewerWebComponent(
   }, []);
 
   // @ts-ignore
-  return <Viewer id={id} iiifContent={iiifContent as any} options={parsedOptions} />;
+  return (
+    <Viewer id={id} iiifContent={iiifContent as any} options={parsedOptions} />
+  );
 }
 
 const cloverViewerWCProps = ["id", "iiif-content"];


### PR DESCRIPTION
- little fork branch that allows us to use options API through clover-viewer in our web components (still just top level). this lets us pass through the json options outlined in clover react docs: https://samvera-labs.github.io/clover-iiif/docs/viewer#api-reference - there may be some parsing quirks to sort out but it does the trick for us! 

cc @mathewjordan ! just a fun first look at the simplest route to get options passed through from the outer web component layer reliably through to the underlying preact widget

btw- this is only a fork since i didn't wanna bug you or assume i have permission to push to the repo directly. we can talk more about that as we establish a good workflow. 

thanks for all the help mat, can't wait to meet ya in the beautiful netherlands next week!