### PR TITLE
fix(viewer): only render caption resources as <track> elements

### DIFF
--- a/src/components/Viewer/Player/Player.tsx
+++ b/src/components/Viewer/Player/Player.tsx
@@ -12,6 +12,7 @@ import AudioVisualizer from "src/components/Viewer/Player/AudioVisualizer";
 import { LabeledIIIFExternalWebResource } from "src/types/presentation-3";
 import { PlayerWrapper } from "src/components/Viewer/Player/Player.styled";
 import Track from "src/components/Viewer/Player/Track";
+import { isCaptionResource } from "src/lib/annotation-helpers";
 import { getPaintingResource } from "src/hooks/use-iiif";
 import { isHls } from "src/lib/hls";
 
@@ -333,16 +334,32 @@ const Player: React.FC<PlayerProps> = ({
                 const annotationBody = vault.get(
                   body.id,
                 ) as LabeledIIIFExternalWebResource;
-                annotationBodies.push(annotationBody);
+
+                /**
+                 * Only external caption resources belong in a <track> element.
+                 *
+                 * An AnnotationPage on an A/V canvas may legitimately carry
+                 * descriptive annotations whose bodies are embedded TextualBody
+                 * resources (no `id`, no dereferenceable URL). Rendering those
+                 * as <track src="..."> makes the browser request a subtitle
+                 * file that does not exist.
+                 *
+                 * Embedded bodies also have no `id` of their own, so the Vault
+                 * mints a content-derived `vault://<hash>`. Two bodies with the
+                 * same text share a hash, which produced duplicate React keys
+                 * (one warning per collision, per render).
+                 */
+                if (isCaptionResource(annotationBody))
+                  annotationBodies.push(annotationBody);
               });
             });
 
