### PR TITLE
Improve keyboard and motion accessibility of the image viewer

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -384,6 +384,7 @@ const MyCustomViewer = () => {
 - Options `canvasBackgroundColor` and `canvasHeight` will apply to both `<video>` elements and the OpenseaDragon canvas.
 - Option `withCredentials` being set as `true` will inform IIIF resource requests to be made [using credentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) such as cookies, authorization headers or TLS client certificates.
 - Option `options.openSeadragon` will grant you ability to override the [OpenSeadragon default options](https://openseadragon.github.io/docs/OpenSeadragon.html#.Options) set within the Clover IIIF Viewer to adjust touch and mouse gesture settings and various other configurations.
+- When the visitor's OS is set to `prefers-reduced-motion: reduce`, Clover sets OpenSeadragon's `animationTime` to `0` so zoom and pan happen instantly instead of easing. Pass your own `animationTime` in `options.openSeadragon` to override this.
 
 ### Map Display
 

--- a/src/components/Image/Controls/Controls.test.tsx
+++ b/src/components/Image/Controls/Controls.test.tsx
@@ -1,3 +1,4 @@
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
 import { render, screen } from "@testing-library/react";
 
 import Controls from "src/components/Image/Controls/Controls";
@@ -10,5 +11,81 @@ describe("Controls component", () => {
       "clover-iiif-image-openseadragon-controls",
     );
     expect(controls);
+  });
+
+  describe("full-page focus restore", () => {
+    const fullPageButtonId = "fullPage-test";
+
+    // Fake OSD viewer exposing just enough of addHandler/removeHandler for
+    // Controls to register its "full-page" listener and for the test to
+    // trigger it directly.
+    const createFakeViewer = () => {
+      const handlers: Record<string, Array<(event: unknown) => void>> = {};
+      return {
+        addHandler: (name: string, handler: (event: unknown) => void) => {
+          handlers[name] = handlers[name] ?? [];
+          handlers[name].push(handler);
+        },
+        removeHandler: (name: string, handler: (event: unknown) => void) => {
+          handlers[name] = (handlers[name] ?? []).filter((h) => h !== handler);
+        },
+        removeAllHandlers: (name: string) => {
+          handlers[name] = [];
+        },
+        trigger: (name: string, event: unknown) => {
+          (handlers[name] ?? []).forEach((handler) => handler(event));
+        },
+        viewport: { getRotation: () => 0 },
+      };
+    };
+
+    it("focuses the full page button when full-page mode exits", () => {
+      const viewer = createFakeViewer();
+      document.body.innerHTML = `<button id="${fullPageButtonId}"></button>`;
+      const button = document.getElementById(fullPageButtonId) as HTMLElement;
+
+      render(
+        <ViewerProvider
+          initialState={{
+            ...defaultState,
+            openSeadragonViewer: viewer as never,
+          }}
+        >
+          <Controls
+            config={{ fullPageButton: fullPageButtonId }}
+            _cloverViewerHasPlaceholder={false}
+          />
+        </ViewerProvider>,
+      );
+
+      viewer.trigger("full-page", { fullPage: false });
+
+      expect(document.activeElement).toBe(button);
+    });
+
+    it("does not move focus when full-page mode is entered", () => {
+      const viewer = createFakeViewer();
+      document.body.innerHTML = `<button id="${fullPageButtonId}"></button>`;
+
+      render(
+        <ViewerProvider
+          initialState={{
+            ...defaultState,
+            openSeadragonViewer: viewer as never,
+          }}
+        >
+          <Controls
+            config={{ fullPageButton: fullPageButtonId }}
+            _cloverViewerHasPlaceholder={false}
+          />
+        </ViewerProvider>,
+      );
+
+      viewer.trigger("full-page", { fullPage: true });
+
+      expect(document.activeElement).not.toBe(
+        document.getElementById(fullPageButtonId),
+      );
+    });
   });
 });

--- a/src/components/Image/Controls/Controls.tsx
+++ b/src/components/Image/Controls/Controls.tsx
@@ -121,6 +121,27 @@ const Controls = ({
     });
   }, [openSeadragonViewer]);
 
