### PR TITLE
Render the active canvas summary in the About panel

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -546,8 +546,14 @@ The information panel is a collapsible panel that displays information about the
 | `options.informationPanel.renderSupplementing` | `boolean`                       | No       | true    |
 | `options.informationPanel.renderToggle`        | `boolean`                       | No       | true    |
 | `options.informationPanel.renderContentSearch` | `boolean`                       | No       | true    |
+| `options.informationPanel.renderCanvasSummary` | `boolean`                       | No       | false   |
 | `options.informationPanel.defaultTab`          | `string`                        | No       |         |
 | `options.informationPanel.annotationTabLabel`  | `string`                        | No       |         |
+
+Set `renderCanvasSummary` to `true` to show the active canvas's `summary` above
+the manifest's own, for manifests that describe each image rather than only the
+object. It follows the active canvas and renders nothing when that canvas has no
+summary. Off by default, since it adds text to the About tab.
 
 If `renderAbout` is true, Clover will use the About tab as the default tab. Use `options.informationPanel.defaultTab` to set the default tab.
 

--- a/src/components/Viewer/InformationPanel/About/About.test.tsx
+++ b/src/components/Viewer/InformationPanel/About/About.test.tsx
@@ -1,0 +1,51 @@
+import { ViewerProvider, createDefaultState } from "src/context/viewer-context";
+import { render, screen } from "@testing-library/react";
+
+import About from "src/components/Viewer/InformationPanel/About/About";
+import React from "react";
+import { Vault } from "@iiif/helpers/vault";
+import { manifestImage } from "src/fixtures/viewer/manifest-image";
+
+const canvasId =
+  "https://api.dc.library.northwestern.edu/api/v2/works/71153379-4283-43be-8b0f-4e7e3bfda275?as=iiif/canvas/access/2";
+
+async function renderAbout(renderCanvasSummary?: boolean) {
+  const vault = new Vault();
+  const manifest = await vault.loadManifest("", manifestImage);
+
+  // Canvases in this fixture carry no summary, so give one to the active canvas.
+  const canvas = vault.get(canvasId) as { summary?: unknown };
+  canvas.summary = { none: ["A description of this particular image"] };
+
+  const initialState = createDefaultState();
+  initialState.vault = vault;
+  initialState.activeManifest = manifest?.id as string;
+  initialState.activeCanvas = canvasId;
+  if (renderCanvasSummary !== undefined)
+    initialState.configOptions.informationPanel = {
+      ...initialState.configOptions.informationPanel,
+      renderCanvasSummary,
+    };
+
+  render(
+    <ViewerProvider initialState={initialState}>
+      <About />
+    </ViewerProvider>,
+  );
+}
+
+describe("About", () => {
+  it("omits the canvas summary by default", async () => {
+    await renderAbout();
+    expect(
+      screen.queryByText("A description of this particular image"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the canvas summary when opted in", async () => {
+    await renderAbout(true);
+    expect(
+      await screen.findByText("A description of this particular image"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Viewer/InformationPanel/About/About.tsx
+++ b/src/components/Viewer/InformationPanel/About/About.tsx
@@ -3,6 +3,7 @@ import {
   AboutStyled,
 } from "src/components/Viewer/InformationPanel/About/About.styled";
 import {
+  CanvasNormalized,
   ContentResource,
   IIIFExternalWebResource,
   ManifestNormalized,
@@ -25,7 +26,7 @@ import { PrimitivesExternalWebResource } from "src/types/primitives";
 
 const About: React.FC = () => {
   const viewerState: ViewerContextStore = useViewerState();
-  const { activeManifest, vault } = viewerState;
+  const { activeCanvas, activeManifest, configOptions, vault } = viewerState;
 
   const [manifest, setManifest] = useState<ManifestNormalized>();
 
@@ -69,6 +70,15 @@ const About: React.FC = () => {
       );
   }, [activeManifest, vault]);
 
+  /*
+   * Manifests that describe each image, not just the object, put that text on
+   * the canvas. Read live rather than into state so it follows the active canvas.
+   */
+  const renderCanvasSummary =
+    configOptions.informationPanel?.renderCanvasSummary;
+  const canvas: CanvasNormalized | undefined =
+    renderCanvasSummary && activeCanvas ? vault.get(activeCanvas) : undefined;
+
   if (!manifest) return <></>;
 
   return (
@@ -79,6 +89,9 @@ const About: React.FC = () => {
           label={manifest.label}
           objectFit="contain"
         />
+        {canvas?.summary && (
+          <Summary summary={canvas.summary} parent="canvas" />
+        )}
         <Summary summary={manifest.summary} />
         <Metadata metadata={manifest.metadata} />
         <RequiredStatement requiredStatement={manifest.requiredStatement} />

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -58,6 +58,7 @@ export type ViewerConfigOptions = {
       autoScroll?: AutoScrollOptions | AutoScrollSettings | boolean;
     };
     renderContentSearch?: boolean;
+    renderCanvasSummary?: boolean;
     defaultTab?: string;
     annotationTabLabel?: string;
     annotationCollectionTabLabel?: string;
@@ -148,6 +149,7 @@ const defaultConfigOptions: ViewerConfigOptions = {
     renderAnnotation: true,
     renderAnnotationCollection: true,
     renderContentSearch: true,
+    renderCanvasSummary: false,
   },
   openSeadragon: {},
   requestHeaders: { "Content-Type": "application/json" },


### PR DESCRIPTION
Clover renders the manifest's `summary` in the About panel but nothing per canvas, so manifests that describe each image individually have that text dropped. IIIF Presentation 3 permits `summary` on a Canvas ("may have", clients "should render").

This change adds the active canvas's summary above the manifest's own in `About.tsx`, reading it live from the vault so it follows the active canvas as you page through the object.

It uses the existing `parent="canvas"` prop on the `Summary` properties component, which was already implemented (giving `id="iiif-canvas-summary"`) but had no callers. Worth mentioning: this suggests the feature was anticipated but never wired up.

It's opt-in via `options.informationPanel.renderCanvasSummary`, defaulting to `false`, because it adds text to a panel consumers already ship.

Verified in a browser against a real manifest with per-canvas summaries: the caption renders and updates as you page between canvases.

Two tests cover it (default omits it, opt-in renders it), plus a docs table row and a short docs section.
