### PR TITLE
Allow the image viewer's controls to be replaced

### DIFF
--- a/pages/docs/viewer.mdx
+++ b/pages/docs/viewer.mdx
@@ -378,6 +378,7 @@ const MyCustomViewer = () => {
 | `options.showIIIFBadge`          | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.showTitle`              | `boolean`                                                                                                                                        | No       | true                                     |
 | `options.customLoadingComponent` | `React.ComponentType`                                                                                                                            | No       |                                          |
+| `options.controlButtons`         | [See Control Buttons](#control-buttons)                                                                                                          | No       |                                          |
 | `options.withCredentials`        | `boolean`                                                                                                                                        | No       | false                                    |
 | `options.contentSearch`          | [See Content Search](#content-search)                                                                                                            | No       |                                          |
 
@@ -545,6 +546,7 @@ The information panel is a collapsible panel that displays information about the
 | `options.informationPanel.renderAnnotation`    | `boolean`                       | No       | true    |
 | `options.informationPanel.renderSupplementing` | `boolean`                       | No       | true    |
 | `options.informationPanel.renderToggle`        | `boolean`                       | No       | true    |
+| `options.informationPanel.toggleComponent`     | `React.ComponentType`           | No       |         |
 | `options.informationPanel.renderContentSearch` | `boolean`                       | No       | true    |
 | `options.informationPanel.defaultTab`          | `string`                        | No       |         |
 | `options.informationPanel.annotationTabLabel`  | `string`                        | No       |         |
@@ -920,6 +922,69 @@ Clients may choose to override the default _loading_ component that displays whi
     customLoadingComponent: () => <>My custom loading component</>,
   }}
 />
+```
+
+---
+
+### Control Buttons
+
+Clients may replace the buttons in the image viewer's control bar with their own components. Each key is optional, so overriding one control leaves the others as Clover's.
+
+OpenSeadragon binds its handlers by element id, so a replacement **must** put the `id` it is given on the element it wants clicks from. It should also use `label` as the accessible name, since Clover's own `svg` title is not rendered. Everything else — shape, size, markup, styling — belongs to the client.
+
+```jsx
+// Spread buttonProps and the control works; the element and its styling are yours.
+const ZoomIn = ({ buttonProps }) => (
+  <button {...buttonProps} className="my-square-button">
+    <MyZoomInIcon />
+  </button>
+);
+
+<Viewer
+  iiifContent="https://example.com/manifest/1"
+  options={{
+    controlButtons: { zoomIn: ZoomIn },
+  }}
+/>;
+```
+
+Each replacement receives `buttonProps` (the id OpenSeadragon binds to, `type`, and the accessible name), `icon` (Clover's own glyph, if you want to keep it), and `label` as plain text. Render whatever element you like, in any shape, as long as `buttonProps` is spread onto the interactive element.
+
+| Key           | Control                 |
+| ------------- | ----------------------- |
+| `zoomIn`      | Zoom in                 |
+| `zoomOut`     | Zoom out                |
+| `fullPage`    | Full screen             |
+| `rotateRight` | Rotate right            |
+| `rotateLeft`  | Rotate left             |
+| `reset`       | Reset zoom and rotation |
+
+Each control is still gated on its OpenSeadragon flag (`showZoomControl`, `showFullPageControl`, `showRotationControl`, `showHomeControl`), so a replacement for a hidden control is not rendered. Note that `options.openSeadragon.navImages` has no effect: Clover supplies OpenSeadragon with button elements, and OpenSeadragon skips its own control images when it is given one.
+
+Two things to know when writing a replacement:
+
+- **Spread `buttonProps`.** It carries the id OpenSeadragon binds its handlers to and the accessible name. A component that drops it renders a button that looks right and does nothing; Clover logs a warning outside production when that happens.
+- **Define the component at module scope.** A component declared inline in `options` is a new type on each render, which remounts the button and leaves OpenSeadragon bound to the discarded element.
+
+OpenSeadragon sets `display: inline-block` and `position: relative` on the element as inline styles, which no class can override, so centre the glyph with `margin: auto` or on a wrapper inside the button rather than making the button a flex container. Clover's own spacing (`margin-left: 0.618rem` between controls) does not apply to a replacement, so add it if you are replacing only some of them.
+
+The information panel toggle sits outside this control bar and is replaced through `options.informationPanel.toggleComponent`. It is driven by Clover's state rather than OpenSeadragon, so its `buttonProps` carry the click handler and `aria-expanded` instead of an id, and none of the caveats above apply to it. `isOpen` is passed separately so the glyph can follow the panel state. Replacing the controls without it tends to look unfinished, since the default toggle keeps Clover's own shape.
+
+Clover positions the replacement where its own toggle sits, so it only needs to supply the button itself.
+
+```jsx
+const PanelToggle = ({ buttonProps, isOpen }) => (
+  <button {...buttonProps} className="my-square-button">
+    {isOpen ? <MyCloseIcon /> : <MyPanelIcon />}
+  </button>
+);
+
+<Viewer
+  iiifContent="https://example.com/manifest/1"
+  options={{
+    informationPanel: { toggleComponent: PanelToggle },
+  }}
+/>;
 ```
 
 ---

--- a/src/components/Image/Controls/Controls.test.tsx
+++ b/src/components/Image/Controls/Controls.test.tsx
@@ -1,14 +1,83 @@
-import { render, screen } from "@testing-library/react";
+import { ViewerProvider, defaultState } from "src/context/viewer-context";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import Controls from "src/components/Image/Controls/Controls";
+import type { ControlButtonProps } from "src/context/viewer-context";
 import React from "react";
+
+const CustomZoomIn = ({ buttonProps, icon }: ControlButtonProps) => (
+  <button {...buttonProps} data-testid="custom-zoom-in">
+    {icon}
+  </button>
+);
+
+const config = {
+  showZoomControl: true,
+  zoomInButton: "zoomIn-abc",
+  zoomOutButton: "zoomOut-abc",
+};
+
+const renderControls = (
+  controlButtons?: Record<string, unknown>,
+  overrides = {},
+) =>
+  render(
+    <ViewerProvider
+      initialState={{
+        ...defaultState,
+        configOptions: { ...defaultState.configOptions, controlButtons },
+      }}
+    >
+      <Controls
+        config={{ ...config, ...overrides }}
+        _cloverViewerHasPlaceholder={false}
+      />
+    </ViewerProvider>,
+  );
 
 describe("Controls component", () => {
   it("renders", () => {
     render(<Controls config={{}} _cloverViewerHasPlaceholder={false} />);
-    const controls = screen.getByTestId(
-      "clover-iiif-image-openseadragon-controls",
+    expect(screen.getByTestId("clover-iiif-image-openseadragon-controls"));
+  });
+});
+
+describe("Controls component with controlButtons", () => {
+  it("replaces a control with the configured component", () => {
+    renderControls({ zoomIn: CustomZoomIn });
+
+    const custom = screen.getByTestId("custom-zoom-in");
+    // OpenSeadragon binds by element id, so a replacement has to keep it.
+    expect(custom.getAttribute("id")).toBe("zoomIn-abc");
+    expect(custom.getAttribute("aria-label")).toBe("Zoom in");
+  });
+
+  it("keeps the default button for controls without a replacement", () => {
+    renderControls({ zoomIn: CustomZoomIn });
+
+    const defaults = screen.getAllByTestId("openseadragon-button");
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0].getAttribute("id")).toBe("zoomOut-abc");
+  });
+
+  it("renders every default when no replacement is configured", () => {
+    renderControls();
+
+    expect(screen.queryByTestId("custom-zoom-in")).toBeNull();
+    expect(screen.getAllByTestId("openseadragon-button")).toHaveLength(2);
+  });
+
+  it("does not render a replacement for a control hidden by its flag", () => {
+    renderControls({ zoomIn: CustomZoomIn }, { showZoomControl: false });
+
+    expect(screen.queryByTestId("custom-zoom-in")).toBeNull();
+  });
+
+  it("accepts a memoised component", () => {
+    renderControls({ zoomIn: React.memo(CustomZoomIn) });
+
+    expect(screen.getByTestId("custom-zoom-in").getAttribute("id")).toBe(
+      "zoomIn-abc",
     );
-    expect(controls);
   });
 });

--- a/src/components/Image/Controls/Controls.tsx
+++ b/src/components/Image/Controls/Controls.tsx
@@ -1,4 +1,5 @@
 import {
+  ControlButtons,
   ViewerContextStore,
   useViewerDispatch,
   useViewerState,
@@ -67,6 +68,33 @@ const Rotate = () => {
   );
 };
 
+/**
+ * Clover's glyphs are bare `path` elements, so a replacement gets them wrapped
+ * in an svg it can drop straight in. Decorative, since the button carries the
+ * name.
+ */
+const ControlIcon = ({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    fill="currentColor"
+    stroke="currentColor"
+    focusable="false"
+    aria-hidden="true"
+    role="presentation"
+    data-testid="openseadragon-button-svg"
+    data-label={label}
+  >
+    {children}
+  </svg>
+);
+
 const Controls = ({
   _cloverViewerHasPlaceholder,
   config,
@@ -87,6 +115,34 @@ const Controls = ({
   const hasInformationToggle = Boolean(
     configOptions.informationPanel?.renderToggle,
   );
+
+  /**
+   * Renders a consumer's control in place of the default when one is configured.
+   * The replacement owns the element, so it is handed props to spread rather than
+   * being told what to render: OpenSeadragon binds by element id, and the
+   * accessible name has to survive whatever markup the consumer chooses.
+   */
+  function renderControl(
+    key: keyof ControlButtons,
+    id: string,
+    label: string,
+    glyph: React.ReactElement,
+  ) {
+    const Custom = configOptions.controlButtons?.[key];
+    if (Custom)
+      return (
+        <Custom
+          buttonProps={{ id, type: "button", "aria-label": label }}
+          icon={<ControlIcon label={label}>{glyph}</ControlIcon>}
+          label={label}
+        />
+      );
+    return (
+      <Button id={id} label={label}>
+        {glyph}
+      </Button>
+    );
+  }
 
   const canvas = vault.get({
     id: activeCanvas,
@@ -111,6 +167,37 @@ const Controls = ({
       });
   }
 
+  /**
+   * Every control OpenSeadragon binds, paired with the flag that renders it.
+   */
+  const controlIds: Array<[keyof ControlButtons, unknown, boolean]> = [
+    ["zoomIn", config.zoomInButton, !!config.showZoomControl],
+    ["zoomOut", config.zoomOutButton, !!config.showZoomControl],
+    ["fullPage", config.fullPageButton, !!config.showFullPageControl],
+    ["rotateRight", config.rotateRightButton, !!config.showRotationControl],
+    ["rotateLeft", config.rotateLeftButton, !!config.showRotationControl],
+    ["reset", config.homeButton, !!config.showHomeControl],
+  ];
+
+  /*
+   * A replacement that does not render the id it is given still looks correct,
+   * but OpenSeadragon binds to an element that is not in the document and the
+   * control does nothing. Say so rather than leaving it to be found by hand.
+   */
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+
+    controlIds.forEach(([key, id, shown]) => {
+      if (!shown) return;
+      if (!configOptions.controlButtons?.[key] || typeof id !== "string")
+        return;
+      if (document.getElementById(id)) return;
+      console.warn(
+        `Clover IIIF: the controlButtons.${key} component does not render the id it was given ("${id}"), so OpenSeadragon cannot bind to it and the control will not work.`,
+      );
+    });
+  }, [config, configOptions.controlButtons]);
+
   useEffect(() => {
     if (!openSeadragonViewer) return;
 
@@ -130,43 +217,50 @@ const Controls = ({
     >
       {config.showZoomControl && (
         <>
-          <Button id={config.zoomInButton as string} label={t("imageZoomIn")}>
-            <ZoomIn />
-          </Button>
-          <Button id={config.zoomOutButton as string} label={t("imageZoomOut")}>
-            <ZoomOut />
-          </Button>
+          {renderControl(
+            "zoomIn",
+            config.zoomInButton as string,
+            t("imageZoomIn"),
+            <ZoomIn />,
+          )}
+          {renderControl(
+            "zoomOut",
+            config.zoomOutButton as string,
+            t("imageZoomOut"),
+            <ZoomOut />,
+          )}
         </>
       )}
-      {config.showFullPageControl && (
-        <Button
-          id={config.fullPageButton as string}
-          label={t("imageFullScreen")}
-        >
-          <ZoomFullScreen />
-        </Button>
-      )}
+      {config.showFullPageControl &&
+        renderControl(
+          "fullPage",
+          config.fullPageButton as string,
+          t("imageFullScreen"),
+          <ZoomFullScreen />,
+        )}
       {config.showRotationControl && (
         <>
-          <Button
-            id={config.rotateRightButton as string}
-            label={t("imageRotateRight")}
-          >
-            <Rotate />
-          </Button>
-          <Button
-            id={config.rotateLeftButton as string}
-            label={t("imageRotateLeft")}
-          >
-            <Rotate />
-          </Button>
+          {renderControl(
+            "rotateRight",
+            config.rotateRightButton as string,
+            t("imageRotateRight"),
+            <Rotate />,
+          )}
+          {renderControl(
+            "rotateLeft",
+            config.rotateLeftButton as string,
+            t("imageRotateLeft"),
+            <Rotate />,
+          )}
         </>
       )}
-      {config.showHomeControl && (
-        <Button id={config.homeButton as string} label={t("imageResetZoom")}>
-          <Reset />
-        </Button>
-      )}
+      {config.showHomeControl &&
+        renderControl(
+          "reset",
+          config.homeButton as string,
+          t("imageResetZoom"),
+          <Reset />,
+        )}
       {renderPlugins()}
     </Wrapper>
   );

--- a/src/components/Viewer/Viewer/Content.test.tsx
+++ b/src/components/Viewer/Viewer/Content.test.tsx
@@ -8,6 +8,7 @@ import { AnnotationResources } from "src/types/annotations";
 import InformationPanel from "../InformationPanel/InformationPanel";
 import Painting from "src/components/Viewer/Painting/Painting";
 import React from "react";
+import type { PanelToggleProps } from "src/context/viewer-context";
 
 vi.mock("@radix-ui/react-collapsible");
 
@@ -101,6 +102,60 @@ describe("ViewerContent with no Annotation Resources", () => {
       </ViewerProvider>,
     );
     expect(screen.queryByTestId("mock-information-panel")).toBeNull();
+  });
+});
+
+describe("ViewerContent with a custom information panel toggle", () => {
+  const CustomToggle = ({ buttonProps, icon }: PanelToggleProps) => (
+    <button {...buttonProps} data-testid="custom-panel-toggle">
+      {icon}
+    </button>
+  );
+
+  test("renders the configured component in place of the default toggle", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          isInformationOpen: false,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              renderToggle: true,
+              toggleComponent: CustomToggle,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
+
+    const toggle = screen.getByTestId("custom-panel-toggle");
+    // The open state has to reach the replacement, not just the handler.
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  test("keeps the default toggle when no component is configured", () => {
+    render(
+      <ViewerProvider
+        initialState={{
+          ...defaultState,
+          isInformationOpen: false,
+          configOptions: {
+            informationPanel: {
+              ...defaultState.configOptions.informationPanel,
+              renderToggle: true,
+            },
+          },
+        }}
+      >
+        <ViewerContent {...props} />
+      </ViewerProvider>,
+    );
+
+    expect(screen.queryByTestId("custom-panel-toggle")).toBeNull();
   });
 });
 

--- a/src/components/Viewer/Viewer/Content.tsx
+++ b/src/components/Viewer/Viewer/Content.tsx
@@ -7,6 +7,7 @@ import { AnnotationResource, AnnotationResources } from "src/types/annotations";
 import {
   Aside,
   Content,
+  CustomPanelToggle,
   DragHandle,
   Main,
   MediaWrapper,
@@ -86,6 +87,7 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
     (informationPanel?.renderAbout && isInformationOpen) || isForcedAside;
 
   const renderToggle = informationPanel?.renderToggle;
+  const CustomToggle = informationPanel?.toggleComponent;
 
   const handleToggle = () => {
     dispatch({
@@ -144,22 +146,45 @@ const ViewerContent: React.FC<ViewerContentProps> = ({
           </MediaWrapper>
         )}
 
-        {renderToggle && (
-          <PanelToggle
-            data-aside-active={isAside}
-            onClick={handleToggle}
-            aria-label={t("informationPanelToggle")}
-            aria-expanded={isInformationOpen}
-          >
-            <Icon fill="currentColor" aria-hidden="true">
-              {isInformationOpen ? (
-                <Icon.PanelExpand />
-              ) : (
-                <Icon.PanelCollapse />
-              )}
-            </Icon>
-          </PanelToggle>
-        )}
+        {renderToggle &&
+          (CustomToggle ? (
+            <CustomPanelToggle data-aside-active={isAside}>
+              <CustomToggle
+                buttonProps={{
+                  type: "button",
+                  "aria-label": t("informationPanelToggle"),
+                  "aria-expanded": isInformationOpen,
+                  onClick: handleToggle,
+                }}
+                icon={
+                  <Icon fill="currentColor" aria-hidden="true">
+                    {isInformationOpen ? (
+                      <Icon.PanelExpand />
+                    ) : (
+                      <Icon.PanelCollapse />
+                    )}
+                  </Icon>
+                }
+                isOpen={isInformationOpen}
+                label={t("informationPanelToggle")}
+              />
+            </CustomPanelToggle>
+          ) : (
+            <PanelToggle
+              data-aside-active={isAside}
+              onClick={handleToggle}
+              aria-label={t("informationPanelToggle")}
+              aria-expanded={isInformationOpen}
+            >
+              <Icon fill="currentColor" aria-hidden="true">
+                {isInformationOpen ? (
+                  <Icon.PanelExpand />
+                ) : (
+                  <Icon.PanelCollapse />
+                )}
+              </Icon>
+            </PanelToggle>
+          ))}
       </Main>
       {isAside && (
         <>

--- a/src/components/Viewer/Viewer/Viewer.styled.tsx
+++ b/src/components/Viewer/Viewer/Viewer.styled.tsx
@@ -163,4 +163,29 @@ const Wrapper = styled("div", {
   },
 });
 
-export { Wrapper, Content, Main, MediaWrapper, Aside, PanelToggle, DragHandle };
+/**
+ * Positions a replacement panel toggle where the default one sits, so a consumer
+ * supplies only the button's appearance. Sizing and styling stay theirs.
+ */
+const CustomPanelToggle = styled("span", {
+  position: "absolute",
+  top: "1rem",
+  right: "1rem",
+  zIndex: "2",
+  display: "flex",
+
+  "&[data-aside-active='true']": {
+    right: "calc(-1rem - 2px)",
+  },
+});
+
+export {
+  Wrapper,
+  Content,
+  Main,
+  MediaWrapper,
+  Aside,
+  PanelToggle,
+  CustomPanelToggle,
+  DragHandle,
+};

--- a/src/context/viewer-context.tsx
+++ b/src/context/viewer-context.tsx
@@ -52,6 +52,7 @@ export type ViewerConfigOptions = {
     renderAbout?: boolean;
     renderSupplementing?: boolean;
     renderToggle?: boolean;
+    toggleComponent?: React.ComponentType<PanelToggleProps>;
     renderAnnotation?: boolean;
     renderAnnotationCollection?: boolean;
     vtt?: {
@@ -68,6 +69,7 @@ export type ViewerConfigOptions = {
   showIIIFBadge?: boolean;
   showTitle?: boolean;
   customLoadingComponent?: React.ComponentType;
+  controlButtons?: ControlButtons;
   withCredentials?: boolean;
   localeText?: {
     contentSearch?: {
@@ -78,6 +80,54 @@ export type ViewerConfigOptions = {
       moreResults?: string;
     };
   };
+};
+
+/**
+ * Everything a control needs in order to work, ready to spread onto a button:
+ * the id OpenSeadragon binds to, the accessible name, and the icon. Spreading
+ * `buttonProps` keeps the wiring while the element, its shape and its styling
+ * stay the consumer's.
+ */
+export type ControlButtonProps = {
+  buttonProps: {
+    id: string;
+    type: "button";
+    "aria-label": string;
+  };
+  icon: React.ReactNode;
+  label: string;
+};
+
+/**
+ * Replacements for the image viewer's controls. Each key is optional, so a
+ * consumer can override one control and leave the rest as they are. A
+ * replacement owns the whole button, not just the glyph, so it can change shape
+ * as well as appearance.
+ */
+export type ControlButtons = {
+  zoomIn?: React.ComponentType<ControlButtonProps>;
+  zoomOut?: React.ComponentType<ControlButtonProps>;
+  fullPage?: React.ComponentType<ControlButtonProps>;
+  rotateRight?: React.ComponentType<ControlButtonProps>;
+  rotateLeft?: React.ComponentType<ControlButtonProps>;
+  reset?: React.ComponentType<ControlButtonProps>;
+};
+
+/**
+ * The same arrangement for the information panel toggle. This control is driven
+ * by Clover's own state rather than OpenSeadragon, so its props carry the click
+ * handler and the expanded state instead of an id.
+ */
+export type PanelToggleProps = {
+  buttonProps: {
+    type: "button";
+    "aria-label": string;
+    "aria-expanded": boolean;
+    onClick: () => void;
+  };
+  icon: React.ReactNode;
+  isOpen: boolean;
+  label: string;
 };
 
 export type OverlayOptions = {
@@ -163,9 +213,24 @@ const cloneViewerConfigOptions = (
   return cloneValue(options) as ViewerConfigOptions;
 };
 
+/**
+ * React components can be objects rather than functions (`memo`, `forwardRef`),
+ * so copying them property by property returns a new object on every clone. The
+ * copy still renders, but its changed identity remounts the component, which for
+ * an OpenSeadragon control means the viewer keeps its handlers on the discarded
+ * element and the button stops working. Treat any component as a leaf.
+ */
+function isReactComponent(value: object): boolean {
+  return "$$typeof" in value;
+}
+
 function cloneValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => cloneValue(item));
+  }
+
+  if (value && typeof value === "object" && isReactComponent(value)) {
+    return value;
   }
 
   if (value && typeof value === "object") {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,11 @@ import {
 import { createOpenSeadragonRect } from "src/lib/openseadragon-helpers";
 import { type Plugin, type PluginInformationPanel } from "src/types/plugins";
 import type {
+  ControlButtonProps,
+  ControlButtons,
+  PanelToggleProps,
+} from "src/context/viewer-context";
+import type {
   CloverMapProps,
   MapCenter,
   MapMarker,
@@ -53,6 +58,8 @@ export {
   isGeoreferenceAnnotation,
   type AnnotationTargetExtended,
   type CloverMapProps,
+  type ControlButtonProps,
+  type ControlButtons,
   type GeoreferenceAnnotation,
   type GeoreferenceAnnotationSource,
   type GroundControlPoint,
@@ -63,6 +70,7 @@ export {
   type NavPlaceGeoJSON,
   type NavPlaceResourceContext,
   type NavPlaceResourceLevel,
+  type PanelToggleProps,
   type Plugin,
   type PluginInformationPanel,
 };

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { cleanTime, convertTime, deepMerge } from "src/lib/utils";
 
 test("Test output a 'cleaned time' when given international standard time notation.", () => {
@@ -62,4 +64,19 @@ test("Test result of deepMerge()", () => {
       renderToggle: false,
     },
   });
+});
+
+test("Test deepMerge keeps a component's identity rather than rebuilding it.", () => {
+  // memo and forwardRef components are objects, so merging into them would
+  // return a new object each time and remount the component.
+  const Memo = React.memo(() => null);
+  const Fwd = React.forwardRef<HTMLButtonElement>(() => null);
+
+  const result = deepMerge(
+    { controlButtons: {} },
+    { controlButtons: { zoomIn: Memo, zoomOut: Fwd } },
+  );
+
+  expect(result.controlButtons.zoomIn).toBe(Memo);
+  expect(result.controlButtons.zoomOut).toBe(Fwd);
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,7 +39,10 @@ export const deepMerge = (target, source) => {
     if (
       typeof source[key] === "object" &&
       source[key] !== null &&
-      !Array.isArray(source[key])
+      !Array.isArray(source[key]) &&
+      // memo and forwardRef components are objects; merging into them would
+      // rebuild them and remount the component on every config change.
+      !("$$typeof" in source[key])
     ) {
       if (!target[key]) target[key] = {};
       target[key] = deepMerge(target[key], source[key]);


### PR DESCRIPTION
Closes #354, which has the problem and the open questions on API shape. Opening this so there is something concrete to react to. Happy to reshape or split it.

## What this adds

`options.controlButtons`, one optional key per image viewer control (`zoomIn`, `zoomOut`, `fullPage`, `rotateRight`, `rotateLeft`, `reset`). A replacement owns the whole button, so it can change shape as well as appearance:

```jsx
const ZoomIn = ({ buttonProps }) => (
  <button {...buttonProps} className="my-square-button">
    <MyZoomInIcon />
  </button>
);

<Viewer options={{ controlButtons: { zoomIn: ZoomIn } }} />;
```

Spreading `buttonProps` is all that is needed: it carries the id OpenSeadragon binds its handlers to and the accessible name. Clover's own glyph comes through as `icon` for consumers who only want to change the chrome. Unreplaced controls keep Clover's defaults, and each is still gated on its existing `show*Control` flag.

`options.informationPanel.toggleComponent` does the same for the panel toggle. That one is driven by Clover's state rather than OpenSeadragon, so its `buttonProps` carry the click handler and `aria-expanded` instead of an id. Clover positions the replacement where its own toggle sits, so a consumer supplies only the button.

## Why not `navImages`

It looks like the answer, but OpenSeadragon's `Button` constructor skips its own control images when it is handed an `element`, and Clover always hands it one. The `navImages` paths are never requested. There is no existing route to restyling the controls short of CSS against library markup, and the `plugins` API appends controls rather than replacing them.

## One fix that applies to the existing API too

Component-valued options do not survive the config clone. `deepMerge` and `cloneValue` treat any object as a plain object, so a `memo` or `forwardRef` component (both objects, not functions) is rebuilt property by property. It still renders, but its identity changes on every config dispatch, which remounts it. For a control that means OpenSeadragon keeps its handlers on the discarded element. `customLoadingComponent` has the same exposure today. Both helpers now treat components as leaves, with a test asserting identity is preserved. I can split this into its own PR if you would rather keep them separate.

## Checks

`npm run lint`, `npm run typecheck`, `npm test` and `npm run build` all run. Prettier reports the same 22 pre-existing failures as `main` and `tsc` the same 7, so this adds none of either. Tests go from 309 to 315.

Verified in a real browser as well as unit tests: replacements receive the id, OpenSeadragon binds to them, and click, Enter, zoom, rotate and the panel toggle all work through custom buttons.

## Not included

A `Space` key fix for the controls, which I found while building this. OpenSeadragon's button handler responds to Enter only, so its buttons cannot be operated with both keys. It belongs with the keyboard work in #352 rather than here, and I will add it there.

