### PR TITLE
Fix information panel visibility for plugin tabs

### DIFF
--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -7,6 +7,7 @@ import { render, screen } from "@testing-library/react";
 import { AnnotationResources } from "src/types/annotations";
 import InformationPanel from "../InformationPanel/InformationPanel";
 import Painting from "src/components/Viewer/Painting/Painting";
+import { type PluginConfig } from "src/context/viewer-context";
 import React from "react";
 
 vi.mock("@radix-ui/react-collapsible");
@@ -101,6 +102,41 @@ describe("ViewerContent with no Annotation Resources", () => {
       </ViewerProvider>,
     );
     expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+
+  test("renders InformationPanel when a plugin provides an information panel tab", () => {
+    const PluginInformationPanel = () => <div>Plugin Information</div>;
+    const plugins: PluginConfig[] = [
+      {
+        id: "plugin-panel",
+        informationPanel: {
+          component: PluginInformationPanel,
+          label: { en: ["Plugin"] },
+        },
+      },
+    ];
+
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          isInformationOpen: true,
+          plugins,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              renderAbout: false,
+              renderAnnotation: false,
+              renderToggle: true,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
+
+    expect(screen.getByTestId("mock-information-panel")).toBeInTheDocument();
   });
 });
 

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -20,6 +20,7 @@ import Painting from "../Painting/Painting";
 import React, { useRef, useState } from "react";
 import { useViewerDispatch, useViewerState } from "src/context/viewer-context";
 import { useCloverTranslation } from "src/i18n/useCloverTranslation";
+import { setupPlugins } from "src/lib/plugin-helpers";
 
 export interface ViewerContentProps {
   activeCanvas: string;
@@ -52,6 +53,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     contentStateAnnotation,
     isInformationOpen,
     configOptions,
+    plugins,
     sequence,
     visibleCanvases,
   } = useViewerState();
@@ -73,17 +75,17 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     annotationResources.length > 0 ||
     // @ts-ignore
     visibleCanvasesIds.includes(contentStateAnnotation?.target?.source?.id);
+  const hasContentSearch =
+    informationPanel?.renderContentSearch && contentSearchResource;
+  const hasPluginInformationPanel =
+    setupPlugins(plugins).pluginsWithInfoPanel.length > 0;
+  const hasInformationPanelContent =
+    informationPanel?.renderAbout ||
+    (informationPanel?.renderAnnotation && hasAnnotations) ||
+    hasContentSearch ||
+    hasPluginInformationPanel;
 
-  // Only force the aside open for annotations when no toggle is rendered.
-  // If a toggle is visible, it must control open/close behavior.
-  const isForcedAside =
-    hasAnnotations &&
-    informationPanel?.renderAnnotation &&
-    informationPanel?.renderToggle === false &&
-    isInformationOpen;
-
-  const isAside =
-    (informationPanel?.renderAbout && isInformationOpen) || isForcedAside;
+  const isAside = Boolean(isInformationOpen && hasInformationPanelContent);
 
   const renderToggle = informationPanel?.renderToggle;
 


### PR DESCRIPTION
## Summary
- render the viewer information panel when plugins provide information panel tabs, even when the built-in About and Annotation tabs are disabled
- add a regression test covering `renderAbout: false` with a plugin-provided information panel tab

Fixes #306

## Testing
- `npm run test:ci -- src/components/Viewer/Viewer/Content.test.tsx`
- `npm run test:ci`
- `npm run build`
- `npx prettier --check src/components/Viewer/Viewer/Content.tsx src/components/Viewer/Viewer/Content.test.tsx`

## Notes
- `npm run typecheck` currently fails on the upstream baseline with existing test type errors outside this change (`src/components/Image/OSD/OSD.test.tsx`, `src/components/Scroll/Items/Item.test.tsx`, `src/components/Scroll/Panel/Panel.test.tsx`, `src/components/Slider/Items/Items.test.tsx`).
- `npm run lint` currently fails on the upstream baseline because Prettier reports existing formatting issues across unrelated files; the files changed by this PR pass Prettier check.