+  /*
+   * OpenSeadragon moves the viewer in and out of the DOM to go full page, which
+   * drops focus. Without this a keyboard user is returned to the top of the
+   * document and has to tab back to the controls.
+   */
+  useEffect(() => {
+    if (!openSeadragonViewer) return;
+
+    // "full-page" fires on both entering and exiting full page mode, with
+    // fullPage true on entry. Only restore focus on exit, when OSD has just
+    // moved the viewer back into its original place in the DOM.
+    const restoreFocus = ({ fullPage }: { fullPage: boolean }) => {
+      if (fullPage) return;
+      const button = document.getElementById(config.fullPageButton as string);
+      if (button) button.focus();
+    };
+
+    openSeadragonViewer.addHandler("full-page", restoreFocus);
+    return () => openSeadragonViewer.removeHandler("full-page", restoreFocus);
+  }, [openSeadragonViewer, config.fullPageButton]);
+
   return (
     <Wrapper
       data-testid="clover-iiif-image-openseadragon-controls"

--- a/src/components/Image/Image.styled.test.tsx
+++ b/src/components/Image/Image.styled.test.tsx
@@ -1,0 +1,17 @@
+import { Viewport } from "src/components/Image/Image.styled";
+import { render } from "@testing-library/react";
+import React from "react";
+
+describe("Viewport styles", () => {
+  it("gives the OSD canvas a visible focus-visible outline", () => {
+    render(<Viewport data-testid="viewport" />);
+
+    const css = Array.from(document.querySelectorAll("style"))
+      .flatMap((style) => Array.from(style.sheet?.cssRules ?? []))
+      .map((rule) => rule.cssText)
+      .join("\n");
+
+    expect(css).toMatch(/\.openseadragon-canvas:focus-visible/);
+    expect(css).toMatch(/outline/);
+  });
+});

--- a/src/components/Image/Image.styled.tsx
+++ b/src/components/Image/Image.styled.tsx
@@ -33,6 +33,12 @@ const Viewport = styled("div", {
   height: "100%",
   zIndex: "0",
 
+  // OSD gives its canvas tabindex="0" but no visible focus state of its own.
+  ".openseadragon-canvas:focus-visible": {
+    outline: "2px solid $accent",
+    outlineOffset: "-2px",
+  },
+
   ".clover-iiif-image-openseadragon-annotation": {
     position: "relative",
     backgroundColor: "transparent",

--- a/src/components/Image/OSD/defaults.test.ts
+++ b/src/components/Image/OSD/defaults.test.ts
@@ -1,0 +1,28 @@
+import defaultOpenSeadragonConfiguration from "./defaults";
+
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+}
+
+describe("defaultOpenSeadragonConfiguration", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leaves OSD's default animation timing alone when motion is not reduced", () => {
+    mockMatchMedia(false);
+    const config = defaultOpenSeadragonConfiguration("test");
+    expect(config.animationTime).toBeUndefined();
+  });
+
+  it("disables animation when the user prefers reduced motion", () => {
+    mockMatchMedia(true);
+    const config = defaultOpenSeadragonConfiguration("test");
+    expect(config.animationTime).toBe(0);
+  });
+});

--- a/src/components/Image/OSD/defaults.ts
+++ b/src/components/Image/OSD/defaults.ts
@@ -1,8 +1,20 @@
 import { Options } from "openseadragon";
 
+// Skip OSD's default zoom/pan easing for users who ask the OS for reduced
+// motion. Guarded for SSR, where matchMedia doesn't exist.
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
 function defaultOpenSeadragonConfiguration(
   openSeadragonInstance: string,
 ): Options {
+  const reducedMotion = prefersReducedMotion();
+
   return {
     id: `openseadragon-${openSeadragonInstance}`,
     navigatorId: `openseadragon-navigator-${openSeadragonInstance}`,
@@ -26,6 +38,7 @@ function defaultOpenSeadragonConfiguration(
       scrollToZoom: false,
     },
     preserveViewport: true,
+    ...(reducedMotion && { animationTime: 0 }),
   };
 }
 


### PR DESCRIPTION
Three fixes.

1. Exiting OpenSeadragon's full-page mode drops focus, because OSD moves the viewer in and out of the DOM and never restores it (its `setFullPage` saves `previousBody` but never calls `.focus()`). Clover now restores focus to the fullscreen button. OSD's `full-page` event fires on both enter and exit with `{ fullPage: boolean }`, so the handler only acts on exit.

2. OSD eases every zoom and pan. The config now sets `animationTime: 0` when `prefers-reduced-motion: reduce` matches, guarded for SSR and still overridable by an explicit `options.openSeadragon.animationTime`.

3. OSD makes its canvas a tab stop but Clover only styled focus on its own buttons, so keyboard users tabbing to the viewer got no visible indication. There's now a default focus outline on the canvas.

On verification: the canvas focus outline and the accessible name were confirmed in a real browser (2px accent outline on keyboard focus). The fullscreen focus restore is covered by unit tests but was not confirmed in a real browser, because headless Chrome would not enter full-page mode. Flagging that plainly rather than implying it was checked end to end.

Tests were added for each fix, and each was checked to fail when the fix is reverted.