-            return annotationBodies.map((body) => {
+            return annotationBodies.map((body, index) => {
               return (
                 <Track
                   resource={body}
                   ignoreCaptionLabels={configOptions.ignoreCaptionLabels || []}
-                  key={body.id}
+                  key={`${annotationPage.id}-${body.id}-${index}`}
                 />
               );
             });

--- a/src/lib/annotation-helpers.test.ts
+++ b/src/lib/annotation-helpers.test.ts
@@ -2,6 +2,7 @@ import {
   getLanguageDirection,
   parseAnnotationTarget,
   filterAnnotationsByMotivation,
+  isCaptionResource,
   AnnotationTargetExtended,
 } from "./annotation-helpers";
 
@@ -228,5 +229,66 @@ describe("filterAnnotationsByMotivation", () => {
   it("returns no annotations when motivations are explicitly empty", () => {
     const filtered = filterAnnotationsByMotivation(textualAnnotations, []);
     expect(filtered).toHaveLength(0);
+  });
+});
+
+describe("isCaptionResource", () => {
+  it("accepts a WebVTT resource declared by format", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/captions.vtt",
+        type: "Text",
+        format: "text/vtt",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a SubRip resource declared by format", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/captions.srt",
+        type: "Text",
+        format: "application/x-subrip",
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to the file extension when no format is declared", () => {
+    expect(isCaptionResource({ id: "https://example.org/c.vtt" })).toBe(true);
+    expect(isCaptionResource({ id: "https://example.org/c.vtt?v=2" })).toBe(
+      true,
+    );
+    expect(isCaptionResource({ id: "https://example.org/notes.txt" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects an embedded TextualBody", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/annotation/1/body",
+        type: "TextualBody",
+        format: "text/plain",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a Vault-minted id for a body with no id of its own", () => {
+    expect(isCaptionResource({ id: "vault://57a8c405" })).toBe(false);
+  });
+
+  it("rejects a body with no id", () => {
+    expect(isCaptionResource({})).toBe(false);
+    expect(isCaptionResource(undefined)).toBe(false);
+  });
+
+  it("rejects a resource whose declared format is not a caption format", () => {
+    expect(
+      isCaptionResource({
+        id: "https://example.org/video.mp4",
+        type: "Video",
+        format: "video/mp4",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/lib/annotation-helpers.ts
+++ b/src/lib/annotation-helpers.ts
@@ -257,3 +257,36 @@ export {
   annotationMatchesMotivations,
   resolveAnnotationBodies,
 };
+
+/**
+ * Is this annotation body an external caption/subtitle resource?
+ *
+ * A `<track>` element needs a URL it can fetch. An AnnotationPage on an A/V
+ * canvas may legitimately carry descriptive annotations whose bodies are
+ * embedded (`TextualBody` and friends): they hold their text inline and have no
+ * dereferenceable id. Rendering those as `<track src="...">` makes the browser
+ * request a subtitle file that does not exist.
+ *
+ * Embedded bodies also have no `id` of their own, so the Vault mints a
+ * content-derived `vault://<hash>`. Two bodies with the same text share a hash,
+ * which yields duplicate React keys — one warning per collision, per render.
+ */
+export function isCaptionResource(body?: {
+  id?: string;
+  type?: string;
+  format?: string;
+}): boolean {
+  if (!body?.id) return false;
+
+  // The Vault mints `vault://<hash>` for embedded resources with no id.
+  if (String(body.id).startsWith("vault://")) return false;
+
+  // Embedded text bodies are not fetchable.
+  if (body.type === "TextualBody") return false;
+
+  const format = String(body.format ?? "").toLowerCase();
+  if (format) return format === "text/vtt" || format === "application/x-subrip";
+
+  // No format declared: fall back to the file extension.
+  return /\.(vtt|srt)(\?|#|$)/i.test(String(body.id));
+}


### PR DESCRIPTION
# Only render caption resources as `<track>` elements

## The problem

An `AnnotationPage` on an A/V canvas may legitimately carry **descriptive**
annotations — the IIIF Presentation API places no restriction on the motivation
or body type of annotations attached to a canvas, and `describing` /
`commenting` bodies on time-based canvases are a normal way to publish a
shot-level catalogue.

`Player.tsx` pushes *every* annotation body into a `<track>` element:

```tsx
annotationNormalized.body.forEach((body) => {
  const annotationBody = vault.get(body.id) as LabeledIIIFExternalWebResource;
  annotationBodies.push(annotationBody);       // ← no filtering
});
…
<Track resource={body} key={body.id} />        // ← <track src={body.id}>
```

This has two consequences.

**1. The browser is asked to fetch subtitle files that do not exist.**
An embedded body (`TextualBody` and friends) holds its text inline and has no
dereferenceable URL, so `<track src="vault://57a8c405">` is a request that can
never succeed.

**2. Duplicate React keys.**
Embedded bodies have no `id` of their own, so the Vault mints a content-derived
`vault://<hash>`. Two bodies with the same text share a hash, so `key={body.id}`
collides and React logs a duplicate-key warning **for each collision, on every
render**.

At realistic catalogue sizes this is not a cosmetic problem. With the browser
console open, the warning volume is enough to make the page unresponsive.

## Reproduction

Manifest: a 27-second video canvas with 8 descriptive annotations. Bodies are
`TextualBody`, targets are time ranges on the canvas.

```jsonc
{
  "type": "Manifest",
  "items": [{
    "id": "https://example.org/practice/canvas/1",
    "type": "Canvas",
    "height": 720, "width": 1280, "duration": 27.0,
    "items": [ /* painting annotation for the video */ ],
    "annotations": [{
      "id": "https://example.org/practice/canvas/1/annos/1",
      "type": "AnnotationPage",
      "items": [{
        "id": "https://example.org/practice/annotation/frame-0000",
        "type": "Annotation",
        "motivation": "describing",
        "body": [
          { "type": "TextualBody", "purpose": "describing",
            "value": "A title card on a black ground.", "language": "en" },
          { "type": "TextualBody", "purpose": "classifying",
            "value": "title card", "language": "en" }
        ],
        "target": "https://example.org/practice/canvas/1#t=0.0,4.0"
      }
      /* … 7 more … */ ]
    }]
  }]
}
```

Open it in `Viewer`. Measured on `main` (`9b0df8a`, v3.14.0):

| annotations on the canvas | duplicate-key warnings on load | `<track>` elements created |
| ---: | ---: | ---: |
| 8 | 14 | 27 |
| 46 | 140 | 247 |
| 217 | **890** | **1222** |

Removing the `annotations` array from the same manifest brings the warning count
to **0**, which isolates the cause to this code path. Making every annotation id
an absolute URI does **not** help — the colliding ids belong to the *bodies*,
not the annotations.

## The change

A new helper, `isCaptionResource()` in `src/lib/annotation-helpers.ts`, filters
annotation bodies down to resources a `<track>` can actually fetch:

- rejects bodies with no `id`
- rejects Vault-minted `vault://<hash>` ids
- rejects `TextualBody`
- accepts a declared `format` of `text/vtt` or `application/x-subrip`
- with no declared `format`, falls back to a `.vtt` / `.srt` file extension

The remaining keys are made unique by including the annotation page id and the
index, so a manifest that legitimately lists the same caption resource twice
cannot collide either.

After the change, all three manifests above produce **0 warnings and 0 stray
`<track>` elements**, while the information panel still lists every annotation
(8 / 46 / 217 rows).

## Not changed

Manifests that declare real caption resources behave exactly as before. The
`ignoreCaptionLabels` option, the WebVTT cue rendering and the
`PointSelector` → `text/vtt` inference are all untouched.

## Verification

Ran the three `pull_request` CI lanes locally (macOS, Node 25):

- `npm run test:ci` — **78 files, 348 passed, 1 skipped**. Includes 7 new cases
  for `isCaptionResource`, covering declared formats, extension fallback,
  `TextualBody`, Vault-minted ids, missing ids and non-caption formats.
- `npm run build` — clean, 1407 modules transformed.
- `npx playwright test e2e/wc.spec.ts` (from `playwright/`, as `wc-e2e.yml`
  does) — 1 passed.
- `npm run typecheck` — reports the same 7 pre-existing errors as `main` (all in
  `src/components/Slider/Items/Items.test.tsx`), none in the touched files.

Not run locally: the React 18/19 example builds in `compat.yml` beyond the
shared library build. The change is a single predicate with no React API
surface, so I would not expect a version-specific effect, but I have not
verified that lane.

Manual: verified in a Next.js app against the three manifests above, counting
duplicate-key warnings and `<track>` elements in the browser before and after.
Warnings went 14 / 140 / 890 → **0 / 0 / 0**; `<track>` elements went
27 / 247 / 1222 → **0 / 0 / 0**; the information panel still listed all
8 / 46 / 217 annotations.

## Context

Found while building a shot-level catalogue of amateur films for a Japanese
research project (JSPS KAKENHI 24K22434). We publish descriptive annotations on
video canvases and embed Clover to demonstrate that the output is readable by a
third-party viewer, so this path is exercised heavily.

Two related gaps are **not** addressed here, to keep this change small. Happy to
open separate issues if they would be welcome:

1. **Spatial annotations on A/V canvases are ignored.** `#xywh` is valid on a
   time-based canvas per the Presentation API, but overlay rendering goes
   through `openSeadragonViewer.getOverlayById()`, which is `null` for A/V. The
   documentation states that spatial overlays are image-only; the underlying
   data is expressible, so a renderer for A/V canvases would be useful.
2. **Time-based annotations are not synchronised to the player.** The only path
   that seeks the player is WebVTT cue playback, reachable via an external
   `.vtt` file or a `PointSelector`. An annotation with
   `target: canvas#t=A,B` appears in the list but is not linked to the
   timeline, and `PointSelector` cannot express the end of a range.
