### PR TITLE
Type useViewerDispatch as a dispatch

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -1110,7 +1110,7 @@ export default function PluginButton(props) {
   const { openSeadragonViewer, activeManifest } = viewerState;
 
   // use useViewerDispatch to update viewer state
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
 
   function clickHandler() {
     dispatch({

--- a/src/components/Image/OSD/OSD.tsx
+++ b/src/components/Image/OSD/OSD.tsx
@@ -63,7 +63,7 @@ const OSD: React.FC<OSDProps> = ({
   const [srcDimensions, setSrcDimensions] = useState<
     Array<{ width: number; height: number }>
   >([]);
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const initializeOSD = useRef(false);
   const isFirstImageLoad = useRef(true);
   // Tracks which URIs are currently rendered in OSD so we can detect clip-only

--- a/src/components/Viewer/Collection/Collection.tsx
+++ b/src/components/Viewer/Collection/Collection.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { v4 as uuidv4 } from "uuid";
 
 const Collection: React.FC = () => {
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const viewerState: any = useViewerState();
 
   const { activeManifest, collection, configOptions, vault } = viewerState;

--- a/src/components/Viewer/InformationPanel/Annotation/Item.tsx
+++ b/src/components/Viewer/InformationPanel/Annotation/Item.tsx
@@ -52,7 +52,7 @@ export const AnnotationItem: React.FC<Props> = ({
   const thumbnail = `${targetResource}/${xywh}/!${computeSize(w, h)}/0/default.jpg`;
 
   const viewerState: ViewerContextStore = useViewerState();
-  const viewerDispatch: any = useViewerDispatch();
+  const viewerDispatch = useViewerDispatch();
 
   const { activeAnnotationId, openSeadragonViewer, vault, visibleCanvases } = viewerState;
 

--- a/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
+++ b/src/components/Viewer/InformationPanel/Annotation/VTT/Cue.tsx
@@ -36,7 +36,7 @@ const findScrollableParent = (
 };
 
 const Cue: React.FC<Props> = ({ html, text, start, end }) => {
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const {
     activePlayer,
     configOptions,

--- a/src/components/Viewer/InformationPanel/AnnotationCollection/Page.tsx
+++ b/src/components/Viewer/InformationPanel/AnnotationCollection/Page.tsx
@@ -30,7 +30,7 @@ const AnnotationCollectionPage: React.FC<Props> = ({
   annotationCollection,
 }) => {
   const viewerState: ViewerContextStore = useViewerState();
-  const viewerDispatch: any = useViewerDispatch();
+  const viewerDispatch = useViewerDispatch();
   const {
     activeAnnotationId,
     activeManifest,

--- a/src/components/Viewer/InformationPanel/InformationPanel.tsx
+++ b/src/components/Viewer/InformationPanel/InformationPanel.tsx
@@ -58,7 +58,7 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
   initialSearchQuery,
 }) => {
   const { t } = useCloverTranslation();
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const viewerState: ViewerContextStore = useViewerState();
   const {
     annotationCollection,
@@ -206,7 +206,7 @@ export const InformationPanel: React.FC<NavigatorProps> = ({
 
       dispatch({
         type: "updateUserScrolling",
-        isUserScrolling: timeout,
+        isUserScrolling: timeout as unknown as number,
       });
     }
   }

--- a/src/components/Viewer/Media/Media.tsx
+++ b/src/components/Viewer/Media/Media.tsx
@@ -30,7 +30,7 @@ interface MediaProps {
 
 const Media: React.FC<MediaProps> = ({ items }) => {
   const { t } = useCloverTranslation();
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const state: ViewerContextStore = useViewerState();
   const { activeCanvas, isPaged, vault, sequence, viewingDirection } = state;
 

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -138,7 +138,7 @@ const Painting: React.FC<PaintingProps> = ({
     // @ts-ignore
     Boolean(activeCanvas === contentStateAnnotation?.target?.source?.id);
 
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const normalizedCanvas: CanvasNormalized = vault.get(activeCanvas);
 
   const {

--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -36,7 +36,7 @@ const Player: React.FC<PlayerProps> = ({
     onEndedRef.current = onEnded;
   }, [onEnded]);
 
-  const viewerDispatch: any = useViewerDispatch();
+  const viewerDispatch = useViewerDispatch();
   const viewerState: ViewerContextStore = useViewerState();
 
   const {

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -55,7 +55,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     sequence,
     visibleCanvases,
   } = useViewerState();
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
   const { informationPanel } = configOptions;
   const { t } = useCloverTranslation();
 

--- a/src/components/Viewer/Viewer/Toggle.tsx
+++ b/src/components/Viewer/Viewer/Toggle.tsx
@@ -10,7 +10,7 @@ import { useCloverTranslation } from "src/i18n/useCloverTranslation";
 
 const Toggle = () => {
   const { isInformationOpen } = useViewerState();
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
 
   const { t } = useCloverTranslation();
 

--- a/src/components/Viewer/Viewer/Viewer.tsx
+++ b/src/components/Viewer/Viewer/Viewer.tsx
@@ -46,7 +46,7 @@ const Viewer: React.FC<ViewerProps> = ({
    * Viewer State
    */
   const viewerState: ViewerContextStore = useViewerState();
-  const viewerDispatch: any = useViewerDispatch();
+  const viewerDispatch = useViewerDispatch();
   const {
     activeCanvas,
     isInformationOpen,

--- a/src/components/Viewer/index.tsx
+++ b/src/components/Viewer/index.tsx
@@ -117,7 +117,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
   options,
   iiifContentSearchQuery,
 }) => {
-  const dispatch: any = useViewerDispatch();
+  const dispatch = useViewerDispatch();
 
   /**
    * Retrieve state set by the wrapping <ViewerProvider/> and make
@@ -509,7 +509,7 @@ const RenderViewer: React.FC<CloverViewerProps> = ({
         );
         dispatch({
           type: "updateCollection",
-          collection: iiifResource,
+          collection: iiifResource as CollectionNormalized,
         });
         if (manifestId) {
           dispatch({

--- a/src/context/viewer-context.test.tsx
+++ b/src/context/viewer-context.test.tsx
@@ -1,12 +1,13 @@
 import {
   AutoScrollSettings,
+  ViewerDispatch,
   ViewerProvider,
   defaultState,
   expandAutoScrollOptions,
   useViewerDispatch,
   useViewerState,
 } from "./viewer-context";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 
 import React from "react";
 
@@ -203,5 +204,44 @@ describe("AutoScroll Options", () => {
     const settings = { behavior: "instant", block: "end" };
     const result = expandAutoScrollOptions(settings as AutoScrollSettings);
     expect(result).toMatchObject({ enabled: true, settings });
+  });
+  test("useViewerDispatch returns a dispatch that updates state", async () => {
+    function CanvasConsumer() {
+      const { activeCanvas } = useViewerState();
+      const dispatch: ViewerDispatch = useViewerDispatch();
+
+      return (
+        <>
+          <span data-testid="active-canvas">{activeCanvas}</span>
+          <button
+            type="button"
+            onClick={() =>
+              dispatch({
+                type: "updateActiveCanvas",
+                canvasId: "https://example.org/canvas/2",
+              })
+            }
+          >
+            next
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <ViewerProvider>
+        <CanvasConsumer />
+      </ViewerProvider>,
+    );
+
+    act(() => {
+      screen.getByRole("button", { name: "next" }).click();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("active-canvas")).toHaveTextContent(
+        "https://example.org/canvas/2",
+      ),
+    );
   });
 });

--- a/src/context/viewer-context.test.tsx
+++ b/src/context/viewer-context.test.tsx
@@ -244,4 +244,15 @@ describe("AutoScroll Options", () => {
       ),
     );
   });
+  test("dispatch outside a provider is a no-op", () => {
+    // Image renders OSD without a provider, and OSD dispatches on image load.
+    function ProviderlessConsumer() {
+      const dispatch = useViewerDispatch();
+      dispatch({ type: "updateActiveCanvas", canvasId: "canvas/1" });
+      return <span data-testid="providerless">rendered</span>;
+    }
+
+    expect(() => render(<ProviderlessConsumer />)).not.toThrow();
+    expect(screen.getByTestId("providerless")).toHaveTextContent("rendered");
+  });
 });

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -217,7 +217,7 @@ export interface ViewerContextStore {
   activeAnnotationId?: string | null;
   activeManifest: string;
   activePlayer: HTMLVideoElement | HTMLAudioElement | null;
-  activeSelector?: string;
+  activeSelector?: string | Record<string, unknown>;
   OSDImageLoaded?: boolean;
   annotationCollection?: AnnotationCollectionNormalized;
   pendingAnnotationTarget?: { canvasId: string; annotationId: string } | null;
@@ -248,7 +248,7 @@ export interface ViewerAction {
   type: string;
   activeAnnotationId?: string | null;
   canvasId: string;
-  selector?: string;
+  selector?: string | Record<string, unknown>;
   annotationCollection?: AnnotationCollectionNormalized;
   pendingAnnotationTarget?: { canvasId: string; annotationId: string } | null;
   collection: CollectionNormalized;
@@ -370,12 +370,24 @@ export const createDefaultState = (): ViewerContextStore => ({
 
 export const defaultState: ViewerContextStore = createDefaultState();
 
+/**
+ * Each reducer case reads only the fields its own action carries, so a dispatched
+ * action supplies a subset of ViewerAction alongside the required type.
+ */
+export type ViewerDispatchAction = Partial<ViewerAction> & { type: string };
+
+export type ViewerDispatch = React.Dispatch<ViewerDispatchAction>;
+
 const ViewerStateContext =
   React.createContext<ViewerContextStore>(defaultState);
-const ViewerDispatchContext =
-  React.createContext<ViewerContextStore>(defaultState);
+const ViewerDispatchContext = React.createContext<ViewerDispatch>(() => {
+  throw new Error("ViewerDispatchContext used outside a ViewerProvider");
+});
 
-function viewerReducer(state: ViewerContextStore, action: ViewerAction) {
+function viewerReducer(
+  state: ViewerContextStore,
+  action: ViewerDispatchAction,
+) {
   switch (action.type) {
     case "updateActiveCanvas": {
       /**
@@ -544,22 +556,23 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
   initialState,
   children,
 }) => {
-  const [state, dispatch] = useReducer<
-    React.Reducer<ViewerContextStore, ViewerAction>,
-    ViewerContextStore | undefined
-  >(viewerReducer, initialState, (initArg?: ViewerContextStore) => {
-    if (initArg) {
-      return {
-        ...initArg,
-        configOptions: cloneViewerConfigOptions(
-          initArg.configOptions ?? defaultConfigOptions,
-        ),
-        viewerId: initArg.viewerId ?? uuidv4(),
-      };
-    }
+  const [state, dispatch] = useReducer(
+    viewerReducer,
+    initialState,
+    (initArg?: ViewerContextStore): ViewerContextStore => {
+      if (initArg) {
+        return {
+          ...initArg,
+          configOptions: cloneViewerConfigOptions(
+            initArg.configOptions ?? defaultConfigOptions,
+          ),
+          viewerId: initArg.viewerId ?? uuidv4(),
+        };
+      }
 
-    return createDefaultState();
-  });
+      return createDefaultState();
+    },
+  );
 
   const { openSeadragonViewer } = state;
 
@@ -581,7 +594,6 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
         const value = `xywh=${xywh.join(",")}`;
         dispatch({
           type: "updateActiveSelector",
-          // @ts-ignore
           selector: {
             type: "FragmentSelector",
             value,
@@ -595,11 +607,14 @@ const ViewerProvider: React.FC<ViewerProviderProps> = ({
     }
   }, [openSeadragonViewer]);
 
+  /*
+   * Several reducer cases assign an optional action field to a required store
+   * field, so the inferred state widens to include undefined. Narrowing those
+   * cases needs its own change.
+   */
   return (
-    <ViewerStateContext.Provider value={state}>
-      <ViewerDispatchContext.Provider
-        value={dispatch as unknown as ViewerContextStore}
-      >
+    <ViewerStateContext.Provider value={state as ViewerContextStore}>
+      <ViewerDispatchContext.Provider value={dispatch}>
         {children}
       </ViewerDispatchContext.Provider>
     </ViewerStateContext.Provider>

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -380,9 +380,12 @@ export type ViewerDispatch = React.Dispatch<ViewerDispatchAction>;
 
 const ViewerStateContext =
   React.createContext<ViewerContextStore>(defaultState);
-const ViewerDispatchContext = React.createContext<ViewerDispatch>(() => {
-  throw new Error("ViewerDispatchContext used outside a ViewerProvider");
-});
+/*
+ * A no-op default, because Image renders OSD without a provider and OSD
+ * dispatches on image load. Throwing here would surface inside an
+ * OpenSeadragon callback, where nothing can catch it.
+ */
+const ViewerDispatchContext = React.createContext<ViewerDispatch>(() => {});
 
 function viewerReducer(
   state: ViewerContextStore,

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -1,9 +1,9 @@
 import { CanvasNormalized, Annotation } from "@iiif/presentation-3";
-import { ViewerContextStore } from "src/context/viewer-context";
+import { ViewerContextStore, ViewerDispatch } from "src/context/viewer-context";
 
 export interface Plugin {
   canvas: CanvasNormalized;
-  useViewerDispatch: () => ViewerContextStore;
+  useViewerDispatch: () => ViewerDispatch;
   useViewerState: () => ViewerContextStore;
 }
 


### PR DESCRIPTION
`ViewerDispatchContext` is created as `React.Context<ViewerContextStore>`, but the provider puts the reducer's `dispatch` in it, via a cast:

```tsx
<ViewerDispatchContext.Provider value={dispatch as unknown as ViewerContextStore}>
```

So `useViewerDispatch()` is typed as returning the store when it actually returns a dispatch function. The consequence shows up throughout the codebase: 13 call sites annotate the result as `any` so they can call it.

```tsx
const dispatch: any = useViewerDispatch();
```

The exported `Plugin` type has the same wrong signature, and since `ViewerAction` isn't exported from the package either, a plugin author's only options are `any` or a double cast. Neither gets you any checking on the action you dispatch. That's how I ran into this.

## What this changes

- Types `ViewerDispatchContext` as a dispatch and drops the cast in the provider.
- Exports `ViewerDispatch` and `ViewerDispatchAction`. Each reducer case reads only the fields its own action carries, so the dispatched action is `Partial<ViewerAction> & { type: string }`. `ViewerAction` itself is untouched.
- Fixes `useViewerDispatch` on the exported `Plugin` type in `src/types/plugins.ts`, which is the signature that actually reaches `dist/index.d.ts`.
- Removes the `: any` annotations from the 13 consumers, and from the plugin example in the docs.
- Widens `ViewerAction.selector` to `string | Record<string, unknown>`. It's declared `string` but `Player` and the `update-viewport` handler both dispatch selector objects, the latter with a `@ts-ignore` that's no longer needed.

Two small fixes were needed because the annotations were hiding them: `updateCollection` in `Viewer/index.tsx` was passed a `CollectionNormalized | AnnotationNormalized` union, and `updateUserScrolling` in `InformationPanel` was passed a `Timeout` where the store wants a number. The latter suggests `isUserScrolling` should be `ReturnType<typeof setTimeout>` rather than `number`, but I've left that alone.

## Compatibility

Type-only, no runtime change. Existing consumers using `: any` or a double cast keep compiling.

Changing the `Plugin` type is a type-level break for plugin authors, but anything typed against the old signature was already runtime-wrong.

The context's default value is a no-op function rather than a throwing one, deliberately: `Image` renders `OSD` without a provider, and `OSD` dispatches on image load behind a `typeof dispatch === "function"` guard. A throwing default passes that guard and then throws inside an OpenSeadragon success callback, where an error boundary can't catch it. There's a test covering that case.

One cast remains, at the state provider. Several reducer cases assign an optional action field to a required store field, which widens the inferred state to include `undefined`. Narrowing those cases changes runtime behaviour and felt out of scope, so there's a comment marking it.

## Follow-up worth doing separately

A discriminated union of action types would catch typo'd `type` strings at compile time, which this doesn't (they still fall through the reducer at runtime). That's a bigger change and I didn't want to gate this on it. Happy to open an issue if you'd like it tracked.

## Checks

`npx vitest run` passes (309 tests) and `npm run build` succeeds. Ran `tsc --noEmit` before and after: 7 errors either way, all pre-existing in test fixtures.

Two tests added to `viewer-context.test.tsx`: one typing the hook as `ViewerDispatch` and dispatching `updateActiveCanvas`, which doesn't compile without this change, and one asserting a providerless dispatch doesn't throw.

Happy to split the `selector` widening out if you'd rather keep this to the context typing, though the branch won't compile without keeping the `@ts-ignore` in that case.
