### PR TITLE
Add showMediaSearch option

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -376,6 +376,7 @@ const MyCustomViewer = () => {
 | `options.requestHeaders`         | `IncomingHttpHeaders`                                                                                                                            | No       | `{ "Content-Type": "application/json" }` |
 | `options.showDownload`           | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.showIIIFBadge`          | `boolean`                                                                                                                                        | No       | true                                     |
+| `options.showMediaSearch`        | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.showTitle`              | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.customLoadingComponent` | `React.ComponentType`                                                                                                                            | No       |                                          |
 | `options.withCredentials`        | `boolean`                                                                                                                                        | No       | false                                    |
@@ -531,6 +532,19 @@ export default function App() {
     </div>
   );
 }
+```
+
+### Media Search
+
+Manifests with more than one canvas render a media strip below the viewer, with a
+search toggle that filters the strip by canvas label. Set
+`options.showMediaSearch` to `false` to hide the toggle; the strip and its
+previous/next navigation are unaffected.
+
+```jsx
+const options = {
+  showMediaSearch: false,
+};
 ```
 
 ### Information Panel

--- a/src/components/Viewer/Media/Controls.tsx
+++ b/src/components/Viewer/Media/Controls.tsx
@@ -13,6 +13,7 @@ import { useCloverTranslation } from "src/i18n/useCloverTranslation";
 interface ControlsProps {
   handleCanvasToggle: (arg0: -1 | 1) => void;
   handleFilter: (arg0: string) => void;
+  renderSearch?: boolean;
   activeIndex: number;
   canvasLength: number;
   isRtlPaged?: boolean;
@@ -76,6 +77,7 @@ const Controls: React.FC<ControlsProps> = ({
   activeIndex,
   canvasLength,
   isRtlPaged = false,
+  renderSearch = true,
 }) => {
   const [toggleFilter, setToggleFilter] = useState<boolean>(false);
   const [isNextDisabled, setIsNextDisabled] = useState<boolean>(false);
@@ -115,10 +117,7 @@ const Controls: React.FC<ControlsProps> = ({
     handleFilter(event.target.value);
 
   return (
-    <Wrapper 
-      isToggle={toggleFilter} 
-      className="clover-viewer-media-controls"
-    >
+    <Wrapper isToggle={toggleFilter} className="clover-viewer-media-controls">
       <Form>
         {toggleFilter && (
           <Input
@@ -128,7 +127,10 @@ const Controls: React.FC<ControlsProps> = ({
           />
         )}
         {!toggleFilter && (
-          <Direction className="clover-viewer-media-navigation" data-rtl-paged={isRtlPaged}>
+          <Direction
+            className="clover-viewer-media-navigation"
+            data-rtl-paged={isRtlPaged}
+          >
             {isRtlPaged ? (
               <>
                 <Button
@@ -172,17 +174,19 @@ const Controls: React.FC<ControlsProps> = ({
             )}
           </Direction>
         )}
-        <Button
-          onClick={handleFilterToggle}
-          type="button"
-          className="clover-viewer-media-search"
-        >
-          {toggleFilter ? (
-            <CloseIcon title={t("commonClose")} />
-          ) : (
-            <SearchIcon title={t("commonSearch")} />
-          )}
-        </Button>
+        {renderSearch && (
+          <Button
+            onClick={handleFilterToggle}
+            type="button"
+            className="clover-viewer-media-search"
+          >
+            {toggleFilter ? (
+              <CloseIcon title={t("commonClose")} />
+            ) : (
+              <SearchIcon title={t("commonSearch")} />
+            )}
+          </Button>
+        )}
       </Form>
     </Wrapper>
   );

--- a/src/components/Viewer/Media/Media.test.tsx
+++ b/src/components/Viewer/Media/Media.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { Canvas } from "@iiif/presentation-3";
 import Media from "src/components/Viewer/Media/Media";
 import React from "react";
+import { ViewerProvider, createDefaultState } from "src/context/viewer-context";
 
 const items = [
   {
@@ -49,5 +50,23 @@ describe("Media component", () => {
       "https://example.org/manifest/1/canvas/1",
     );
     expect(media.getAttribute("data-canvas-length")).toBe("2");
+  });
+
+  it("renders the search toggle by default", () => {
+    render(<Media items={items} activeItem={0} />);
+    expect(document.querySelector(".clover-viewer-media-search")).toBeTruthy();
+  });
+
+  it("hides the search toggle when showMediaSearch is false", () => {
+    const initialState = createDefaultState();
+    initialState.configOptions.showMediaSearch = false;
+
+    render(
+      <ViewerProvider initialState={initialState}>
+        <Media items={items} activeItem={0} />
+      </ViewerProvider>,
+    );
+
+    expect(document.querySelector(".clover-viewer-media-search")).toBeNull();
   });
 });

--- a/src/components/Viewer/Media/Media.tsx
+++ b/src/components/Viewer/Media/Media.tsx
@@ -32,7 +32,14 @@ const Media: React.FC<MediaProps> = ({ items }) => {
   const { t } = useCloverTranslation();
   const dispatch: any = useViewerDispatch();
   const state: ViewerContextStore = useViewerState();
-  const { activeCanvas, isPaged, vault, sequence, viewingDirection } = state;
+  const {
+    activeCanvas,
+    configOptions,
+    isPaged,
+    vault,
+    sequence,
+    viewingDirection,
+  } = state;
 
   /**
    * Determine if RTL paged navigation should be used
@@ -116,6 +123,7 @@ const Media: React.FC<MediaProps> = ({ items }) => {
         activeIndex={activeIndex}
         canvasLength={items.length}
         isRtlPaged={isRtlPaged}
+        renderSearch={configOptions.showMediaSearch}
       />
       <StyledSequence
         aria-label={t("media.selectItem")}

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -66,6 +66,7 @@ export type ViewerConfigOptions = {
   requestHeaders?: IncomingHttpHeaders;
   showDownload?: boolean;
   showIIIFBadge?: boolean;
+  showMediaSearch?: boolean;
   showTitle?: boolean;
   customLoadingComponent?: React.ComponentType;
   withCredentials?: boolean;
@@ -153,6 +154,7 @@ const defaultConfigOptions: ViewerConfigOptions = {
   requestHeaders: { "Content-Type": "application/json" },
   showDownload: true,
   showIIIFBadge: true,
+  showMediaSearch: true,
   showTitle: true,
   withCredentials: false,
 };


### PR DESCRIPTION
The media strip's search toggle renders unconditionally, so there's no way to turn it off. The navigation next to it in the same component is already conditional, and comparable UI elsewhere in the Viewer has a `show*` or `render*` flag, so this looked like an oversight rather than a deliberate choice.

I ran into it building an object page where the strip's filter wasn't wanted: most of our objects have generic canvas labels (`Image 1`…`Image n`), so filtering by label does nothing useful and the magnifier just invites a dead end. Hiding it needed a CSS override on `.clover-viewer-media-search`.

## What this changes

Adds `options.showMediaSearch`, defaulting to `true` so existing viewers look the same. When `false`, the toggle is hidden and the strip's previous/next navigation is untouched.

It's a top-level option rather than nested under `informationPanel`, since the media strip isn't part of that panel.

```jsx
const options = {
  showMediaSearch: false,
};
```

## Checks

`npx vitest run` passes (309 tests) and `npm run build` succeeds. Two tests added to `Media.test.tsx` covering the toggle present by default and absent when the option is off. Docs table and a short section added to `pages/docs/viewer.mdx`.

Happy to rename the option if `showMediaSearch` doesn't fit your conventions.
