### PR TITLE
Add language option to Viewer for metadata display

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -369,6 +369,7 @@ const MyCustomViewer = () => {
 | `options.canvasHeight`           | `string` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/height)                                                                          | No       | `500px`                                  |
 | `options.crossOrigin`            | `anonymous`, `use-credentials`, or `undefined` [crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) | No       | `anonymous`                              |
 | `options.ignoreCaptionLabels`    | `string[]`                                                                                                                                       | No       | []                                       |
+| `options.language`               | `string` [BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language tag, [See Language](#language)                 | No       |                                          |
 | `options.openSeadragon`          | `OpenSeadragon.Options`                                                                                                                          | No       |                                          |
 | `options.map`                    | [See Map Display](#map-display)                                                                                                                  | No       |                                          |
 | `options.informationPanel`       | [See Information Panel](#information-panel)                                                                                                      | No       |                                          |
@@ -384,6 +385,16 @@ const MyCustomViewer = () => {
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.
 - Option `options.openSeadragon` will grant you ability to override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within the Clover IIIF Viewer to adjust touch and mouse gesture settings and various other configurations.
+
+### Language
+
+IIIF Presentation API properties such as `label`, `summary`, `metadata`, and `requiredStatement` may provide values in multiple languages ([language of property values](https://iiif.io/api/presentation/3.0/#44-language-of-property-values)). By default, the Viewer renders the first available language. Set `options.language` to a [BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language tag (ex: `en`, `nl`, `zh`) to select which translation the information panel _About_ tab displays for the Manifest summary, metadata, required statement, and thumbnail alternative text. If the requested language is not present on a property, the Viewer falls back to the first available language.
+
+```jsx
+const options = {
+  language: "nl",
+};
+```
 
 ### Map Display
 

--- a/src/components/Viewer/InformationPanel/About/About.tsx
+++ b/src/components/Viewer/InformationPanel/About/About.tsx
@@ -25,7 +25,8 @@ import { PrimitivesExternalWebResource } from "src/types/primitives";
 
 const About: React.FC = () => {
   const viewerState: ViewerContextStore = useViewerState();
-  const { activeManifest, vault } = viewerState;
+  const { activeManifest, vault, configOptions } = viewerState;
+  const { language } = configOptions;
 
   const [manifest, setManifest] = useState<ManifestNormalized>();
 
@@ -78,10 +79,14 @@ const About: React.FC = () => {
           thumbnail={thumbnail}
           label={manifest.label}
           objectFit="contain"
+          language={language}
         />
-        <Summary summary={manifest.summary} />
-        <Metadata metadata={manifest.metadata} />
-        <RequiredStatement requiredStatement={manifest.requiredStatement} />
+        <Summary summary={manifest.summary} language={language} />
+        <Metadata metadata={manifest.metadata} language={language} />
+        <RequiredStatement
+          requiredStatement={manifest.requiredStatement}
+          language={language}
+        />
         <Rights rights={manifest.rights} />
         <Homepage homepage={homepage} />
         <SeeAlso seeAlso={seeAlso} />

--- a/src/components/Viewer/Properties/Metadata.tsx
+++ b/src/components/Viewer/Properties/Metadata.tsx
@@ -5,17 +5,23 @@ import { Metadata } from "src/components/Primitives";
 interface PropertiesMetadataProps {
   metadata: MetadataItem[] | null;
   parent?: "manifest" | "canvas";
+  language?: string;
 }
 
 const PropertiesMetadata: React.FC<PropertiesMetadataProps> = ({
   metadata,
   parent = "manifest",
+  language,
 }) => {
   if (!metadata) return <></>;
 
   return (
     <>
-      <Metadata metadata={metadata} id={`iiif-${parent}-metadata`} />
+      <Metadata
+        metadata={metadata}
+        id={`iiif-${parent}-metadata`}
+        lang={language}
+      />
     </>
   );
 };

--- a/src/components/Viewer/Properties/RequiredStatement.tsx
+++ b/src/components/Viewer/Properties/RequiredStatement.tsx
@@ -2,15 +2,15 @@ import { MetadataItem } from "@iiif/presentation-3";
 import React from "react";
 import { RequiredStatement } from "src/components/Primitives";
 
-interface PropertiesSummaryProps {
+interface PropertiesRequiredStatementProps {
   requiredStatement: MetadataItem | null;
   parent?: "manifest" | "canvas";
+  language?: string;
 }
 
-const PropertiesRequiredStatement: React.FC<PropertiesSummaryProps> = ({
-  requiredStatement,
-  parent = "manifest",
-}) => {
+const PropertiesRequiredStatement: React.FC<
+  PropertiesRequiredStatementProps
+> = ({ requiredStatement, parent = "manifest", language }) => {
   if (!requiredStatement) return <></>;
 
   return (
@@ -18,6 +18,7 @@ const PropertiesRequiredStatement: React.FC<PropertiesSummaryProps> = ({
       <RequiredStatement
         requiredStatement={requiredStatement}
         id={`iiif-${parent}-required-statement`}
+        lang={language}
       />
     </>
   );

--- a/src/components/Viewer/Properties/Summary.tsx
+++ b/src/components/Viewer/Properties/Summary.tsx
@@ -5,17 +5,24 @@ import { Summary } from "src/components/Primitives";
 interface PropertiesSummaryProps {
   summary: InternationalString | null;
   parent?: "manifest" | "canvas";
+  language?: string;
 }
 
 const PropertiesSummary: React.FC<PropertiesSummaryProps> = ({
   summary,
   parent = "manifest",
+  language,
 }) => {
   if (!summary) return <></>;
 
   return (
     <>
-      <Summary summary={summary} as="p" id={`iiif-${parent}-summary`} />
+      <Summary
+        summary={summary}
+        as="p"
+        id={`iiif-${parent}-summary`}
+        lang={language}
+      />
     </>
   );
 };

--- a/src/components/Viewer/Properties/Thumbnail.tsx
+++ b/src/components/Viewer/Properties/Thumbnail.tsx
@@ -10,12 +10,14 @@ interface PropertiesThumbnailProps {
   label: InternationalString | null;
   thumbnail: IIIFExternalWebResource[];
   objectFit?: "cover" | "contain";
+  language?: string;
 }
 
 const PropertiesThumbnail: React.FC<PropertiesThumbnailProps> = ({
   label,
   thumbnail,
   objectFit = "cover",
+  language,
 }) => {
   if (thumbnail?.length === 0) return <></>;
 
@@ -25,6 +27,7 @@ const PropertiesThumbnail: React.FC<PropertiesThumbnailProps> = ({
         altAsLabel={label ? label : { none: ["resource"] }}
         thumbnail={thumbnail}
         style={{ backgroundColor: "#6663", objectFit: objectFit }}
+        lang={language}
       />
     </>
   );

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -78,6 +78,13 @@ export type ViewerConfigOptions = {
       moreResults?: string;
     };
   };
+  /**
+   * Language code (BCP 47) for displaying IIIF metadata labels and values.
+   * Used to select the appropriate translation from InternationalString objects.
+   * Example: "en", "nl", "zh", "fr-CA"
+   * If not set or the language is not available, falls back to the first available language.
+   */
+  language?: string;
 };
 
 export type OverlayOptions = {


### PR DESCRIPTION
## What does this do?

Adds an optional `options.language` config option (a [BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language tag, e.g. `en`, `nl`, `zh`) to `ViewerConfigOptions`.

IIIF Presentation API properties (`label`, `summary`, `metadata`, `requiredStatement`) may carry values in multiple languages via `InternationalString` ([language of property values](https://iiif.io/api/presentation/3.0/#44-language-of-property-values)). Today the Viewer information panel always renders the first available language. This option lets integrators pin which translation the **About** tab displays for the Manifest summary, metadata, required statement, and thumbnail alternative text.

```jsx
<Viewer iiifContent={iiifContent} options={{ language: "nl" }} />
```

## Behavior

- When `options.language` is unset, behavior is unchanged (first available language).
- When the requested language is not present on a property, it falls back to the first available language (existing `getLabelAsString` / label-helpers behavior).
- Plumbs the value through the existing `lang` prop already supported by the Primitives components — no changes to Primitives themselves.

## Changes

- `ViewerConfigOptions`: new optional `language?: string` field (documented with TSDoc).
- `About` tab passes `language` to `Thumbnail`, `Summary`, `Metadata`, and `RequiredStatement` property components, which forward it as `lang` to Primitives.
- Docs: new **Language** section and API reference row in `pages/docs/viewer.mdx`.

## Testing

- `npm run test:ci` — 73 files, 307 tests passing
- `npm run prettier` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
