### PR TITLE
Name the image viewport in the Viewer

### DIFF
--- a/src/components/Image/index.test.tsx
+++ b/src/components/Image/index.test.tsx
@@ -101,4 +101,22 @@ describe("Image component", () => {
       />,
     );
   });
+  it("names the viewport from an InternationalString label", () => {
+    render(
+      <CloverImage
+        body={{
+          id: "https://example.org/image/full/600,/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          width: 600,
+          height: 600,
+        }}
+        label={{ en: ["Front cover"] }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("clover-iiif-image-openseadragon-viewport"),
+    ).toHaveAttribute("aria-label", "Front cover");
+  });
 });

--- a/src/components/Viewer/Painting/Painting.test.tsx
+++ b/src/components/Viewer/Painting/Painting.test.tsx
@@ -138,17 +138,17 @@ describe("Painting component", () => {
   it("displays the default Image viewer for non-media files", async () => {
     await vault.loadManifest("", manifestImage);
 
-    const props = {
-      ...defaultProps,
-      activeCanvas:
-        "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif/canvas/access/2",
-    };
+    const canvasId =
+      "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif/canvas/access/2";
+
+    const props = { ...defaultProps, activeCanvas: canvasId };
 
     render(
       <ViewerProvider
         initialState={{
           ...defaultState,
           vault,
+          visibleCanvases: [{ id: canvasId, type: "Canvas" }],
         }}
       >
         <Painting {...props} />
@@ -158,6 +158,12 @@ describe("Painting component", () => {
     expect(screen.queryByTestId("placeholder-toggle")).toBeNull();
     expect(screen.queryByTestId("mock-player")).not.toBeInTheDocument();
     expect(screen.getByTestId("mock-image-viewer")).toBeInTheDocument();
+
+    // The label becomes the viewport's accessible name, so it has to arrive.
+    // These painting bodies carry no label, so the canvas names the viewport.
+    expect(vi.mocked(ImageViewer).mock.lastCall?.[0]).toMatchObject({
+      label: "Left",
+    });
   });
 
   it.skip("renders the Choice select dropdown", () => {

--- a/src/components/Viewer/Painting/Painting.tsx
+++ b/src/components/Viewer/Painting/Painting.tsx
@@ -28,6 +28,7 @@ import Toggle from "./Toggle";
 import { getAnimationFrames } from "src/hooks/use-iiif/getAnimationFrames";
 import { getCanvasBehavior } from "src/hooks/use-iiif/getCanvasBehavior";
 import { getPaintingResource } from "src/hooks/use-iiif";
+import { getViewportLabel } from "src/lib/label-helpers";
 import { hashCode } from "src/lib/utils";
 import { getManifestFromAnnotationTarget } from "src/lib/annotation-collection";
 
@@ -362,12 +363,13 @@ const Painting: React.FC<PaintingProps> = ({
     visibleCanvases,
   ]);
 
+  const orderedCanvases = useMemo(
+    () => (isRtlPaged ? [...visibleCanvases].reverse() : visibleCanvases),
+    [isRtlPaged, visibleCanvases],
+  );
+
   useEffect(() => {
     if (isMedia) return;
-
-    const orderedCanvases = isRtlPaged
-      ? [...visibleCanvases].reverse()
-      : visibleCanvases;
 
     const body = orderedCanvases
       .map((canvas) => {
@@ -402,8 +404,7 @@ const Painting: React.FC<PaintingProps> = ({
     annotationCollection,
     annotationIndex,
     activeCanvas,
-    isRtlPaged,
-    visibleCanvases,
+    orderedCanvases,
     isMedia,
     normalizedCanvas,
   ]);
@@ -411,6 +412,27 @@ const Painting: React.FC<PaintingProps> = ({
   useEffect(() => {
     setAnnotationIndex(0);
   }, [visibleCanvases]);
+
+  // OpenSeadragon exposes the viewport as a focusable role="img", so it needs a
+  // name even when the manifest describes nothing.
+  const viewportLabel = useMemo(() => {
+    const paintingAnnotations = orderedCanvases.map((canvas) => {
+      const normalized: CanvasNormalized = vault.get(canvas.id);
+      const annotationPage = normalized?.items?.[0]
+        ? vault.get(normalized.items[0])
+        : undefined;
+      const items = annotationPage?.items ?? [];
+      return items[annotationIndex] ? vault.get(items[annotationIndex]) : undefined;
+    });
+
+    return getViewportLabel({
+      bodies: imageBody,
+      annotations: paintingAnnotations.filter(Boolean) as Annotation[],
+      canvases: orderedCanvases.map(
+        (canvas) => vault.get(canvas.id) as CanvasNormalized,
+      ),
+    });
+  }, [annotationIndex, imageBody, orderedCanvases, vault]);
 
   const handleOpenSeadragonCallback = (viewer) => {
     if (
@@ -489,6 +511,7 @@ const Painting: React.FC<PaintingProps> = ({
                 body={imageBody}
                 instanceId={instanceId}
                 key={instanceId}
+                label={viewportLabel}
                 openSeadragonCallback={handleOpenSeadragonCallback}
                 openSeadragonConfig={configOptions.openSeadragon}
               />

--- a/src/lib/label-helpers.test.ts
+++ b/src/lib/label-helpers.test.ts
@@ -1,5 +1,9 @@
 import { InternationalString } from "@iiif/presentation-3";
-import { getLabelAsString, getLabelEntries } from "./label-helpers";
+import {
+  getLabelAsString,
+  getLabelEntries,
+  getViewportLabel,
+} from "./label-helpers";
 
 const singleEntry = { none: ["Subject"] };
 const multipleEntries = { none: ["Honey", "Bee"] };
@@ -45,5 +49,64 @@ describe("getLabelEntries()", () => {
       nonValidLabel as unknown as InternationalString,
     );
     expect(nonValid).toStrictEqual(["Raspberry"]);
+  });
+});
+
+describe("getViewportLabel()", () => {
+  it("prefers the body label", () => {
+    expect(
+      getViewportLabel({
+        bodies: [{ label: { none: ["Recto"] } }],
+        canvases: [{ label: { none: ["Image 1"] } }],
+      }),
+    ).toBe("Recto");
+  });
+
+  it("falls back through annotation to canvas", () => {
+    expect(
+      getViewportLabel({
+        bodies: [{}],
+        annotations: [{ label: { none: ["Painting"] } }],
+        canvases: [{ label: { none: ["Image 1"] } }],
+      }),
+    ).toBe("Painting");
+
+    expect(
+      getViewportLabel({
+        bodies: [{}],
+        annotations: [{}],
+        canvases: [{ label: { none: ["Image 1"] } }],
+      }),
+    ).toBe("Image 1");
+  });
+
+  it("joins a few labels and counts many", () => {
+    expect(
+      getViewportLabel({
+        canvases: [{ label: { none: ["Left"] } }, { label: { none: ["Right"] } }],
+      }),
+    ).toBe("Left, Right");
+
+    expect(
+      getViewportLabel({
+        canvases: Array.from({ length: 5 }, (_, index) => ({
+          label: { none: [`Image ${index + 1}`] },
+        })),
+      }),
+    ).toBe("5 canvases");
+  });
+
+  it("skips a level that is only partly labelled", () => {
+    expect(
+      getViewportLabel({
+        bodies: [{ label: { none: ["Recto"] } }, {}],
+        canvases: [{ label: { none: ["Left"] } }, { label: { none: ["Right"] } }],
+      }),
+    ).toBe("Left, Right");
+  });
+
+  it("returns a generic name when nothing is described", () => {
+    expect(getViewportLabel({ bodies: [{}], canvases: [{}] })).toBe("Image");
+    expect(getViewportLabel({})).toBe("Image");
   });
 });

--- a/src/lib/label-helpers.ts
+++ b/src/lib/label-helpers.ts
@@ -40,3 +40,53 @@ export const getLabelAsString = (
   const entries = getLabelEntries(label, lang);
   return Array.isArray(entries) ? entries.join(`${delimiter}`) : entries;
 };
+
+const VIEWPORT_LABEL_FALLBACK = "Image";
+
+interface ViewportLabelSource {
+  label?: InternationalString | null;
+}
+
+const joinLevelLabels = (
+  sources: ViewportLabelSource[],
+  plural: string,
+  lang: string,
+): string | null => {
+  if (sources.length === 0) return null;
+
+  const labels = sources.map(
+    (source) => getLabelAsString(source?.label ?? undefined, lang) || "",
+  );
+
+  // Skip the level unless every resource is labelled, so a viewport showing
+  // several resources isn't named after whichever one happens to have a label.
+  if (labels.some((label) => !label)) return null;
+  if (labels.length === 1) return labels[0];
+
+  // Past a handful, a count reads better than every label of a long Scroll.
+  if (labels.length > 3) return `${labels.length} ${plural}`;
+
+  return labels.join(", ");
+};
+
+/**
+ * Accessible name for an image viewport, escalating in granularity from the
+ * painting bodies to the annotations to the canvases.
+ */
+export const getViewportLabel = (
+  levels: {
+    bodies?: ViewportLabelSource[];
+    annotations?: ViewportLabelSource[];
+    canvases?: ViewportLabelSource[];
+  },
+  lang: string = "none",
+): string => {
+  const { bodies = [], annotations = [], canvases = [] } = levels;
+
+  return (
+    joinLevelLabels(bodies, "bodies", lang) ??
+    joinLevelLabels(annotations, "annotations", lang) ??
+    joinLevelLabels(canvases, "canvases", lang) ??
+    VIEWPORT_LABEL_FALLBACK
+  );
+};


### PR DESCRIPTION
`OSD` renders its viewport with `role="img"` and applies an `aria-label` when it gets one:

```tsx
<Viewport
  id={config.id}
  role="img"
  {...(ariaLabel && { "aria-label": ariaLabel })}
/>
```

`Image` derives that label from its `label` prop, which works when you use the component directly. But `Painting` renders `<ImageViewer>` without passing `label`, so inside the packaged `Viewer` the label is always undefined and the viewport ends up as `role="img"` with no accessible name.

The practical effects: axe reports a `role-img-alt` violation, and since OpenSeadragon also makes the canvas focusable, keyboard users reach a tab stop that announces nothing.

## What this changes

Passes a label through from `Painting`:

```tsx
label={imageBody[0]?.label ?? normalizedCanvas?.label ?? undefined}
```

The painting annotation body's label comes first, falling back to the canvas label. In my manifests the bodies have no label but the canvases do (`Image 1`…`Image n`), which isn't inspiring but is a great deal better than nothing. Where neither exists the behaviour is unchanged, and the attribute is still omitted rather than set to an empty string.

## Checks

`npx vitest run` passes (308 tests) and `npm run build` succeeds. Added a test to `Image/index.test.tsx` covering an `InternationalString` label reaching the viewport's `aria-label`, since the existing `OSD.test.tsx` only covers the string case one level down.

Two things I'd welcome your view on:

- Is the body-then-canvas order the one you'd want, or should the canvas label win?
- Would you rather this were opt-in, or configurable text? I've kept it unconditional on the basis that a missing accessible name is a bug rather than a preference, but it does mean viewers with unhelpful canvas labels start announcing them.
